### PR TITLE
Feat/universal aggregate update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,9 @@ dependencies = [
     "numpy>=1.24.0",
     "scipy>=1.10.0",
     "psutil>=5.8.0",
-    "pandas>=1.5.0"
+    "pandas>=1.5.0",
+    "tqdm>=4.67.1",
+    "s3fs>=2025.9.0"
 ]
 
 [project.optional-dependencies]

--- a/src/stickler/algorithms/hungarian.py
+++ b/src/stickler/algorithms/hungarian.py
@@ -211,26 +211,29 @@ class HungarianMatcher:
             else:
                 score = self.comparator(prepared_list1[0], prepared_list2[0])
 
-            if score > 0:
-                return {
-                    "matched_pairs": [(0, 0, score)],
-                    "tp": 1,
-                    "fp": 0,
-                    "fn": 0,
-                    "precision": 1.0,
-                    "recall": 1.0,
-                    "f1": 1.0,
-                }
-            else:
-                return {
-                    "matched_pairs": [],
-                    "tp": 0,
-                    "fp": 1,
-                    "fn": 1,
-                    "precision": 0.0,
-                    "recall": 0.0,
-                    "f1": 0.0,
-                }
+            # Always match single items regardless of score (optimal assignment)
+            # Only use threshold for TP classification, not for matching decision
+            tp = 1 if score >= self.match_threshold else 0
+            fp = 1 - tp  # If not TP, then it's FP
+            fn = 1 - tp  # If not TP, then it's FN
+            
+            precision = tp / (tp + fp) if tp + fp > 0 else 0.0
+            recall = tp / (tp + fn) if tp + fn > 0 else 0.0
+            f1 = (
+                2 * precision * recall / (precision + recall)
+                if precision + recall > 0
+                else 0.0
+            )
+            
+            return {
+                "matched_pairs": [(0, 0, score)],  # Always match, regardless of score
+                "tp": tp,
+                "fp": fp,
+                "fn": fn,
+                "precision": precision,
+                "recall": recall,
+                "f1": f1,
+            }
 
         # Handle empty lists
         if not prepared_list1 and not prepared_list2:

--- a/src/stickler/algorithms/hungarian.py
+++ b/src/stickler/algorithms/hungarian.py
@@ -211,29 +211,26 @@ class HungarianMatcher:
             else:
                 score = self.comparator(prepared_list1[0], prepared_list2[0])
 
-            # Always match single items regardless of score (optimal assignment)
-            # Only use threshold for TP classification, not for matching decision
-            tp = 1 if score >= self.match_threshold else 0
-            fp = 1 - tp  # If not TP, then it's FP
-            fn = 1 - tp  # If not TP, then it's FN
-            
-            precision = tp / (tp + fp) if tp + fp > 0 else 0.0
-            recall = tp / (tp + fn) if tp + fn > 0 else 0.0
-            f1 = (
-                2 * precision * recall / (precision + recall)
-                if precision + recall > 0
-                else 0.0
-            )
-            
-            return {
-                "matched_pairs": [(0, 0, score)],  # Always match, regardless of score
-                "tp": tp,
-                "fp": fp,
-                "fn": fn,
-                "precision": precision,
-                "recall": recall,
-                "f1": f1,
-            }
+            if score > 0:
+                return {
+                    "matched_pairs": [(0, 0, score)],
+                    "tp": 1,
+                    "fp": 0,
+                    "fn": 0,
+                    "precision": 1.0,
+                    "recall": 1.0,
+                    "f1": 1.0,
+                }
+            else:
+                return {
+                    "matched_pairs": [],
+                    "tp": 0,
+                    "fp": 1,
+                    "fn": 1,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                }
 
         # Handle empty lists
         if not prepared_list1 and not prepared_list2:

--- a/src/stickler/structured_object_evaluator/bulk_structured_model_evaluator.py
+++ b/src/stickler/structured_object_evaluator/bulk_structured_model_evaluator.py
@@ -10,16 +10,26 @@ memory-efficient processing of large datasets through accumulation-based evaluat
 
 import gc
 import time
+import csv
+from tqdm import tqdm
 import json
 from collections import defaultdict
 from typing import List, Dict, Any, Optional, Type, Tuple, Union
 import logging
+import s3fs
 
 from stickler.structured_object_evaluator.models.structured_model import StructuredModel
 from stickler.utils.process_evaluation import ProcessEvaluation
 
 logger = logging.getLogger(__name__)
 
+# Choose appropriate file opening method
+def open_file(path, mode, **kwargs):
+    if path.startswith('s3://'):
+        fs = s3fs.S3FileSystem()
+        return fs.open(path, mode, **kwargs)
+    else:
+        return open(path, mode, **kwargs)
 
 class BulkStructuredModelEvaluator:
     """
@@ -46,6 +56,7 @@ class BulkStructuredModelEvaluator:
         document_non_matches: bool = True,
         elide_errors: bool = False,
         individual_results_jsonl: Optional[str] = None,
+        include_aggregates: bool = False
     ):
         """
         Initialize the stateful bulk evaluator.
@@ -56,13 +67,15 @@ class BulkStructuredModelEvaluator:
             document_non_matches: Whether to document detailed non-match information
             elide_errors: If True, skip documents with errors; if False, accumulate error metrics
             individual_results_jsonl: Optional path to JSONL file for appending individual comparison results
+            include_aggregates: Whether to enable aggregate metrics accumulation for performance control
         """
         self.target_schema = target_schema
         self.verbose = verbose
         self.document_non_matches = document_non_matches
         self.elide_errors = elide_errors
         self.individual_results_jsonl = individual_results_jsonl
-
+        self.include_aggregates = include_aggregates
+        
         # Initialize state
         self.reset()
 
@@ -86,7 +99,13 @@ class BulkStructuredModelEvaluator:
         # Accumulated confusion matrix state using nested defaultdicts
         self._confusion_matrix = {
             "overall": defaultdict(int),
-            "fields": defaultdict(lambda: defaultdict(int)),
+            "fields": defaultdict(lambda: defaultdict(int))
+        }
+        
+        # Accumulated aggregate metrics state (when include_aggregates=True)
+        self._aggregate_metrics = {
+            "overall": defaultdict(int),
+            "fields": defaultdict(lambda: defaultdict(int))
         }
 
         # Non-match tracking (when document_non_matches=True)
@@ -126,12 +145,13 @@ class BulkStructuredModelEvaluator:
         try:
             # Use compare_with method directly on the StructuredModel
             # Pass document_non_matches to achieve parity with compare_with method
+            # Pass include_aggregates to enable aggregate metrics when requested
             comparison_result = gt_model.compare_with(
                 pred_model,
                 include_confusion_matrix=True,
                 document_non_matches=self.document_non_matches,
             )
-
+            
             # Collect non-matches if enabled
             if self.document_non_matches and "non_matches" in comparison_result:
                 # Add doc_id to each non-match for bulk tracking
@@ -142,13 +162,20 @@ class BulkStructuredModelEvaluator:
 
             # Simple JSONL append of raw comparison result (before any processing)
             if self.individual_results_jsonl:
-                record = {"doc_id": doc_id, "comparison_result": comparison_result}
-                with open(self.individual_results_jsonl, "a", encoding="utf-8") as f:
-                    f.write(json.dumps(record) + "\n")
-
+                record = {
+                    "doc_id": doc_id,
+                    "comparison_result": comparison_result
+                }
+                with open_file(self.individual_results_jsonl, 'a', encoding = 'utf-8') as f:
+                        f.write(json.dumps(record, default=str) + '\n')
+            
             # Accumulate the results into our state (this flattens for aggregation)
             self._accumulate_confusion_matrix(comparison_result["confusion_matrix"])
-
+            
+            # Accumulate aggregate metrics if enabled and available
+            if self.include_aggregates and "confusion_matrix" in comparison_result:
+                self._accumulate_aggregate_metrics(comparison_result["confusion_matrix"])
+            
             self._processed_count += 1
 
             if self.verbose and self._processed_count % 1000 == 0:
@@ -161,7 +188,7 @@ class BulkStructuredModelEvaluator:
                 "error": str(e),
                 "error_type": type(e).__name__,
             }
-
+            
             if not self.elide_errors:
                 self._errors.append(error_record)
 
@@ -177,22 +204,22 @@ class BulkStructuredModelEvaluator:
     ) -> None:
         """
         Process multiple document pairs efficiently in a batch.
-
-        This method provides efficient batch processing by calling update()
+        
+        This method provides efficient batch processing by calling update() 
         multiple times with optional garbage collection for memory management.
-
+        
         Args:
             batch_data: List of tuples containing (gt_model, pred_model, doc_id)
         """
         batch_start = self._processed_count
-
+        
         for gt_model, pred_model, doc_id in batch_data:
             self.update(gt_model, pred_model, doc_id)
-
+        
         # Garbage collection for large batches
         if len(batch_data) >= 1000:
             gc.collect()
-
+            
         if self.verbose:
             batch_size = self._processed_count - batch_start
             print(f"Processed batch of {batch_size} documents")
@@ -200,11 +227,11 @@ class BulkStructuredModelEvaluator:
     def get_current_metrics(self) -> ProcessEvaluation:
         """
         Get current accumulated metrics without clearing state.
-
+        
         This method allows monitoring evaluation progress by returning current
         metrics computed from accumulated state. Unlike compute(), this does
         not clear the internal state.
-
+        
         Returns:
             ProcessEvaluation with current accumulated metrics
         """
@@ -213,33 +240,33 @@ class BulkStructuredModelEvaluator:
     def compute(self) -> ProcessEvaluation:
         """
         Calculate final aggregated metrics from accumulated state.
-
+        
         This method performs the final computation of all derived metrics from
         the accumulated confusion matrix state, similar to PyTorch Lightning's
         training_epoch_end pattern.
-
+        
         Returns:
             ProcessEvaluation with final aggregated metrics
         """
         result = self._build_process_evaluation()
-
+        
         if self.verbose:
             total_time = time.time() - self._start_time
             print(
                 f"Final computation completed: {self._processed_count} documents in {total_time:.2f}s"
             )
             print(f"Overall accuracy: {result.metrics.get('cm_accuracy', 0.0):.3f}")
-
+        
         return result
 
     def _accumulate_confusion_matrix(self, cm_result: Dict[str, Any]) -> None:
         """
         Accumulate confusion matrix results from a single document evaluation.
-
+        
         This method handles the core accumulation logic, properly aggregating
         both overall metrics and field-level metrics while maintaining correct
         nested field paths.
-
+        
         Args:
             cm_result: Confusion matrix result from compare_with method
         """
@@ -265,21 +292,21 @@ class BulkStructuredModelEvaluator:
     ) -> None:
         """
         Recursively accumulate field-level metrics with proper nested path construction.
-
+        
         This method fixes the nested field aggregation bugs from the original implementation
         by properly handling different field structure formats and maintaining correct
         dotted notation paths for nested fields.
-
+        
         Args:
             fields_dict: Dictionary containing field metrics to accumulate
             path_prefix: Current path prefix for building nested field paths
         """
         for field_name, field_data in fields_dict.items():
             current_path = f"{path_prefix}.{field_name}" if path_prefix else field_name
-
+            
             if not isinstance(field_data, dict):
                 continue
-
+            
             # Handle field with direct confusion matrix metrics (simple leaf field)
             direct_metrics = {
                 k: v
@@ -289,14 +316,14 @@ class BulkStructuredModelEvaluator:
             }
             if direct_metrics:
                 self._accumulate_single_field_metrics(current_path, direct_metrics)
-
+            
             # Handle hierarchical field structure (object fields with overall + fields)
             if "overall" in field_data:
                 # Accumulate the overall metrics for this field
                 self._accumulate_single_field_metrics(
                     current_path, field_data["overall"]
                 )
-
+            
             # Handle nested fields - check if there's a "fields" structure
             if "fields" in field_data and isinstance(field_data["fields"], dict):
                 # For each nested field, create the proper dotted path
@@ -304,7 +331,7 @@ class BulkStructuredModelEvaluator:
                     "fields"
                 ].items():
                     nested_path = f"{current_path}.{nested_field_name}"
-
+                    
                     if isinstance(nested_field_data, dict):
                         # If nested field has "overall", use those metrics
                         if "overall" in nested_field_data:
@@ -323,13 +350,13 @@ class BulkStructuredModelEvaluator:
                                 self._accumulate_single_field_metrics(
                                     nested_path, nested_metrics
                                 )
-
+                        
                         # Continue recursion if there are more nested fields
                         if "fields" in nested_field_data:
                             self._accumulate_field_metrics(
                                 nested_field_data["fields"], nested_path
                             )
-
+            
             # Handle list field structure with nested_fields
             elif "nested_fields" in field_data:
                 # Accumulate list-level metrics
@@ -341,7 +368,7 @@ class BulkStructuredModelEvaluator:
                 }
                 if list_metrics:
                     self._accumulate_single_field_metrics(current_path, list_metrics)
-
+                
                 # Accumulate nested field metrics from the list items
                 for nested_field_name, nested_metrics in field_data[
                     "nested_fields"
@@ -354,7 +381,7 @@ class BulkStructuredModelEvaluator:
     ) -> None:
         """
         Accumulate metrics for a single field path.
-
+        
         Args:
             field_path: Dotted path to the field (e.g., 'transactions.date')
             metrics: Dictionary of confusion matrix metrics to accumulate
@@ -365,18 +392,65 @@ class BulkStructuredModelEvaluator:
             ):
                 self._confusion_matrix["fields"][field_path][metric_name] += value
 
-    def _calculate_derived_metrics(
-        self, cm_dict: Dict[str, Union[int, float]]
-    ) -> Dict[str, float]:
+    def _accumulate_aggregate_metrics(self, cm_result: Dict[str, Any]) -> None:
+        """
+        Accumulate aggregate metrics from comparison results.
+        
+        This method handles accumulation of aggregate metrics that are calculated
+        automatically by the universal aggregation feature. Aggregate metrics
+        provide hierarchical confusion matrix counts at each level.
+        
+        Args:
+            cm_result: Confusion matrix result containing aggregate metrics
+        """
+        # Accumulate root-level aggregate metrics
+        if "aggregate" in cm_result and isinstance(cm_result["aggregate"], dict):
+            for metric_name, value in cm_result["aggregate"].items():
+                if isinstance(value, (int, float)) and metric_name in ["tp", "fp", "tn", "fn", "fd", "fa"]:
+                    self._aggregate_metrics["overall"][metric_name] += value
+
+        # Accumulate field-level aggregate metrics with proper path handling
+        if "fields" in cm_result:
+            self._accumulate_field_aggregate_metrics(cm_result["fields"], "")
+
+    def _accumulate_field_aggregate_metrics(
+        self, 
+        fields_dict: Dict[str, Any], 
+        path_prefix: str
+    ) -> None:
+        """
+        Recursively accumulate field-level aggregate metrics with proper nested path construction.
+        
+        Args:
+            fields_dict: Dictionary containing field aggregate metrics to accumulate
+            path_prefix: Current path prefix for building nested field paths
+        """
+        for field_name, field_data in fields_dict.items():
+            current_path = f"{path_prefix}.{field_name}" if path_prefix else field_name
+            
+            if not isinstance(field_data, dict):
+                continue
+            
+            # Handle field-level aggregate metrics
+            if "aggregate" in field_data and isinstance(field_data["aggregate"], dict):
+                for metric_name, value in field_data["aggregate"].items():
+                    if isinstance(value, (int, float)) and metric_name in ["tp", "fp", "tn", "fn", "fd", "fa"]:
+                        self._aggregate_metrics["fields"][current_path][metric_name] += value
+            
+            # Continue recursion if there are nested fields
+            if "fields" in field_data and isinstance(field_data["fields"], dict):
+                self._accumulate_field_aggregate_metrics(field_data["fields"], current_path)
+
+    def _calculate_derived_metrics(self, cm_dict: Dict[str, Union[int, float]]) -> Dict[str, float]:
         """
         Calculate derived confusion matrix metrics (precision, recall, f1, accuracy).
-
+        
         This method replicates the derivation logic that was previously handled
         by StructuredModelEvaluator.
-
+        
         Args:
             cm_dict: Dictionary with basic confusion matrix counts
-
+            
         Returns:
             Dictionary with derived metrics
         """
@@ -384,7 +458,7 @@ class BulkStructuredModelEvaluator:
         fp = cm_dict.get("fp", 0)
         tn = cm_dict.get("tn", 0)
         fn = cm_dict.get("fn", 0)
-
+        
         # Calculate derived metrics with safe division
         precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
         recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
@@ -394,7 +468,7 @@ class BulkStructuredModelEvaluator:
             else 0.0
         )
         accuracy = (tp + tn) / (tp + tn + fp + fn) if (tp + tn + fp + fn) > 0 else 0.0
-
+        
         return {
             "cm_precision": precision,
             "cm_recall": recall,
@@ -405,7 +479,7 @@ class BulkStructuredModelEvaluator:
     def _build_process_evaluation(self) -> ProcessEvaluation:
         """
         Build ProcessEvaluation from current accumulated state.
-
+        
         Returns:
             ProcessEvaluation with computed metrics from accumulated state
         """
@@ -413,16 +487,33 @@ class BulkStructuredModelEvaluator:
         overall_cm = dict(self._confusion_matrix["overall"])
         overall_derived = self._calculate_derived_metrics(overall_cm)
         overall_metrics = {**overall_cm, **overall_derived}
-
+        
+        # Add aggregate metrics to overall if enabled
+        if self.include_aggregates:
+            overall_aggregate = dict(self._aggregate_metrics["overall"])
+            if any(overall_aggregate.values()):  # Only add if there are aggregate metrics
+                overall_aggregate_derived = self._calculate_derived_metrics(overall_aggregate)
+                overall_metrics["aggregate"] = {**overall_aggregate, **overall_aggregate_derived}
+        
         # Calculate derived metrics for each field
         field_metrics = {}
         for field_path, field_cm in self._confusion_matrix["fields"].items():
             field_cm_dict = dict(field_cm)
             field_derived = self._calculate_derived_metrics(field_cm_dict)
             field_metrics[field_path] = {**field_cm_dict, **field_derived}
-
+        
+        # Add aggregate metrics to fields if enabled
+        if self.include_aggregates:
+            for field_path, field_aggregate in self._aggregate_metrics["fields"].items():
+                field_aggregate_dict = dict(field_aggregate)
+                if any(field_aggregate_dict.values()):  # Only add if there are aggregate metrics
+                    field_aggregate_derived = self._calculate_derived_metrics(field_aggregate_dict)
+                    if field_path not in field_metrics:
+                        field_metrics[field_path] = {}
+                    field_metrics[field_path]["aggregate"] = {**field_aggregate_dict, **field_aggregate_derived}
+        
         total_time = time.time() - self._start_time
-
+        
         return ProcessEvaluation(
             metrics=overall_metrics,
             field_metrics=field_metrics,
@@ -434,12 +525,12 @@ class BulkStructuredModelEvaluator:
     def save_metrics(self, filepath: str) -> None:
         """
         Save current accumulated metrics to a JSON file.
-
+        
         Args:
             filepath: Path where metrics will be saved as JSON
         """
         process_eval = self._build_process_evaluation()
-
+        
         # Build comprehensive metrics dictionary
         metrics_data = {
             "overall_metrics": process_eval.metrics,
@@ -464,36 +555,37 @@ class BulkStructuredModelEvaluator:
                     "document_non_matches": self.document_non_matches,
                     "elide_errors": self.elide_errors,
                     "individual_results_jsonl": self.individual_results_jsonl,
-                },
-            },
+                    "include_aggregates": self.include_aggregates
+                }
+            }
         }
-
+        
         # Ensure directory exists
         import os
 
         os.makedirs(os.path.dirname(os.path.abspath(filepath)), exist_ok=True)
-
+        
         # Write to file
-        with open(filepath, "w", encoding="utf-8") as f:
+        with open_file(filepath, 'w', encoding='utf-8') as f:
             json.dump(metrics_data, f, indent=2, default=str)
-
+        
         if self.verbose:
             print(f"Metrics saved to: {filepath}")
 
     def pretty_print_metrics(self) -> None:
         """
         Pretty print current accumulated metrics in a format similar to StructuredModel.
-
+        
         Displays overall metrics, field-level metrics, and evaluation summary
         in a human-readable format.
         """
         process_eval = self._build_process_evaluation()
-
+        
         # Header
         print("\n" + "=" * 80)
         print(f"BULK EVALUATION RESULTS - {self.target_schema.__name__}")
         print("=" * 80)
-
+        
         # Overall metrics
         overall_metrics = process_eval.metrics
         print("\nOVERALL METRICS:")
@@ -505,35 +597,51 @@ class BulkStructuredModelEvaluator:
             if process_eval.total_time > 0
             else "Processing Rate: N/A"
         )
-
+        
         # Confusion matrix
         print(f"\nCONFUSION MATRIX:")
         print(f"  True Positives (TP):    {overall_metrics.get('tp', 0):,}")
-        print(f"  False Positives (FP):   {overall_metrics.get('fp', 0):,}")
+        print(f"  False Positives (FP):   {overall_metrics.get('fp', 0):,}")  
         print(f"  True Negatives (TN):    {overall_metrics.get('tn', 0):,}")
         print(f"  False Negatives (FN):   {overall_metrics.get('fn', 0):,}")
         print(f"  False Discovery (FD):   {overall_metrics.get('fd', 0):,}")
         print(f"  False Alarm (FA):   {overall_metrics.get('fa', 0):,}")
-
+        
         # Derived metrics
         print(f"\nDERIVED METRICS:")
         print(f"  Precision:     {overall_metrics.get('cm_precision', 0.0):.4f}")
         print(f"  Recall:        {overall_metrics.get('cm_recall', 0.0):.4f}")
         print(f"  F1 Score:      {overall_metrics.get('cm_f1', 0.0):.4f}")
         print(f"  Accuracy:      {overall_metrics.get('cm_accuracy', 0.0):.4f}")
-
+        
+        # Aggregate metrics (if enabled)
+        if self.include_aggregates and "aggregate" in overall_metrics:
+            aggregate = overall_metrics["aggregate"]
+            print(f"\nAGGREGATE METRICS:")
+            print("-" * 40)
+            print(f"  True Positives (TP):    {aggregate.get('tp', 0):,}")
+            print(f"  False Positives (FP):   {aggregate.get('fp', 0):,}")  
+            print(f"  True Negatives (TN):    {aggregate.get('tn', 0):,}")
+            print(f"  False Negatives (FN):   {aggregate.get('fn', 0):,}")
+            print(f"  False Discovery (FD):   {aggregate.get('fd', 0):,}")
+            print(f"  False Alarm (FA):       {aggregate.get('fa', 0):,}")
+            print(f"  Precision:              {aggregate.get('cm_precision', 0.0):.4f}")
+            print(f"  Recall:                 {aggregate.get('cm_recall', 0.0):.4f}")
+            print(f"  F1 Score:               {aggregate.get('cm_f1', 0.0):.4f}")
+            print(f"  Accuracy:               {aggregate.get('cm_accuracy', 0.0):.4f}")
+        
         # Field-level metrics
         if process_eval.field_metrics:
             print(f"\nFIELD-LEVEL METRICS:")
             print("-" * 40)
-
+            
             # Sort fields by F1 score descending for better readability
             sorted_fields = sorted(
                 process_eval.field_metrics.items(),
                 key=lambda x: x[1].get("cm_f1", 0.0),
                 reverse=True,
             )
-
+            
             for field_path, field_metrics in sorted_fields:
                 tp = field_metrics.get("tp", 0)
                 fp = field_metrics.get("fp", 0)
@@ -541,13 +649,25 @@ class BulkStructuredModelEvaluator:
                 precision = field_metrics.get("cm_precision", 0.0)
                 recall = field_metrics.get("cm_recall", 0.0)
                 f1 = field_metrics.get("cm_f1", 0.0)
-
+                
                 # Only show fields with some activity
                 if tp + fp + fn > 0:
                     print(
                         f"  {field_path:30} P: {precision:.3f} | R: {recall:.3f} | F1: {f1:.3f} | TP: {tp:,} | FP: {fp:,} | FN: {fn:,}"
                     )
-
+                    # Show aggregate metrics for this field if available
+                    if self.include_aggregates and "aggregate" in field_metrics:
+                        agg = field_metrics["aggregate"]
+                        agg_tp = agg.get('tp', 0)
+                        agg_fp = agg.get('fp', 0)
+                        agg_fn = agg.get('fn', 0)
+                        agg_precision = agg.get('cm_precision', 0.0)
+                        agg_recall = agg.get('cm_recall', 0.0)
+                        agg_f1 = agg.get('cm_f1', 0.0)
+                        
+                        if agg_tp + agg_fp + agg_fn > 0:
+                            print(f"    └─ Aggregate:          P: {agg_precision:.3f} | R: {agg_recall:.3f} | F1: {agg_f1:.3f} | TP: {agg_tp:,} | FP: {agg_fp:,} | FN: {agg_fn:,}")
+        
         # Error summary
         if process_eval.errors:
             print(f"\nERROR SUMMARY:")
@@ -558,43 +678,44 @@ class BulkStructuredModelEvaluator:
                 if self._processed_count > 0
                 else "Error Rate: N/A"
             )
-
+            
             # Group errors by type
             error_types = {}
             for error in process_eval.errors:
                 error_type = error.get("error_type", "Unknown")
                 error_types[error_type] = error_types.get(error_type, 0) + 1
-
+            
             if error_types:
                 print("Error Types:")
                 for error_type, count in sorted(
                     error_types.items(), key=lambda x: x[1], reverse=True
                 ):
                     print(f"  {error_type}: {count:,}")
-
+        
         # Configuration info
         print(f"\nCONFIGURATION:")
         print("-" * 40)
         print(f"Target Schema: {self.target_schema.__name__}")
         print(f"Document Non-matches: {'Yes' if self.document_non_matches else 'No'}")
         print(f"Elide Errors: {'Yes' if self.elide_errors else 'No'}")
+        print(f"Include Aggregates: {'Yes' if self.include_aggregates else 'No'}")
         if self.individual_results_jsonl:
             print(f"Individual Results JSONL: {self.individual_results_jsonl}")
-
+        
         print("=" * 80)
 
     def get_state(self) -> Dict[str, Any]:
         """
         Get serializable state for checkpointing and recovery.
-
+        
         Returns a dictionary containing all internal state that can be serialized
         and later restored using load_state(). This enables checkpointing for
         long-running evaluation jobs.
-
+        
         Returns:
             Dictionary containing serializable evaluator state
         """
-        return {
+        state = {
             "confusion_matrix": {
                 "overall": dict(self._confusion_matrix["overall"]),
                 "fields": {
@@ -608,15 +729,25 @@ class BulkStructuredModelEvaluator:
             # Configuration
             "target_schema": self.target_schema.__name__,
             "elide_errors": self.elide_errors,
+            "include_aggregates": self.include_aggregates
         }
+        
+        # Include aggregate metrics if enabled
+        if self.include_aggregates:
+            state["aggregate_metrics"] = {
+                "overall": dict(self._aggregate_metrics["overall"]),
+                "fields": {path: dict(metrics) for path, metrics in self._aggregate_metrics["fields"].items()}
+            }
+        
+        return state
 
     def load_state(self, state: Dict[str, Any]) -> None:
         """
         Restore evaluator state from serialized data.
-
+        
         This method restores the internal state from data previously saved
         with get_state(), enabling recovery from checkpoints.
-
+        
         Args:
             state: State dictionary from get_state()
         """
@@ -625,35 +756,46 @@ class BulkStructuredModelEvaluator:
             raise ValueError(
                 f"State schema {state.get('target_schema')} doesn't match evaluator schema {self.target_schema.__name__}"
             )
-
+        
         # Restore confusion matrix state
         cm_state = state["confusion_matrix"]
         self._confusion_matrix = {
             "overall": defaultdict(int, cm_state["overall"]),
             "fields": defaultdict(lambda: defaultdict(int)),
         }
-
+        
         for field_path, field_metrics in cm_state["fields"].items():
             self._confusion_matrix["fields"][field_path] = defaultdict(
                 int, field_metrics
             )
-
+        
+        # Restore aggregate metrics state if available and enabled
+        if self.include_aggregates and "aggregate_metrics" in state:
+            agg_state = state["aggregate_metrics"]
+            self._aggregate_metrics = {
+                "overall": defaultdict(int, agg_state["overall"]),
+                "fields": defaultdict(lambda: defaultdict(int))
+            }
+            
+            for field_path, field_metrics in agg_state["fields"].items():
+                self._aggregate_metrics["fields"][field_path] = defaultdict(int, field_metrics)
+        
         # Restore other state
         self._errors = list(state["errors"])
         self._processed_count = state["processed_count"]
         self._start_time = state["start_time"]
-
+        
         if self.verbose:
             print(f"Loaded state: {self._processed_count} documents processed")
 
     def merge_state(self, other_state: Dict[str, Any]) -> None:
         """
         Merge results from another evaluator instance.
-
+        
         This method enables distributed processing by merging confusion matrix
         counts from multiple evaluator instances that processed different
         portions of a dataset.
-
+        
         Args:
             other_state: State dictionary from another evaluator instance
         """
@@ -662,29 +804,69 @@ class BulkStructuredModelEvaluator:
             raise ValueError(
                 f"Cannot merge incompatible schemas: {other_state.get('target_schema')} vs {self.target_schema.__name__}"
             )
-
+        
         # Merge overall metrics
         other_cm = other_state["confusion_matrix"]
         for metric, value in other_cm["overall"].items():
             self._confusion_matrix["overall"][metric] += value
-
+        
         # Merge field-level metrics
         for field_path, field_metrics in other_cm["fields"].items():
             for metric, value in field_metrics.items():
                 self._confusion_matrix["fields"][field_path][metric] += value
-
+        
+        # Merge aggregate metrics if both evaluators have them enabled
+        if self.include_aggregates and "aggregate_metrics" in other_state:
+            other_agg = other_state["aggregate_metrics"]
+            
+            # Merge overall aggregate metrics
+            for metric, value in other_agg["overall"].items():
+                self._aggregate_metrics["overall"][metric] += value
+            
+            # Merge field-level aggregate metrics
+            for field_path, field_metrics in other_agg["fields"].items():
+                for metric, value in field_metrics.items():
+                    self._aggregate_metrics["fields"][field_path][metric] += value
+        
         # Merge errors and counts
         self._errors.extend(other_state["errors"])
         self._processed_count += other_state["processed_count"]
-
+        
         if self.verbose:
             print(
                 f"Merged state: now {self._processed_count} total documents processed"
             )
 
+    def save_non_matches(self, file_path): 
+        """Save non-matches to CSV file with enhanced field-level granularity.
+        
+        Args:
+            file_path: Path to save the CSV file
+        """
+        with open_file(self.individual_results_jsonl, "r", encoding="utf-8") as infile, open_file(file_path, "w", newline='', encoding="utf-8") as outfile:            
+            writer = csv.writer(outfile)
+            # Enhanced header with level column to distinguish object vs field level
+            writer.writerow(["doc_id", "non_match_field", "non_match_type", "ground_truth", "prediction"]) 
+
+            for line in infile:
+                data = json.loads(line)
+                document_id = data.get("doc_id")
+                non_match_fields = data.get("comparison_result", {}).get('non_matches', [])
+
+                for field in non_match_fields:
+                    field_path = field.get('field_path', '')
+                    
+                    writer.writerow([
+                        document_id, 
+                        field_path, 
+                        field.get('non_match_type', ''), 
+                        field.get('ground_truth_value', ''), 
+                        field.get('prediction_value', '')
+                    ])
+
     # Legacy compatibility methods
 
-    def evaluate_dataframe(self, df) -> ProcessEvaluation:
+    def evaluate_dataframe(self, df) -> Tuple[ProcessEvaluation, int]:
         """
         Legacy compatibility method for DataFrame-based evaluation.
 
@@ -699,16 +881,27 @@ class BulkStructuredModelEvaluator:
         """
         # Reset state for clean evaluation
         self.reset()
-
+        count_errors = 0
+        
         # Process each row
-        for idx, row in df.iterrows():
+        for idx, row in tqdm(df.iterrows(), total=len(df), desc='Evaluation'):
             doc_id = row.get("doc_id", f"row_{idx}")
 
             try:
-                # Parse JSON data
-                gt_data = json.loads(row["expected"])
-                pred_data = json.loads(row["predicted"])
+                gt_data = row['expected']
+                if isinstance(gt_data, dict):
+                    if 'error' in gt_data:
+                        raise ValueError(f"Ground truth contains error: {gt_data['error']}")
+                else:
+                    gt_data = json.loads(row['expected'])
 
+                pred_data = row['predicted']
+                if isinstance(pred_data, dict):
+                    if 'error' in pred_data:
+                        raise ValueError(f"Prediction contains error: {pred_data['error']}")
+                else:
+                    pred_data = json.loads(row['predicted'])
+                
                 # Create StructuredModel instances
                 gt_model = self.target_schema(**gt_data)
                 pred_model = self.target_schema(**pred_data)
@@ -717,8 +910,11 @@ class BulkStructuredModelEvaluator:
                 self.update(gt_model, pred_model, doc_id)
 
             except Exception as e:
+                count_errors += 1
                 if self.verbose:
                     print(f"Error processing row {idx}: {e}")
                 continue
+        
+        print(f"There were a total of {count_errors} errors.")
 
-        return self.compute()
+        return self.compute(), count_errors

--- a/src/stickler/structured_object_evaluator/evaluator.py
+++ b/src/stickler/structured_object_evaluator/evaluator.py
@@ -28,7 +28,7 @@ from stickler.algorithms.hungarian import HungarianMatcher
 def get_memory_usage():
     """
     Get current memory usage of the process in MB.
-
+    
     Returns:
         float: Memory usage in MB
     """
@@ -39,12 +39,12 @@ def get_memory_usage():
 class StructuredModelEvaluator:
     """
     Evaluator for StructuredModel objects.
-
+    
     This evaluator computes comprehensive metrics for StructuredModel objects,
     leveraging their built-in comparison capabilities. It includes confusion matrix
     calculations, field-level metrics, non-match documentation, and memory optimization capabilities.
     """
-
+    
     def __init__(
         self,
         model_class: Optional[Type[StructuredModel]] = None,
@@ -54,7 +54,7 @@ class StructuredModelEvaluator:
     ):
         """
         Initialize the evaluator.
-
+        
         Args:
             model_class: Optional StructuredModel class for type checking
             threshold: Similarity threshold for considering a match
@@ -66,28 +66,28 @@ class StructuredModelEvaluator:
         self.verbose = verbose
         self.peak_memory_usage = 0
         self.start_memory = get_memory_usage()
-
+        
         # New attributes for documenting non-matches
         self.document_non_matches = document_non_matches
         self.non_match_documents: List[NonMatchField] = []
-
+        
         if self.verbose:
             print(
                 f"Initialized StructuredModelEvaluator. Starting memory: {self.start_memory:.2f} MB"
             )
-
+    
     def _check_memory(self):
         """Check current memory usage and update peak memory."""
         current_memory = get_memory_usage()
-
+        
         if current_memory > self.peak_memory_usage:
             self.peak_memory_usage = current_memory
-
+            
         if self.verbose and current_memory > self.start_memory + 100:  # 100MB increase
             print(f"Memory usage increased: {current_memory:.2f} MB")
-
+            
         return current_memory
-
+    
     def _calculate_metrics_from_binary(
         self,
         tp: float,
@@ -121,36 +121,36 @@ class StructuredModelEvaluator:
         else:
             # Traditional recall: TP / (TP + FN)
             recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
-
+        
         # Calculate F1 score
         f1 = (
             2 * (precision * recall) / (precision + recall)
             if (precision + recall) > 0
             else 0.0
         )
-
+        
         # Calculate accuracy
         accuracy = (tp + tn) / (tp + fp + fn + tn) if (tp + fp + fn + tn) > 0 else 0.0
-
+        
         return {
             "precision": precision,
             "recall": recall,
             "f1": f1,
             "accuracy": accuracy,
         }
-
+    
     def calculate_derived_confusion_matrix_metrics(
         self, cm_counts: Dict[str, Union[int, float]]
     ) -> Dict[str, float]:
         """
         Calculate derived metrics from confusion matrix counts.
-
+        
         This method uses MetricsHelper to maintain consistency and avoid code duplication.
-
+        
         Args:
             cm_counts: Dictionary with confusion matrix counts containing keys:
                       'tp', 'fp', 'tn', 'fn', and optionally 'fd', 'fa'
-
+                      
         Returns:
             Dictionary with derived metrics: cm_precision, cm_recall, cm_f1, cm_accuracy
         """
@@ -158,9 +158,9 @@ class StructuredModelEvaluator:
         from stickler.structured_object_evaluator.models.metrics_helper import (
             MetricsHelper,
         )
-
+        
         metrics_helper = MetricsHelper()
-
+        
         # Convert counts to the format expected by MetricsHelper
         metrics_dict = {
             "tp": int(cm_counts.get("tp", 0)),
@@ -170,24 +170,24 @@ class StructuredModelEvaluator:
             "fd": int(cm_counts.get("fd", 0)),
             "fa": int(cm_counts.get("fa", 0)),
         }
-
+        
         # Use MetricsHelper to calculate derived metrics
         return metrics_helper.calculate_derived_metrics(metrics_dict)
-
+    
     def _convert_score_to_binary(self, score: float) -> Dict[str, float]:
         """
         Convert an ANLS Star score to binary classification counts.
-
+        
         Args:
             score: ANLS Star similarity score [0-1]
-
+            
         Returns:
             Dictionary with TP, FP, FN, TN counts
         """
         # For a single field comparison, there are different approaches
         # to convert a similarity score to binary classification:
-
-        # Approach used here: If score >= threshold, count as TP with
+        
+        # Approach used here: If score >= threshold, count as TP with 
         # proportional value, otherwise count as partial FP and partial FN
         if score >= self.threshold:
             # Handle as true positive with proportional credit
@@ -203,16 +203,16 @@ class StructuredModelEvaluator:
             fp = score  # Give partial credit for similarity even if below threshold
             fn = 1 - score  # More different = higher FN
             tn = 0
-
+            
         return {"tp": tp, "fp": fp, "fn": fn, "tn": tn}
-
+    
     def _is_null_value(self, value: Any) -> bool:
         """
         Determine if a value should be considered null or empty.
-
+        
         Args:
             value: The value to check
-
+            
         Returns:
             True if the value is null/empty, False otherwise
         """
@@ -232,11 +232,11 @@ class StructuredModelEvaluator:
     ) -> Dict[str, int]:
         """
         Combine two confusion matrix dictionaries by adding corresponding values.
-
+        
         Args:
             cm1: First confusion matrix dictionary
             cm2: Second confusion matrix dictionary
-
+            
         Returns:
             Combined confusion matrix dictionary
         """
@@ -244,19 +244,19 @@ class StructuredModelEvaluator:
             key: cm1.get(key, 0) + cm2.get(key, 0)
             for key in ["tp", "fa", "fd", "fp", "tn", "fn"]
         }
-
+        
     def add_non_match(
         self,
-        field_path: str,
-        non_match_type: NonMatchType,
-        gt_value: Any,
-        pred_value: Any,
-        similarity_score: Optional[float] = None,
+                     field_path: str, 
+                     non_match_type: NonMatchType,
+                     gt_value: Any, 
+                     pred_value: Any, 
+                     similarity_score: Optional[float] = None,
         details: Optional[Dict[str, Any]] = None,
     ):
         """
         Document a non-match with detailed information.
-
+        
         Args:
             field_path: Dot-notation path to the field (e.g., 'address.city')
             non_match_type: Type of non-match
@@ -268,7 +268,7 @@ class StructuredModelEvaluator:
         """
         if not self.document_non_matches:
             return
-
+            
         self.non_match_documents.append(
             NonMatchField(
                 field_path=field_path,
@@ -283,15 +283,15 @@ class StructuredModelEvaluator:
     def clear_non_match_documents(self):
         """Clear the stored non-match documents."""
         self.non_match_documents = []
-
+    
     def _convert_enhanced_non_match_to_field(
         self, nm_dict: Dict[str, Any]
     ) -> Dict[str, Any]:
         """Convert enhanced non-match format to NonMatchField format.
-
+        
         Args:
             nm_dict: Enhanced non-match dictionary from StructuredModel
-
+            
         Returns:
             Dictionary in NonMatchField format
         """
@@ -303,22 +303,41 @@ class StructuredModelEvaluator:
             "similarity_score": nm_dict.get("similarity_score"),
             "details": nm_dict.get("details", {}),
         }
-
+        
         # The non_match_type is already a NonMatchType enum from StructuredModel
         converted["non_match_type"] = nm_dict.get("non_match_type")
-
+        
+        # NEW: Preserve leaf-level debugging information
+        if nm_dict.get("is_leaf_level", False):
+            if "details" not in converted:
+                converted["details"] = {}
+            converted["details"]["is_leaf_level"] = True
+            converted["details"]["comparison_type"] = nm_dict.get("comparison_type", "")
+            
+            # Add threshold information if available
+            if "threshold" in nm_dict:
+                converted["details"]["threshold"] = nm_dict["threshold"]
+            
+            # Add aggregate contribution information if available
+            if "aggregate_contribution" in nm_dict:
+                converted["details"]["aggregate_contribution"] = nm_dict["aggregate_contribution"]
+        
+        # NEW: Preserve hierarchical debugging metadata (only for first entry)
+        if "_debugging_metadata" in nm_dict:
+            converted["details"]["debugging_metadata"] = nm_dict["_debugging_metadata"]
+        
         return converted
-
+    
     def _compare_models(
         self, gt_model: StructuredModel, pred_model: StructuredModel
     ) -> Dict[str, Any]:
         """
         Compare two StructuredModel instances and return metrics.
-
+        
         Args:
             gt_model: Ground truth model
             pred_model: Predicted model
-
+            
         Returns:
             Dict with comparison metrics including tp, fp, fn, tn, field_scores, overall_score
         """
@@ -328,7 +347,7 @@ class StructuredModelEvaluator:
             and isinstance(pred_model, StructuredModel)
         ):
             raise TypeError("Both models must be StructuredModel instances")
-
+        
         # If model_class is specified, check type
         if self.model_class and not (
             isinstance(gt_model, self.model_class)
@@ -337,13 +356,13 @@ class StructuredModelEvaluator:
             raise TypeError(
                 f"Both models must be instances of {self.model_class.__name__}"
             )
-
+        
         # Use the built-in compare_with method from StructuredModel
         comparison_result = gt_model.compare_with(pred_model)
-
+        
         # Initialize metrics
         tp = fp = fn = tn = 0
-
+        
         # Determine match status
         if comparison_result["overall_score"] >= self.threshold:
             # Good enough match
@@ -351,7 +370,7 @@ class StructuredModelEvaluator:
         else:
             # Not a good enough match
             fp = 1
-
+            
         # Prepare result
         result = {
             "tp": tp,
@@ -362,9 +381,9 @@ class StructuredModelEvaluator:
             "overall_score": comparison_result["overall_score"],
             # match_status removed - now unnecessary
         }
-
+        
         return result
-
+    
     def evaluate(
         self,
         ground_truth: StructuredModel,
@@ -373,25 +392,25 @@ class StructuredModelEvaluator:
     ) -> Dict[str, Any]:
         """
         Evaluate predictions against ground truth and return comprehensive metrics.
-
+        
         Args:
             ground_truth: Ground truth data (StructuredModel instance)
             predictions: Predicted data (StructuredModel instance)
             recall_with_fd: If True, include FD in recall denominator (TP/(TP+FN+FD))
                             If False, use traditional recall (TP/(TP+FN))
-
+            
         Returns:
             Dictionary with the following structure:
-
+            
             {
                 "overall": {
                     "precision": float,     # Overall precision [0-1]
-                    "recall": float,        # Overall recall [0-1]
+                    "recall": float,        # Overall recall [0-1] 
                     "f1": float,           # Overall F1 score [0-1]
                     "accuracy": float,     # Overall accuracy [0-1]
                     "anls_score": float    # Overall ANLS similarity score [0-1]
                 },
-
+                
                 "fields": {
                     "<field_name>": {
                         # For primitive fields (str, int, float, bool):
@@ -401,7 +420,7 @@ class StructuredModelEvaluator:
                         "accuracy": float,
                         "anls_score": float
                     },
-
+                    
                     "<list_field_name>": {
                         # For list fields (e.g., products: List[Product]):
                         "overall": {
@@ -422,17 +441,17 @@ class StructuredModelEvaluator:
                         ]
                     }
                 },
-
+                
                 "confusion_matrix": {
                     "fields": {
                         # AGGREGATED metrics for all field types
                         "<field_name>": {
                             "tp": int,          # True positives
-                            "fp": int,          # False positives
+                            "fp": int,          # False positives  
                             "tn": int,          # True negatives
                             "fn": int,          # False negatives
                             "fd": int,          # False discoveries (non-null but don't match)
-                            "fa": int,          # False alarms
+                            "fa": int,          # False alarms 
                             "derived": {
                                 "cm_precision": float,
                                 "cm_recall": float,
@@ -440,7 +459,7 @@ class StructuredModelEvaluator:
                                 "cm_accuracy": float
                             }
                         },
-
+                        
                         # For list fields with nested objects, aggregated field metrics:
                         "<list_field>.<nested_field>": {
                             # Aggregated counts across ALL instances in the list
@@ -452,7 +471,7 @@ class StructuredModelEvaluator:
                             "derived": {...}
                         }
                     },
-
+                    
                     "overall": {
                         # Overall confusion matrix aggregating all fields
                         "tp": int, "fp": int, "tn": int, "fn": int, "fd": int, "fa": int
@@ -460,42 +479,42 @@ class StructuredModelEvaluator:
                     }
                 }
             }
-
+            
         Key Usage Patterns:
-
+        
         1. **Individual Item Metrics** (per-instance analysis):
            ```python
            # Access metrics for each individual item in a list
            for i, item_metrics in enumerate(results['fields']['products']['items']):
                print(f"Product {i}: {item_metrics['overall']['f1']}")
            ```
-
+           
         2. **Aggregated Field Metrics** (recommended for field performance analysis):
            ```python
            # Access aggregated metrics across all instances of a field type
            cm_fields = results['confusion_matrix']['fields']
            product_id_performance = cm_fields['products.product_id']
            print(f"Product ID field: {product_id_performance['derived']['cm_precision']}")
-
+           
            # Get all aggregated product field metrics
-           product_fields = {k: v for k, v in cm_fields.items()
+           product_fields = {k: v for k, v in cm_fields.items() 
                            if k.startswith('products.')}
            ```
-
+           
         3. **Helper Function for Aggregated Metrics**:
            ```python
            def get_aggregated_metrics(results, list_field_name):
                '''Extract aggregated field metrics for a list field.'''
                cm_fields = results['confusion_matrix']['fields']
                prefix = f"{list_field_name}."
-               return {k.replace(prefix, ''): v for k, v in cm_fields.items()
+               return {k.replace(prefix, ''): v for k, v in cm_fields.items() 
                       if k.startswith(prefix)}
-
+           
            # Usage:
            product_metrics = get_aggregated_metrics(results, 'products')
            print(f"Product name precision: {product_metrics['name']['derived']['cm_precision']}")
            ```
-
+           
         Note:
             - Use `results['fields'][field]['items']` for per-instance analysis
             - Use `results['confusion_matrix']['fields'][field.subfield]` for aggregated field analysis
@@ -504,7 +523,7 @@ class StructuredModelEvaluator:
         """
         # Clear any existing non-match documents
         self.clear_non_match_documents()
-
+        
         # Use StructuredModel's enhanced comparison with evaluator format
         # This pushes all the heavy lifting into the StructuredModel as requested
         result = ground_truth.compare_with(
@@ -514,48 +533,48 @@ class StructuredModelEvaluator:
             evaluator_format=True,  # This makes StructuredModel return evaluator-compatible format
             recall_with_fd=recall_with_fd,
         )
-
+        
         # Add non-matches to evaluator's collection if they exist
         if result.get("non_matches"):
             for nm_dict in result["non_matches"]:
                 # Convert enhanced non-match format to NonMatchField format
                 converted_nm = self._convert_enhanced_non_match_to_field(nm_dict)
                 self.non_match_documents.append(NonMatchField(**converted_nm))
-
+        
         # Process derived metrics explicitly with recall_with_fd parameter
         if "confusion_matrix" in result and "overall" in result["confusion_matrix"]:
             overall_cm = result["confusion_matrix"]["overall"]
-
+            
             # Update derived metrics directly in the result
             from stickler.structured_object_evaluator.models.metrics_helper import (
                 MetricsHelper,
             )
 
             metrics_helper = MetricsHelper()
-
+            
             # Apply correct recall_with_fd to overall metrics
             derived_metrics = metrics_helper.calculate_derived_metrics(
                 overall_cm, recall_with_fd=recall_with_fd
             )
             result["confusion_matrix"]["overall"]["derived"] = derived_metrics
-
+            
             # Copy these to the top-level metrics if needed
             if "overall" in result:
                 result["overall"]["precision"] = derived_metrics["cm_precision"]
                 result["overall"]["recall"] = derived_metrics["cm_recall"]
                 result["overall"]["f1"] = derived_metrics["cm_f1"]
-
+            
         return result
-
+    
     def _format_evaluation_results(
         self, comparison_result: Dict[str, Any]
     ) -> Dict[str, Any]:
         """
         Format StructuredModel comparison results to match expected evaluator output format.
-
+        
         Args:
             comparison_result: Result from StructuredModel.compare_with()
-
+            
         Returns:
             Dictionary in the expected evaluator format
         """
@@ -564,10 +583,10 @@ class StructuredModelEvaluator:
         overall_score = comparison_result["overall_score"]
         confusion_matrix = comparison_result.get("confusion_matrix", {})
         non_matches = comparison_result.get("non_matches", [])
-
+        
         # Calculate field metrics using existing logic for backward compatibility
         field_metrics = {}
-
+        
         for field_name, score in field_scores.items():
             # Convert field score to binary metrics using existing method
             binary = self._convert_score_to_binary(score)
@@ -577,7 +596,7 @@ class StructuredModelEvaluator:
             )
             metrics["anls_score"] = score
             field_metrics[field_name] = metrics
-
+        
         # Calculate overall metrics
         binary = self._convert_score_to_binary(overall_score)
         # For overall metrics, use confusion_matrix data which should have fd
@@ -591,12 +610,12 @@ class StructuredModelEvaluator:
             recall_with_fd=recall_with_fd,
         )
         overall_metrics["anls_score"] = overall_score
-
+        
         # Add non-matches to evaluator's collection if they exist
         if non_matches:
             for nm_dict in non_matches:
                 self.non_match_documents.append(NonMatchField(**nm_dict))
-
+        
         # Prepare final result in expected format
         result = {
             "overall": overall_metrics,
@@ -604,19 +623,19 @@ class StructuredModelEvaluator:
             "confusion_matrix": confusion_matrix,
             "non_matches": non_matches,
         }
-
+        
         return result
-
+        
     def _compare_model_lists(
         self, gt_models: List[StructuredModel], pred_models: List[StructuredModel]
     ) -> Dict[str, Any]:
         """
         Compare two lists of StructuredModel instances using Hungarian matching.
-
+        
         Args:
             gt_models: List of ground truth models
             pred_models: List of predicted models
-
+            
         Returns:
             Dict with comparison metrics including tp, fp, fn, overall_score
         """
@@ -629,7 +648,7 @@ class StructuredModelEvaluator:
                 "tn": 0,
                 "overall_score": 1.0,  # Empty lists are a perfect match
             }
-
+            
         if not gt_models:
             return {
                 "tp": 0,
@@ -638,7 +657,7 @@ class StructuredModelEvaluator:
                 "tn": 0,
                 "overall_score": 0.0,  # All predictions are false positives
             }
-
+            
         if not pred_models:
             return {
                 "tp": 0,
@@ -647,13 +666,13 @@ class StructuredModelEvaluator:
                 "tn": 0,
                 "overall_score": 0.0,  # All ground truths are false negatives
             }
-
+            
         # Ensure all items are StructuredModel instances
         if not all(
             isinstance(model, StructuredModel) for model in gt_models + pred_models
         ):
             raise TypeError("All items in both lists must be StructuredModel instances")
-
+        
         # If model_class is specified, check type for all models
         if self.model_class:
             if not all(
@@ -662,18 +681,18 @@ class StructuredModelEvaluator:
                 raise TypeError(
                     f"All models must be instances of {self.model_class.__name__}"
                 )
-
+        
         # Create a Hungarian matcher with StructuredModelComparator
         hungarian = HungarianMatcher(StructuredModelComparator())
-
+        
         # Run Hungarian matching
         tp, fp = hungarian(gt_models, pred_models)
-
+        
         # Calculate false negatives
         fn = len(gt_models) - tp
-
+        
         # Calculate overall score (proportion of correct matches)
         max_items = max(len(gt_models), len(pred_models))
         overall_score = tp / max_items if max_items > 0 else 1.0
-
+        
         return {"tp": tp, "fp": fp, "fn": fn, "tn": 0, "overall_score": overall_score}

--- a/src/stickler/structured_object_evaluator/models/comparable_field.py
+++ b/src/stickler/structured_object_evaluator/models/comparable_field.py
@@ -17,7 +17,6 @@ def ComparableField(
     threshold: float = 0.5,
     weight: float = 1.0,
     default: Any = None,
-    aggregate: bool = False,
     clip_under_threshold: bool = True,
     # Pydantic Field parameters (all optional, just like Field)
     alias: Optional[str] = None,
@@ -35,8 +34,6 @@ def ComparableField(
         threshold: Minimum similarity score to consider a match (default: 0.5)
         weight: Weight of this field in overall score calculation (default: 1.0)
         default: Default value for the field (default: None)
-        aggregate: DEPRECATED - This parameter is deprecated and will be removed in a future version.
-                  Use the new universal 'aggregate' field in compare_with() output instead.
         clip_under_threshold: Whether to zero out scores below threshold (default: True)
         alias: Pydantic field alias for serialization (default: None)
         description: Field description for documentation (default: None)
@@ -59,15 +56,6 @@ def ComparableField(
                 examples=["user@example.com"]
             )
     """
-    # Issue deprecation warning if aggregate=True is used
-    if aggregate:
-        warnings.warn(
-            "The 'aggregate' parameter in ComparableField is deprecated and will be removed "
-            "in a future version. All nodes now automatically include an 'aggregate' field "
-            "in the compare_with() output that sums primitive field metrics below that node.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
 
     # Create the actual comparator instance
     actual_comparator = comparator or LevenshteinComparator()
@@ -79,8 +67,7 @@ def ComparableField(
         "comparator_config": getattr(actual_comparator, "config", {}),
         "threshold": threshold,
         "weight": weight,
-        "clip_under_threshold": clip_under_threshold,
-        "aggregate": aggregate,
+        "clip_under_threshold": clip_under_threshold
     }
 
     # Create json_schema_extra function that stores runtime data
@@ -93,7 +80,6 @@ def ComparableField(
     json_schema_extra_func._threshold = threshold
     json_schema_extra_func._weight = weight
     json_schema_extra_func._clip_under_threshold = clip_under_threshold
-    json_schema_extra_func._aggregate = aggregate
     json_schema_extra_func._comparison_metadata = serializable_metadata
 
     # Merge with existing json_schema_extra if provided
@@ -109,7 +95,6 @@ def ComparableField(
         enhanced_json_schema_extra._threshold = threshold
         enhanced_json_schema_extra._weight = weight
         enhanced_json_schema_extra._clip_under_threshold = clip_under_threshold
-        enhanced_json_schema_extra._aggregate = aggregate
         enhanced_json_schema_extra._comparison_metadata = serializable_metadata
         final_json_schema_extra = enhanced_json_schema_extra
     elif isinstance(existing_json_schema_extra, dict):
@@ -123,7 +108,6 @@ def ComparableField(
         enhanced_json_schema_extra._threshold = threshold
         enhanced_json_schema_extra._weight = weight
         enhanced_json_schema_extra._clip_under_threshold = clip_under_threshold
-        enhanced_json_schema_extra._aggregate = aggregate
         enhanced_json_schema_extra._comparison_metadata = serializable_metadata
         final_json_schema_extra = enhanced_json_schema_extra
     else:

--- a/src/stickler/structured_object_evaluator/models/comparison_info.py
+++ b/src/stickler/structured_object_evaluator/models/comparison_info.py
@@ -93,7 +93,6 @@ class ComparableFieldConfig:
         comparator: Optional[BaseComparator] = None,
         threshold: float = 0.5,
         weight: float = 1.0,
-        aggregate: bool = False,
         clip_under_threshold: bool = True,
     ):
         """Initialize comparison configuration.
@@ -102,13 +101,11 @@ class ComparableFieldConfig:
             comparator: Comparator to use (default: LevenshteinComparator)
             threshold: Minimum similarity score to consider a match (default: 0.5)
             weight: Weight of this field in the overall score (default: 1.0)
-            aggregate: Whether to aggregate metrics from child fields (default: False)
             clip_under_threshold: Whether to zero out scores below threshold (default: True)
         """
         self.comparator = comparator or LevenshteinComparator()
         self.threshold = threshold
         self.weight = weight
-        self.aggregate = aggregate
         self.clip_under_threshold = clip_under_threshold
 
     def compare(self, value1: Any, value2: Any) -> float:
@@ -136,7 +133,7 @@ class ComparableFieldConfig:
 
     def __repr__(self) -> str:
         """Return string representation."""
-        return f"ComparableFieldConfig(comparator={self.comparator}, threshold={self.threshold}, weight={self.weight}, aggregate={self.aggregate}, clip_under_threshold={self.clip_under_threshold})"
+        return f"ComparableFieldConfig(comparator={self.comparator}, threshold={self.threshold}, weight={self.weight}, clip_under_threshold={self.clip_under_threshold})"
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to a serializable dictionary for JSON schema."""
@@ -146,7 +143,6 @@ class ComparableFieldConfig:
             "comparator_config": getattr(self.comparator, "config", {}),
             "threshold": self.threshold,
             "weight": self.weight,
-            "aggregate": self.aggregate,
             "clip_under_threshold": self.clip_under_threshold,
         }
 

--- a/src/stickler/structured_object_evaluator/models/configuration_helper.py
+++ b/src/stickler/structured_object_evaluator/models/configuration_helper.py
@@ -191,7 +191,6 @@ class ConfigurationHelper:
                 threshold = getattr(json_func, "_threshold", 0.5)
                 weight = getattr(json_func, "_weight", 1.0)
                 clip_under_threshold = getattr(json_func, "_clip_under_threshold", True)
-                aggregate = getattr(json_func, "_aggregate", False)
                 
                 from .comparison_info import ComparableFieldConfig
 
@@ -199,8 +198,7 @@ class ConfigurationHelper:
                     comparator=comparator,
                     threshold=threshold,
                     weight=weight,
-                    clip_under_threshold=clip_under_threshold,
-                    aggregate=aggregate,
+                    clip_under_threshold=clip_under_threshold
                 )
         
         # FALLBACK: Legacy JSON schema approach for backward compatibility
@@ -234,7 +232,6 @@ class ConfigurationHelper:
                 clip_under_threshold = comparison_config.get(
                     "clip_under_threshold", True
                 )
-                aggregate = comparison_config.get("aggregate", False)
                 
                 from .comparison_info import ComparableFieldConfig
 
@@ -242,8 +239,7 @@ class ConfigurationHelper:
                     comparator=comparator,
                     threshold=threshold,
                     weight=weight,
-                    clip_under_threshold=clip_under_threshold,
-                    aggregate=aggregate,
+                    clip_under_threshold=clip_under_threshold
                 )
         
         # Check if this is a structured field type that needs special handling

--- a/src/stickler/structured_object_evaluator/models/configuration_helper.py
+++ b/src/stickler/structured_object_evaluator/models/configuration_helper.py
@@ -15,41 +15,41 @@ from .comparable_field import ComparableField
 
 class ConfigurationHelper:
     """Helper class for StructuredModel configuration and schema operations."""
-
+    
     @staticmethod
     def from_json(cls, json_data: Dict[str, Any]):
         """Create a StructuredModel instance from JSON data.
-
+        
         This method handles missing fields gracefully and stores extra fields
         in the extra_fields attribute.
-
+        
         Args:
             cls: StructuredModel class
             json_data: Dictionary containing the JSON data
-
+            
         Returns:
             StructuredModel instance created from the JSON data
         """
         # Make a copy of the input data
         data_copy = json_data.copy()
-
+        
         # Extract field names defined in the model
         model_fields = set(cls.model_fields.keys())
-
+        
         # Remove 'extra_fields' from consideration if it exists in the model
         if "extra_fields" in model_fields:
             model_fields.remove("extra_fields")
-
+        
         # Find extra fields (those in json_data but not in model_fields)
         extra_field_names = set(data_copy.keys()) - model_fields
-
+        
         # Extract extra fields into a separate dictionary
         extra_fields = {k: data_copy[k] for k in extra_field_names}
-
+        
         # Since ComparableField is now always a function, we don't need special handling
         # for missing fields - Pydantic will handle them with the field's default value
         pass
-
+        
         # CRITICAL FIX: Recursively handle nested StructuredModel objects
         # For each field that exists in the data and is a StructuredModel, process it recursively
         for field_name in model_fields:
@@ -58,7 +58,7 @@ class ConfigurationHelper:
                 if field_info:
                     # Check if this field is a StructuredModel type
                     annotation = field_info.annotation
-
+                    
                     # Handle direct StructuredModel annotations
                     if ConfigurationHelper._is_structured_model_class(annotation):
                         # Recursively process the nested object
@@ -69,7 +69,7 @@ class ConfigurationHelper:
                                     annotation, nested_data
                                 )
                             )
-
+                    
                     # Handle Optional[StructuredModel] annotations
                     elif ConfigurationHelper._is_optional_structured_model(annotation):
                         nested_data = data_copy[field_name]
@@ -84,7 +84,7 @@ class ConfigurationHelper:
                                         structured_class, nested_data
                                     )
                                 )
-
+                    
                     # Handle List[StructuredModel] and Optional[List[StructuredModel]] annotations
                     elif ConfigurationHelper._is_list_structured_model(annotation):
                         nested_data = data_copy[field_name]
@@ -108,32 +108,32 @@ class ConfigurationHelper:
                                         # Non-dict items are kept as-is
                                         processed_items.append(item_data)
                                 data_copy[field_name] = processed_items
-
+        
         # Create the model instance
         instance = cls.model_validate(data_copy)
-
+        
         # Store extra fields
         instance.extra_fields = extra_fields
-
+        
         return instance
-
+    
     @staticmethod
     def is_structured_field_type(field_info) -> bool:
         """Check if a field represents a structured type that needs special handling.
-
+        
         Args:
             field_info: Pydantic field info object
-
+            
         Returns:
             True if the field is a List[StructuredModel] or StructuredModel type
         """
         try:
             # Get the field annotation
             annotation = field_info.annotation
-
+            
             # Import here to avoid circular import
             from .structured_model import StructuredModel
-
+            
             # Handle List[SomeType] annotations
             if get_origin(annotation) is list:
                 args = get_args(annotation)
@@ -144,7 +144,7 @@ class ConfigurationHelper:
                         element_type, StructuredModel
                     ):
                         return True
-
+            
             # Handle Optional[List[SomeType]] annotations (Union[List[SomeType], NoneType])
             elif get_origin(annotation) is Union:
                 union_args = get_args(annotation)
@@ -158,31 +158,31 @@ class ConfigurationHelper:
                                 element_type, StructuredModel
                             ):
                                 return True
-
+            
             # Handle direct StructuredModel annotations
             elif inspect.isclass(annotation):
                 if issubclass(annotation, StructuredModel):
                     return True
-
+                    
         except (TypeError, AttributeError):
             # If we can't determine the type, assume it's not structured
             pass
-
+            
         return False
-
+    
     @staticmethod
     def get_comparison_info(cls, field_name: str) -> "ComparableFieldConfig":
         """Extract comparison info from a field.
-
+        
         Args:
             cls: StructuredModel class
             field_name: Name of the field to get comparison info for
-
+            
         Returns:
             ComparableFieldConfig object with comparison configuration
         """
         field_info = cls.model_fields[field_name]
-
+        
         # NEW HYBRID APPROACH: Try function attribute access first (fixes custom comparators)
         if hasattr(field_info, "json_schema_extra") and callable(
             field_info.json_schema_extra
@@ -195,7 +195,7 @@ class ConfigurationHelper:
                 weight = getattr(json_func, "_weight", 1.0)
                 clip_under_threshold = getattr(json_func, "_clip_under_threshold", True)
                 aggregate = getattr(json_func, "_aggregate", False)
-
+                
                 from .comparison_info import ComparableFieldConfig
 
                 return ComparableFieldConfig(
@@ -205,11 +205,11 @@ class ConfigurationHelper:
                     clip_under_threshold=clip_under_threshold,
                     aggregate=aggregate,
                 )
-
+        
         # FALLBACK: Legacy JSON schema approach for backward compatibility
         if hasattr(field_info, "json_schema_extra"):
             comparison_config = None
-
+            
             if callable(field_info.json_schema_extra):
                 # Handle callable json_schema_extra (from ComparableField function)
                 schema = {}
@@ -218,7 +218,7 @@ class ConfigurationHelper:
             elif isinstance(field_info.json_schema_extra, dict):
                 # Handle dict json_schema_extra
                 comparison_config = field_info.json_schema_extra.get("x-comparison")
-
+            
             if comparison_config:
                 # Reconstruct from type name and config
                 from .comparable_field import _reconstruct_comparator_from_type
@@ -230,7 +230,7 @@ class ConfigurationHelper:
                 comparator = _reconstruct_comparator_from_type(
                     comparator_type, comparator_config_dict
                 )
-
+                
                 # Extract all configuration parameters
                 threshold = comparison_config.get("threshold", 0.5)
                 weight = comparison_config.get("weight", 1.0)
@@ -238,7 +238,7 @@ class ConfigurationHelper:
                     "clip_under_threshold", True
                 )
                 aggregate = comparison_config.get("aggregate", False)
-
+                
                 from .comparison_info import ComparableFieldConfig
 
                 return ComparableFieldConfig(
@@ -248,7 +248,7 @@ class ConfigurationHelper:
                     clip_under_threshold=clip_under_threshold,
                     aggregate=aggregate,
                 )
-
+        
         # Check if this is a structured field type that needs special handling
         if ConfigurationHelper.is_structured_field_type(field_info):
             # Use StructuredModelComparator with higher threshold for structured types
@@ -259,7 +259,7 @@ class ConfigurationHelper:
                 threshold=0.9,  # Higher threshold for structured object matching
                 weight=1.0,
             )
-
+        
         # Default fallback for primitive fields - use class-level threshold if available
         default_threshold = getattr(cls, "match_threshold", 0.5)
         from .comparison_info import ComparableFieldConfig
@@ -267,85 +267,63 @@ class ConfigurationHelper:
         return ComparableFieldConfig(
             comparator=LevenshteinComparator(), threshold=default_threshold, weight=1.0
         )
+    
 
-    @staticmethod
-    def is_aggregate_field(cls, field_name: str) -> bool:
-        """Check if field is marked for confusion matrix aggregation.
-
-        Args:
-            cls: StructuredModel class
-            field_name: Name of the field to check
-
-        Returns:
-            True if the field is marked for aggregation, False otherwise
-        """
-        field_info = cls.model_fields[field_name]
-
-        # Since ComparableField is now always a function, check for json_schema_extra
-        if hasattr(field_info, "json_schema_extra") and callable(
-            field_info.json_schema_extra
-        ):
-            schema = {}
-            field_info.json_schema_extra(schema)
-            comparison_config = schema.get("x-comparison", {})
-            return comparison_config.get("aggregate", False)
-
-        return False
-
+    
     @staticmethod
     def is_immediate_child(nested_path: str, field_name: str) -> bool:
         """
         Determines if nested_path is an immediate child of field_name.
-
+        
         Args:
             nested_path (str): The nested path to check, e.g., 'owner.contact.phone'
             field_name (str): The potential parent path, e.g., 'owner.contact'
-
+            
         Returns:
             bool: True if nested_path is an immediate child of field_name, False otherwise
         """
         # Check if field_name is a prefix of nested_path
         if not nested_path.startswith(field_name):
             return False
-
+        
         # If field_name is a prefix, it should be followed by a dot
         if len(field_name) >= len(nested_path):
             return False
-
+        
         if nested_path[len(field_name)] != ".":
             return False
-
+        
         # The remaining part after field_name and the dot should not contain any more dots
         remaining = nested_path[len(field_name) + 1 :]
         return "." not in remaining
-
+    
     @staticmethod
     def generate_model_json_schema(cls, **kwargs):
         """Override to add model-level comparison metadata.
-
+        
         Extends the standard Pydantic JSON schema with comparison metadata
         at the field level.
-
+        
         Args:
             cls: StructuredModel class
             **kwargs: Arguments to pass to the parent method
-
+            
         Returns:
             JSON schema with added comparison metadata
         """
         schema = super(cls, cls).model_json_schema(**kwargs)
-
+        
         # Add comparison metadata to each field in the schema
         for field_name, field_info in cls.model_fields.items():
             if field_name == "extra_fields":
                 continue
-
+                
             # Get the schema property for this field
             if field_name not in schema.get("properties", {}):
                 continue
-
+                
             field_props = schema["properties"][field_name]
-
+            
             # Check for json_schema_extra function (ComparableField creates these)
             if hasattr(field_info, "json_schema_extra") and callable(
                 field_info.json_schema_extra
@@ -353,20 +331,20 @@ class ConfigurationHelper:
                 # Fallback: Check for json_schema_extra function
                 temp_schema = {}
                 field_info.json_schema_extra(temp_schema)
-
+                
                 if "x-comparison" in temp_schema:
                     # Copy the comparison metadata from the temp schema to the real schema
                     field_props["x-comparison"] = temp_schema["x-comparison"]
-
+        
         return schema
-
+    
     @staticmethod
     def _is_structured_model_class(annotation) -> bool:
         """Check if annotation is a direct StructuredModel class.
-
+        
         Args:
             annotation: Type annotation to check
-
+            
         Returns:
             True if annotation is a StructuredModel subclass
         """
@@ -378,20 +356,20 @@ class ConfigurationHelper:
             )
         except (TypeError, AttributeError):
             return False
-
+    
     @staticmethod
     def _is_optional_structured_model(annotation) -> bool:
         """Check if annotation is Optional[StructuredModel].
-
+        
         Args:
             annotation: Type annotation to check
-
+            
         Returns:
             True if annotation is Optional[StructuredModel]
         """
         try:
             from .structured_model import StructuredModel
-
+            
             # Handle Union types (like Optional[StructuredModel])
             if get_origin(annotation) is Union:
                 union_args = get_args(annotation)
@@ -409,20 +387,20 @@ class ConfigurationHelper:
             return False
         except (TypeError, AttributeError):
             return False
-
+    
     @staticmethod
     def _extract_structured_class_from_optional(annotation):
         """Extract the StructuredModel class from Optional[StructuredModel].
-
+        
         Args:
             annotation: Type annotation (should be Optional[StructuredModel])
-
+            
         Returns:
             The StructuredModel class, or None if not found
         """
         try:
             from .structured_model import StructuredModel
-
+            
             if get_origin(annotation) is Union:
                 union_args = get_args(annotation)
                 none_type = type(None)
@@ -436,20 +414,20 @@ class ConfigurationHelper:
             return None
         except (TypeError, AttributeError):
             return None
-
+    
     @staticmethod
     def _is_list_structured_model(annotation) -> bool:
         """Check if annotation is List[StructuredModel] or Optional[List[StructuredModel]].
-
+        
         Args:
             annotation: Type annotation to check
-
+            
         Returns:
             True if annotation is List[StructuredModel] or Optional[List[StructuredModel]]
         """
         try:
             from .structured_model import StructuredModel
-
+            
             # Handle direct List[StructuredModel] annotations
             if get_origin(annotation) is list:
                 args = get_args(annotation)
@@ -459,7 +437,7 @@ class ConfigurationHelper:
                     and issubclass(args[0], StructuredModel)
                 ):
                     return True
-
+            
             # Handle Optional[List[StructuredModel]] annotations (Union[List[StructuredModel], NoneType])
             elif get_origin(annotation) is Union:
                 union_args = get_args(annotation)
@@ -474,24 +452,24 @@ class ConfigurationHelper:
                             and issubclass(list_args[0], StructuredModel)
                         ):
                             return True
-
+            
             return False
         except (TypeError, AttributeError):
             return False
-
+    
     @staticmethod
     def _extract_structured_class_from_list(annotation):
         """Extract the StructuredModel class from List[StructuredModel] or Optional[List[StructuredModel]].
-
+        
         Args:
             annotation: Type annotation (should be List[StructuredModel] or Optional[List[StructuredModel]])
-
+            
         Returns:
             The StructuredModel class, or None if not found
         """
         try:
             from .structured_model import StructuredModel
-
+            
             # Handle direct List[StructuredModel]
             if get_origin(annotation) is list:
                 args = get_args(annotation)
@@ -501,7 +479,7 @@ class ConfigurationHelper:
                     and issubclass(args[0], StructuredModel)
                 ):
                     return args[0]
-
+            
             # Handle Optional[List[StructuredModel]]
             elif get_origin(annotation) is Union:
                 union_args = get_args(annotation)
@@ -515,19 +493,19 @@ class ConfigurationHelper:
                             and issubclass(list_args[0], StructuredModel)
                         ):
                             return list_args[0]
-
+            
             return None
         except (TypeError, AttributeError):
             return None
-
+    
     @staticmethod
     def _process_nested_structured_data(structured_class, nested_data):
         """Process nested structured data recursively.
-
+        
         Args:
             structured_class: The StructuredModel class to process with
             nested_data: Dictionary data for the nested object
-
+            
         Returns:
             Dictionary with processed nested data
         """

--- a/src/stickler/structured_object_evaluator/models/non_matches_helper.py
+++ b/src/stickler/structured_object_evaluator/models/non_matches_helper.py
@@ -1,16 +1,16 @@
 """Non-matches helper for StructuredModel comparisons."""
 
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 from .hungarian_helper import HungarianHelper
 from .non_match_field import NonMatchType
 
 
 class NonMatchesHelper:
     """Helper class for collecting and formatting non-matches in StructuredModel comparisons."""
-
+    
     def __init__(self):
         self.hungarian_helper = HungarianHelper()
-
+    
     def create_non_match_entry(
         self,
         field_name: str,
@@ -21,7 +21,7 @@ class NonMatchesHelper:
         similarity_score: float = None,
     ) -> Dict[str, Any]:
         """Create a non-match entry for detailed analysis.
-
+        
         Args:
             field_name: Name of the field
             gt_object: Ground truth object (can be None for FA)
@@ -29,7 +29,7 @@ class NonMatchesHelper:
             non_match_type: Type of non-match ("FD", "FN", "FA")
             object_index: Optional index of the object in the list for indexed field paths
             similarity_score: Similarity score for FD entries
-
+            
         Returns:
             Dictionary with non-match information
         """
@@ -37,14 +37,14 @@ class NonMatchesHelper:
         indexed_field_path = (
             f"{field_name}[{object_index}]" if object_index is not None else field_name
         )
-
+        
         # Map short codes to actual NonMatchType enum values
         type_mapping = {
             "FD": NonMatchType.FALSE_DISCOVERY,
-            "FN": NonMatchType.FALSE_NEGATIVE,
+            "FN": NonMatchType.FALSE_NEGATIVE, 
             "FA": NonMatchType.FALSE_ALARM,
         }
-
+        
         entry = {
             "field_path": indexed_field_path,
             "non_match_type": type_mapping.get(non_match_type, non_match_type),
@@ -55,7 +55,7 @@ class NonMatchesHelper:
             if pred_object and hasattr(pred_object, "model_dump")
             else pred_object,
         }
-
+        
         # Add descriptive reason based on non-match type
         if non_match_type == "FD":
             # False Discovery: matched but below threshold
@@ -84,27 +84,27 @@ class NonMatchesHelper:
             entry["reason"] = "unmatched prediction"
         else:
             entry["reason"] = "unknown non-match type"
-
+        
         return entry
-
+    
     def collect_list_non_matches(
         self, field_name: str, gt_list: List[Any], pred_list: List[Any]
     ) -> List[Dict[str, Any]]:
         """Collect individual object-level non-matches from a list field.
-
+        
         Args:
             field_name: Name of the list field
             gt_list: Ground truth list
             pred_list: Prediction list
-
+            
         Returns:
             List of non-match dictionaries with individual object information
         """
         non_matches = []
-
+        
         if not gt_list and not pred_list:
             return non_matches
-
+        
         # Get optimal assignments with scores
         assignments = []
         matched_pairs_with_scores = []
@@ -114,7 +114,7 @@ class NonMatchesHelper:
             )
             matched_pairs_with_scores = hungarian_info["matched_pairs"]
             assignments = [(i, j) for i, j, score in matched_pairs_with_scores]
-
+        
         # Get the match threshold from the model class
         if (
             gt_list
@@ -124,13 +124,13 @@ class NonMatchesHelper:
             match_threshold = gt_list[0].__class__.match_threshold
         else:
             match_threshold = 0.7
-
+        
         # Process matched pairs for FD entries
         for gt_idx, pred_idx, similarity_score in matched_pairs_with_scores:
             if gt_idx < len(gt_list) and pred_idx < len(pred_list):
                 gt_item = gt_list[gt_idx]
                 pred_item = pred_list[pred_idx]
-
+                
                 # Check if this is a False Discovery (below threshold)
                 is_below_threshold = (
                     similarity_score < match_threshold
@@ -147,7 +147,7 @@ class NonMatchesHelper:
                             similarity_score,
                         )
                     )
-
+        
         # Process unmatched ground truth items (FN)
         matched_gt_indices = set(idx for idx, _ in assignments)
         for gt_idx, gt_item in enumerate(gt_list):
@@ -155,48 +155,392 @@ class NonMatchesHelper:
                 non_matches.append(
                     self.create_non_match_entry(field_name, gt_item, None, "FN", gt_idx)
                 )
-
+        
         # Process unmatched prediction items (FA)
         matched_pred_indices = set(idx for _, idx in assignments)
         for pred_idx, pred_item in enumerate(pred_list):
             if pred_idx not in matched_pred_indices:
                 non_matches.append(
                     self.create_non_match_entry(
-                        field_name, None, pred_item, "FA", pred_idx
+                    field_name, None, pred_item, "FA", pred_idx
                     )
                 )
-
+        
         return non_matches
-
+    
     def add_non_matches_for_null_cases(
         self, field_name: str, gt_list: List[Any], pred_list: List[Any]
     ) -> List[Dict[str, Any]]:
         """Add non-matches for null cases (empty lists).
-
+        
         Args:
             field_name: Name of the field
             gt_list: Ground truth list (may be empty/None)
             pred_list: Prediction list (may be empty/None)
-
+            
         Returns:
             List of non-match entries for null cases
         """
         non_matches = []
-
+        
         # Handle null cases
         if not gt_list and pred_list:
             # Add non-matches for each FA item when GT is empty
             for pred_idx, pred_item in enumerate(pred_list):
                 non_matches.append(
                     self.create_non_match_entry(
-                        field_name, None, pred_item, "FA", pred_idx
+                    field_name, None, pred_item, "FA", pred_idx
                     )
                 )
         elif gt_list and not pred_list:
             # Add non-matches for each FN item when prediction is empty
             for gt_idx, gt_item in enumerate(gt_list):
-                non_matches.append(
-                    self.create_non_match_entry(field_name, gt_item, None, "FN", gt_idx)
-                )
-
+                non_matches.append(self.create_non_match_entry(
+                    field_name, gt_item, None, "FN", gt_idx
+                ))
+        
         return non_matches
+    def create_leaf_non_match_entry(self, field_path: str, gt_value: Any, pred_value: Any, 
+                                   comparison_type: str, similarity_score: Optional[float] = None,
+                                   threshold: Optional[float] = None) -> Dict[str, Any]:
+        """Create a leaf-level non-match entry for primitive field comparisons.
+        
+        Args:
+            field_path: Full dot-notation path to the leaf field (e.g., 'people[0].name')
+            gt_value: Ground truth value
+            pred_value: Prediction value
+            comparison_type: Type of comparison result ("TP", "FA", "FD", "TN", "FN")
+            similarity_score: Similarity score from comparator
+            threshold: Threshold used for classification
+            
+        Returns:
+            Dictionary with leaf-level non-match information
+        """
+        # Map comparison types to non-match types for failed comparisons
+        type_mapping = {
+            "FD": NonMatchType.FALSE_DISCOVERY,
+            "FN": NonMatchType.FALSE_NEGATIVE, 
+            "FA": NonMatchType.FALSE_ALARM
+        }
+        
+        # Only create non-match entries for failed comparisons
+        if comparison_type not in type_mapping:
+            return None
+            
+        entry = {
+            "field_path": field_path,
+            "non_match_type": type_mapping[comparison_type],
+            "ground_truth_value": gt_value,
+            "prediction_value": pred_value,
+            "comparison_type": comparison_type,
+            "is_leaf_level": True  # Flag to distinguish from object-level non_matches
+        }
+        
+        # Add similarity and threshold information for debugging
+        if similarity_score is not None:
+            entry["similarity_score"] = similarity_score
+            entry["similarity"] = similarity_score
+            
+        if threshold is not None:
+            entry["threshold"] = threshold
+            
+        # Add descriptive reason based on comparison type
+        if comparison_type == "FD":
+            if similarity_score is not None and threshold is not None:
+                entry["reason"] = f"below threshold ({similarity_score:.3f} < {threshold})"
+            else:
+                entry["reason"] = "below threshold"
+        elif comparison_type == "FN":
+            entry["reason"] = "ground truth present, prediction missing/null"
+        elif comparison_type == "FA":
+            entry["reason"] = "prediction present, ground truth missing/null"
+        else:
+            entry["reason"] = f"comparison failed ({comparison_type})"
+        
+        return entry
+    
+    def collect_primitive_field_non_matches(self, field_path: str, gt_value: Any, pred_value: Any,
+                                          comparison_result: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Collect leaf-level non_matches from primitive field comparison results.
+        
+        Args:
+            field_path: Full path to the field being compared
+            gt_value: Ground truth value
+            pred_value: Prediction value  
+            comparison_result: Result from primitive field comparison
+            
+        Returns:
+            List of leaf-level non-match entries
+        """
+        non_matches = []
+        
+        # Extract metrics from comparison result
+        overall = comparison_result.get("overall", {})
+        similarity_score = comparison_result.get("similarity_score")
+        threshold_score = comparison_result.get("threshold_applied_score")
+        
+        # Determine threshold from comparison info if available
+        threshold = None
+        if hasattr(comparison_result, 'threshold'):
+            threshold = comparison_result.threshold
+        elif similarity_score is not None and threshold_score is not None:
+            # If threshold was applied and score changed, we can infer threshold was used
+            if abs(similarity_score - threshold_score) > 1e-10:
+                # This suggests threshold clipping occurred
+                threshold = 0.7  # Default threshold assumption
+        
+        # Check each metric type and create non-match entries for failures
+        if overall.get("fd", 0) > 0:
+            entry = self.create_leaf_non_match_entry(
+                field_path, gt_value, pred_value, "FD", similarity_score, threshold
+            )
+            if entry:
+                non_matches.append(entry)
+                
+        if overall.get("fn", 0) > 0:
+            entry = self.create_leaf_non_match_entry(
+                field_path, gt_value, pred_value, "FN", similarity_score, threshold
+            )
+            if entry:
+                non_matches.append(entry)
+                
+        if overall.get("fa", 0) > 0:
+            entry = self.create_leaf_non_match_entry(
+                field_path, gt_value, pred_value, "FA", similarity_score, threshold
+            )
+            if entry:
+                non_matches.append(entry)
+        
+        return non_matches
+    
+    def collect_primitive_list_non_matches(self, field_path: str, gt_list: List[Any], pred_list: List[Any],
+                                         comparison_result: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Collect leaf-level non_matches from primitive list comparison results.
+        
+        Args:
+            field_path: Full path to the list field being compared
+            gt_list: Ground truth list
+            pred_list: Prediction list
+            comparison_result: Result from primitive list comparison
+            
+        Returns:
+            List of leaf-level non-match entries for individual list items
+        """
+        non_matches = []
+        
+        # For primitive lists, we need to analyze the Hungarian matching results
+        # to determine which specific items contributed to FA/FD/FN counts
+        
+        # Extract metrics from comparison result
+        overall = comparison_result.get("overall", {})
+        similarity_score = comparison_result.get("similarity_score", 0.0)
+        
+        # Handle null/empty cases
+        if not gt_list and not pred_list:
+            return non_matches
+        elif not gt_list and pred_list:
+            # All prediction items are FA
+            for i, pred_item in enumerate(pred_list):
+                entry = self.create_leaf_non_match_entry(
+                    f"{field_path}[{i}]", None, pred_item, "FA", 0.0
+                )
+                if entry:
+                    non_matches.append(entry)
+        elif gt_list and not pred_list:
+            # All ground truth items are FN
+            for i, gt_item in enumerate(gt_list):
+                entry = self.create_leaf_non_match_entry(
+                    f"{field_path}[{i}]", gt_item, None, "FN", 0.0
+                )
+                if entry:
+                    non_matches.append(entry)
+        else:
+            # Both lists have items - need to analyze matching results
+            # For now, create aggregate entries based on overall counts
+            # TODO: In future, could integrate with Hungarian matching to get specific item pairs
+            
+            fd_count = overall.get("fd", 0)
+            fa_count = overall.get("fa", 0) 
+            fn_count = overall.get("fn", 0)
+            
+            # Create representative entries for each type of failure
+            if fd_count > 0:
+                entry = self.create_leaf_non_match_entry(
+                    f"{field_path}[*]", f"{len(gt_list)} items", f"{len(pred_list)} items", 
+                    "FD", similarity_score
+                )
+                if entry:
+                    entry["count"] = fd_count
+                    entry["reason"] = f"{fd_count} items below threshold"
+                    non_matches.append(entry)
+                    
+            if fa_count > 0:
+                entry = self.create_leaf_non_match_entry(
+                    f"{field_path}[*]", f"{len(gt_list)} items", f"{len(pred_list)} items",
+                    "FA", similarity_score
+                )
+                if entry:
+                    entry["count"] = fa_count
+                    entry["reason"] = f"{fa_count} unmatched prediction items"
+                    non_matches.append(entry)
+                    
+            if fn_count > 0:
+                entry = self.create_leaf_non_match_entry(
+                    f"{field_path}[*]", f"{len(gt_list)} items", f"{len(pred_list)} items",
+                    "FN", similarity_score
+                )
+                if entry:
+                    entry["count"] = fn_count
+                    entry["reason"] = f"{fn_count} unmatched ground truth items"
+                    non_matches.append(entry)
+        
+        return non_matches
+    
+    def organize_non_matches_hierarchically(self, non_matches: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Organize non_matches into a hierarchical structure for better debugging.
+        
+        Args:
+            non_matches: List of non-match entries
+            
+        Returns:
+            Hierarchical structure organizing non_matches by field path and type
+        """
+        hierarchical = {
+            "summary": {
+                "total_count": len(non_matches),
+                "leaf_level_count": 0,
+                "object_level_count": 0,
+                "by_type": {"FA": 0, "FD": 0, "FN": 0}
+            },
+            "by_field_path": {},
+            "by_type": {"FA": [], "FD": [], "FN": []},
+            "leaf_level": [],
+            "object_level": []
+        }
+        
+        for nm in non_matches:
+            # Count by type
+            comparison_type = nm.get("comparison_type", "")
+            if comparison_type in hierarchical["summary"]["by_type"]:
+                hierarchical["summary"]["by_type"][comparison_type] += 1
+            
+            # Separate leaf-level from object-level
+            if nm.get("is_leaf_level", False):
+                hierarchical["leaf_level"].append(nm)
+                hierarchical["summary"]["leaf_level_count"] += 1
+            else:
+                hierarchical["object_level"].append(nm)
+                hierarchical["summary"]["object_level_count"] += 1
+            
+            # Organize by field path
+            field_path = nm.get("field_path", "unknown")
+            if field_path not in hierarchical["by_field_path"]:
+                hierarchical["by_field_path"][field_path] = []
+            hierarchical["by_field_path"][field_path].append(nm)
+            
+            # Organize by type
+            if comparison_type in hierarchical["by_type"]:
+                hierarchical["by_type"][comparison_type].append(nm)
+        
+        return hierarchical
+    
+    def add_aggregate_contribution_tracing(self, non_matches: List[Dict[str, Any]], 
+                                         aggregate_metrics: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Add traceability from leaf non_matches to aggregate metric contributions.
+        
+        Args:
+            non_matches: List of non-match entries
+            aggregate_metrics: Aggregate metrics from comparison result
+            
+        Returns:
+            Enhanced non_matches with aggregate contribution information
+        """
+        enhanced_non_matches = []
+        
+        for nm in non_matches:
+            enhanced_nm = nm.copy()
+            
+            # Add aggregate contribution information for leaf-level non_matches
+            if nm.get("is_leaf_level", False):
+                comparison_type = nm.get("comparison_type", "")
+                field_path = nm.get("field_path", "")
+                
+                # Determine which aggregate this contributes to
+                path_parts = field_path.split(".")
+                parent_field = path_parts[0] if path_parts else "root"
+                
+                enhanced_nm["aggregate_contribution"] = {
+                    "contributes_to": parent_field,
+                    "metric_type": comparison_type.lower(),
+                    "field_hierarchy": path_parts
+                }
+                
+                # Add context about how this affects aggregate counts
+                if comparison_type == "FD":
+                    enhanced_nm["aggregate_contribution"]["impact"] = "Increases FD count in parent aggregate"
+                elif comparison_type == "FA":
+                    enhanced_nm["aggregate_contribution"]["impact"] = "Increases FA count in parent aggregate"
+                elif comparison_type == "FN":
+                    enhanced_nm["aggregate_contribution"]["impact"] = "Increases FN count in parent aggregate"
+            
+            enhanced_non_matches.append(enhanced_nm)
+        
+        return enhanced_non_matches
+    
+    def create_debugging_report(self, non_matches: List[Dict[str, Any]], 
+                              aggregate_metrics: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Create a comprehensive debugging report from non_matches.
+        
+        Args:
+            non_matches: List of non-match entries
+            aggregate_metrics: Optional aggregate metrics for correlation
+            
+        Returns:
+            Comprehensive debugging report
+        """
+        # Organize hierarchically
+        hierarchical = self.organize_non_matches_hierarchically(non_matches)
+        
+        # Add aggregate contribution tracing if metrics provided
+        if aggregate_metrics:
+            enhanced_non_matches = self.add_aggregate_contribution_tracing(non_matches, aggregate_metrics)
+            hierarchical["enhanced_entries"] = enhanced_non_matches
+        
+        # Create field-level analysis
+        field_analysis = {}
+        for field_path, field_non_matches in hierarchical["by_field_path"].items():
+            field_analysis[field_path] = {
+                "count": len(field_non_matches),
+                "types": {},
+                "has_leaf_level": any(nm.get("is_leaf_level", False) for nm in field_non_matches),
+                "has_object_level": any(not nm.get("is_leaf_level", False) for nm in field_non_matches)
+            }
+            
+            # Count by type for this field
+            for nm in field_non_matches:
+                comp_type = nm.get("comparison_type", "unknown")
+                field_analysis[field_path]["types"][comp_type] = field_analysis[field_path]["types"].get(comp_type, 0) + 1
+        
+        # Create debugging insights
+        insights = []
+        
+        if hierarchical["summary"]["leaf_level_count"] > 0:
+            insights.append(f"Found {hierarchical['summary']['leaf_level_count']} leaf-level non_matches that explain primitive field failures")
+        
+        if hierarchical["summary"]["object_level_count"] > 0:
+            insights.append(f"Found {hierarchical['summary']['object_level_count']} object-level non_matches for structured comparisons")
+        
+        # Identify fields with high failure rates
+        high_failure_fields = [
+            field for field, analysis in field_analysis.items() 
+            if analysis["count"] > 1
+        ]
+        if high_failure_fields:
+            insights.append(f"Fields with multiple failures: {', '.join(high_failure_fields)}")
+        
+        return {
+            "hierarchical_structure": hierarchical,
+            "field_analysis": field_analysis,
+            "debugging_insights": insights,
+            "total_non_matches": len(non_matches)
+        }

--- a/src/stickler/structured_object_evaluator/models/structured_list_comparator.py
+++ b/src/stickler/structured_object_evaluator/models/structured_list_comparator.py
@@ -1,12 +1,12 @@
 """
 Dedicated class for handling Hungarian matching of List[StructuredModel] fields.
 
-This class extracts the Hungarian matching logic from StructuredModel to improve
+This class extracts the Hungarian matching logic from StructuredModel to improve 
 code organization and maintainability. The extraction preserves existing behavior
 exactly, including current bugs that will be fixed in subsequent phases.
 
 Current Behavior Preserved (including bugs):
-- Uses parent field threshold instead of object match_threshold (bug)
+- Uses parent field threshold instead of object match_threshold (bug)  
 - Generates nested metrics for all matched pairs regardless of threshold (bug)
 - Object-level counting discrepancies in some scenarios (bug)
 """
@@ -23,15 +23,15 @@ if TYPE_CHECKING:
 
 class StructuredListComparator:
     """Handles comparison of List[StructuredModel] fields using Hungarian matching."""
-
+    
     def __init__(self, parent_model: "StructuredModel"):
         """Initialize the comparator with reference to parent model.
-
+        
         Args:
             parent_model: The StructuredModel instance that owns the list field
         """
         self.parent_model = parent_model
-
+    
     def compare_struct_list_with_scores(
         self,
         gt_list: List["StructuredModel"],
@@ -39,15 +39,15 @@ class StructuredListComparator:
         field_name: str,
     ) -> dict:
         """Enhanced structural list comparison that returns both metrics AND scores.
-
+        
         CRITICAL: This is the main entry point extracted from StructuredModel.
         Maintains identical behavior including current bugs for Phase 2 compatibility.
-
+        
         Args:
             gt_list: Ground truth list of StructuredModel objects
-            pred_list: Predicted list of StructuredModel objects
+            pred_list: Predicted list of StructuredModel objects  
             field_name: Name of the list field being compared
-
+            
         Returns:
             Dictionary with overall metrics, nested field details, and scores
         """
@@ -55,7 +55,7 @@ class StructuredListComparator:
         info = self.parent_model.__class__._get_comparison_info(field_name)
         weight = info.weight
         threshold = info.threshold
-
+        
         # PHASE 3 FIX: Use correct threshold source for Hungarian matching decisions
         # Should use the list element model's match_threshold, not the parent field's threshold
         if gt_list and hasattr(gt_list[0].__class__, "match_threshold"):
@@ -65,18 +65,18 @@ class StructuredListComparator:
             match_threshold = getattr(
                 self.parent_model.__class__, "match_threshold", 0.7
             )
-
+        
         # Handle empty list cases with beautiful match statements
         early_exit_result = self._handle_struct_list_empty_cases(
             gt_list, pred_list, weight
         )
         if early_exit_result is not None:
             return early_exit_result
-
+        
         # Normalize None to empty lists for consistent processing below
         gt_list = gt_list or []
         pred_list = pred_list or []
-
+        
         # Calculate object-level metrics using extracted method
         (
             object_level_metrics,
@@ -84,15 +84,15 @@ class StructuredListComparator:
             matched_gt_indices,
             matched_pred_indices,
         ) = self._calculate_object_level_metrics(gt_list, pred_list, match_threshold)
-
+        
         # Calculate raw similarity score using extracted method
         raw_similarity = self._calculate_struct_list_similarity(
             gt_list, pred_list, info
         )
-
+        
         # CRITICAL FIX: For structured lists, we NEVER clip under threshold - partial matches are important
         threshold_applied_score = raw_similarity  # Always use raw score for lists
-
+        
         # Get field-level details for nested structure (but DON'T aggregate to list level)
         # THRESHOLD-GATED RECURSION: Only generate field details for good matches
         field_details = self._calculate_nested_field_metrics(
@@ -104,7 +104,7 @@ class StructuredListComparator:
             matched_pred_indices,
             match_threshold,
         )
-
+        
         # Build final result structure
         final_result = {
             "overall": object_level_metrics,  # Count OBJECTS, not fields
@@ -114,9 +114,9 @@ class StructuredListComparator:
             "threshold_applied_score": threshold_applied_score,
             "weight": weight,
         }
-
+        
         return final_result
-
+    
     def _handle_struct_list_empty_cases(
         self,
         gt_list: List["StructuredModel"],
@@ -124,19 +124,19 @@ class StructuredListComparator:
         weight: float,
     ) -> dict:
         """Handle empty list cases with beautiful match statements.
-
+        
         Args:
             gt_list: Ground truth list (may be None)
-            pred_list: Predicted list (may be None)
+            pred_list: Predicted list (may be None) 
             weight: Field weight for scoring
-
+            
         Returns:
             Result dictionary if early exit needed, None if should continue processing
         """
         # Normalize None to empty lists for consistent handling
         gt_len = len(gt_list or [])
         pred_len = len(pred_list or [])
-
+        
         match (gt_len, pred_len):
             case (0, 0):
                 # Both empty lists → True Negative
@@ -193,12 +193,12 @@ class StructuredListComparator:
         match_threshold: float,
     ) -> tuple:
         """Calculate object-level metrics using Hungarian matching.
-
+        
         Args:
             gt_list: Ground truth list
             pred_list: Predicted list
             match_threshold: Threshold for considering objects as matches
-
+            
         Returns:
             Tuple of (object_metrics_dict, matched_pairs, matched_gt_indices, matched_pred_indices)
         """
@@ -206,7 +206,7 @@ class StructuredListComparator:
         hungarian_helper = HungarianHelper()
         hungarian_info = hungarian_helper.get_complete_matching_info(gt_list, pred_list)
         matched_pairs = hungarian_info["matched_pairs"]
-
+        
         # Count OBJECTS, not individual fields
         tp_objects = 0  # Objects with similarity >= match_threshold
         fd_objects = 0  # Objects with similarity < match_threshold
@@ -215,7 +215,7 @@ class StructuredListComparator:
                 tp_objects += 1
             else:
                 fd_objects += 1
-
+        
         # Count unmatched objects
         matched_gt_indices = {idx for idx, _, _ in matched_pairs}
         matched_pred_indices = {idx for _, idx, _ in matched_pairs}
@@ -223,17 +223,17 @@ class StructuredListComparator:
         fa_objects = len(pred_list) - len(
             matched_pred_indices
         )  # Unmatched pred objects
-
+        
         # Build list-level metrics counting OBJECTS (not fields)
         object_level_metrics = {
             "tp": tp_objects,
-            "fa": fa_objects,
+            "fa": fa_objects,  
             "fd": fd_objects,
             "fp": fa_objects + fd_objects,  # Total false positives
             "tn": 0,  # No true negatives at object level for non-empty lists
             "fn": fn_objects,
         }
-
+        
         return (
             object_level_metrics,
             matched_pairs,
@@ -248,12 +248,12 @@ class StructuredListComparator:
         info: "ComparableField",
     ) -> float:
         """Calculate raw similarity score for structured list.
-
+        
         Args:
             gt_list: Ground truth list
             pred_list: Predicted list
             info: Field comparison info
-
+            
         Returns:
             Raw similarity score between 0.0 and 1.0
         """
@@ -271,121 +271,232 @@ class StructuredListComparator:
         list_field_name: str,
         gt_list: List["StructuredModel"],
         pred_list: List["StructuredModel"],
-        matched_pairs: List,
-        matched_gt_indices: set,
-        matched_pred_indices: set,
+                                       matched_pairs: List,
+                                       matched_gt_indices: set,
+                                       matched_pred_indices: set,
         match_threshold: float,
     ) -> Dict[str, Dict[str, Any]]:
         """Calculate field-level details for nested structure with threshold-gated recursion.
-
+        
         PHASE 3 FIX: Implements proper threshold-gated recursion as documented.
         Only generates nested field metrics for object pairs with similarity >= match_threshold.
         Poor matches and unmatched items are treated as atomic units without field-level analysis.
-
+        
         Args:
             list_field_name: Name of the parent list field
             gt_list: Ground truth list
-            pred_list: Predicted list
+            pred_list: Predicted list  
             matched_pairs: List of (gt_idx, pred_idx, similarity) tuples
             matched_gt_indices: Set of matched GT indices
             matched_pred_indices: Set of matched pred indices
             match_threshold: Match threshold for threshold-gating (NOW PROPERLY USED!)
-
+            
         Returns:
             Dictionary mapping field names to their metrics
         """
         field_details = {}
-
+        
         if gt_list and isinstance(gt_list[0], StructuredModel):
             model_class = gt_list[0].__class__
-
-            # PHASE 3 FIX: Only process pairs that meet the match_threshold
-            # Filter to good matches only - poor matches get no recursive analysis
-            good_matched_pairs = [
-                (gt_idx, pred_idx, similarity)
-                for gt_idx, pred_idx, similarity in matched_pairs
-                if similarity >= match_threshold
-            ]
-
-            # Only generate field details if we have good matched pairs OR unmatched objects
-            has_good_matches = len(good_matched_pairs) > 0
-            has_unmatched = (len(matched_gt_indices) < len(gt_list)) or (
-                len(matched_pred_indices) < len(pred_list)
-            )
-
-            if has_good_matches or has_unmatched:
+            
+            # CRITICAL FIX: Process ALL matched pairs for field-level metrics, regardless of threshold
+            # The threshold is only used for object-level classification, not field-level analysis
+            # This ensures field-level metrics are calculated for all matched pairs
+            all_matched_pairs = matched_pairs  # Process all matched pairs, not just good ones
+            
+            # Generate field details if we have any matched pairs OR unmatched objects
+            has_matched_pairs = len(all_matched_pairs) > 0
+            has_unmatched = (len(matched_gt_indices) < len(gt_list)) or (len(matched_pred_indices) < len(pred_list))
+            
+            if has_matched_pairs or has_unmatched:
                 for sub_field_name in model_class.model_fields:
                     if sub_field_name == "extra_fields":
                         continue
-
+                    
                     # Check if this field is a List[StructuredModel] that needs hierarchical treatment
                     field_info = model_class.model_fields.get(sub_field_name)
                     is_hierarchical_field = (
                         field_info and model_class._is_structured_field_type(field_info)
                     )
-
+                    
                     if is_hierarchical_field:
-                        # Handle hierarchical fields with recursive aggregation - ONLY for good matches
+                        # Handle hierarchical fields with recursive aggregation - for ALL matched pairs
                         field_details[sub_field_name] = self._handle_hierarchical_field(
-                            sub_field_name,
-                            gt_list,
-                            pred_list,
-                            good_matched_pairs,
-                            matched_gt_indices,
-                            matched_pred_indices,
-                            match_threshold,
+                            sub_field_name, gt_list, pred_list, all_matched_pairs, 
+                            matched_gt_indices, matched_pred_indices, match_threshold
                         )
                     else:
-                        # Handle primitive fields with simple aggregation - ONLY for good matches
+                        # Handle primitive fields with simple aggregation - for ALL matched pairs
                         field_details[sub_field_name] = self._handle_primitive_field(
-                            sub_field_name,
-                            gt_list,
-                            pred_list,
-                            good_matched_pairs,
-                            matched_gt_indices,
-                            matched_pred_indices,
+                            sub_field_name, gt_list, pred_list, all_matched_pairs,
+                            matched_gt_indices, matched_pred_indices
                         )
-
+        
         return field_details
-
+    
     def _handle_hierarchical_field(
         self,
         sub_field_name: str,
         gt_list: List["StructuredModel"],
         pred_list: List["StructuredModel"],
-        matched_pairs: List,
-        matched_gt_indices: set,
-        matched_pred_indices: set,
-        match_threshold: float,
-    ) -> Dict[str, Any]:
-        """Handle hierarchical List[StructuredModel] fields with TRUE recursive aggregation.
-
-        CRITICAL FIX: Now uses proper recursion to handle arbitrary nesting depth.
+                                  matched_pairs: List,
+                                  matched_gt_indices: set,
+                                  matched_pred_indices: set,
+                                  match_threshold: float) -> Dict[str, Any]:
+        """Handle hierarchical List[StructuredModel] fields with proper threshold-based processing.
+        
+        CRITICAL FIX: Now applies threshold-based classification for hierarchical fields too.
         """
-
+        
         # Collect all pair results for recursive aggregation
         pair_results = []
-
-        # Process good matched pairs only
+        
+        # Process matched pairs with field-level comparison (regardless of object-level similarity)
         for gt_idx, pred_idx, similarity in matched_pairs:
             if gt_idx < len(gt_list) and pred_idx < len(pred_list):
                 gt_item = gt_list[gt_idx]
                 pred_item = pred_list[pred_idx]
-                gt_sub_value = getattr(gt_item, sub_field_name)
-                pred_sub_value = getattr(pred_item, sub_field_name)
-
-                # Get hierarchical comparison for this pair
+                gt_sub_value = getattr(gt_item, sub_field_name, None)
+                pred_sub_value = getattr(pred_item, sub_field_name, None)
+                
+                # CRITICAL FIX: Always use field-level comparison for matched pairs
+                # The object-level similarity doesn't affect field-level metrics
                 pair_result = gt_item._dispatch_field_comparison(
                     sub_field_name, gt_sub_value, pred_sub_value
                 )
+                
+                # CRITICAL FIX: For hierarchical fields, we need to account for nested field contributions
+                # when the parent field is None but we still need to count the nested fields
+                if pair_result["overall"].get("fa", 0) > 0 or pair_result["overall"].get("tn", 0) > 0:
+                    # This is a FA or TN case - we need to add nested field contributions
+                    pair_result = self._expand_hierarchical_field_metrics(pair_result, gt_sub_value, pred_sub_value, sub_field_name, gt_item)
+                
                 pair_results.append(pair_result)
-
+        
+        # Handle unmatched GT objects (contribute FN for non-null fields, TN for null fields)
+        unmatched_gt_fn_count = 0
+        unmatched_gt_tn_count = 0
+        for gt_idx, gt_item in enumerate(gt_list):
+            if gt_idx not in matched_gt_indices:
+                gt_sub_value = getattr(gt_item, sub_field_name, None)
+                if gt_sub_value is not None and gt_sub_value != [] and gt_sub_value != "":
+                    # Count nested fields for hierarchical structures
+                    field_info = gt_item.__class__.model_fields.get(sub_field_name)
+                    if field_info and gt_item.__class__._is_structured_field_type(field_info):
+                        # Get nested field count
+                        from typing import get_origin, get_args, Union
+                        field_type = field_info.annotation if hasattr(field_info, 'annotation') else None
+                        if field_type:
+                            # Handle Union types
+                            if get_origin(field_type) is Union:
+                                for arg in get_args(field_type):
+                                    if get_origin(arg) is list:
+                                        field_type = arg
+                                        break
+                            
+                            if get_origin(field_type) is list:
+                                args = get_args(field_type)
+                                if args and hasattr(args[0], 'model_fields'):
+                                    nested_model_class = args[0]
+                                    nested_field_count = len([f for f in nested_model_class.model_fields.keys() if f != 'extra_fields'])
+                                    # Count the list items and their nested fields
+                                    list_length = len(gt_sub_value) if isinstance(gt_sub_value, list) else 1
+                                    unmatched_gt_fn_count += list_length * nested_field_count
+                                else:
+                                    unmatched_gt_fn_count += 1
+                            else:
+                                unmatched_gt_fn_count += 1
+                        else:
+                            unmatched_gt_fn_count += 1
+                    else:
+                        unmatched_gt_fn_count += 1
+                else:
+                    # GT field is None/empty - this is a TN for hierarchical fields too
+                    field_info = gt_item.__class__.model_fields.get(sub_field_name)
+                    if field_info and gt_item.__class__._is_structured_field_type(field_info):
+                        # Get nested field count for TN
+                        from typing import get_origin, get_args, Union
+                        field_type = field_info.annotation if hasattr(field_info, 'annotation') else None
+                        if field_type:
+                            # Handle Union types
+                            if get_origin(field_type) is Union:
+                                for arg in get_args(field_type):
+                                    if get_origin(arg) is list:
+                                        field_type = arg
+                                        break
+                            
+                            if get_origin(field_type) is list:
+                                args = get_args(field_type)
+                                if args and hasattr(args[0], 'model_fields'):
+                                    nested_model_class = args[0]
+                                    nested_field_count = len([f for f in nested_model_class.model_fields.keys() if f != 'extra_fields'])
+                                    unmatched_gt_tn_count += nested_field_count + 1  # +1 for the list field itself
+                                else:
+                                    unmatched_gt_tn_count += 1
+                            else:
+                                unmatched_gt_tn_count += 1
+                        else:
+                            unmatched_gt_tn_count += 1
+                    else:
+                        unmatched_gt_tn_count += 1
+        
+        if unmatched_gt_fn_count > 0:
+            # Add FN result for unmatched GT items
+            unmatched_result = {
+                "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": unmatched_gt_fn_count},
+                "fields": {}
+            }
+            pair_results.append(unmatched_result)
+        
+        if unmatched_gt_tn_count > 0:
+            # Add TN result for unmatched GT items with null fields
+            unmatched_result = {
+                "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": unmatched_gt_tn_count, "fn": 0},
+                "fields": {}
+            }
+            pair_results.append(unmatched_result)
+        
+        # Handle unmatched pred objects (contribute FA for hierarchical fields)
+        unmatched_pred_fa_count = 0
+        for pred_idx, pred_item in enumerate(pred_list):
+            if pred_idx not in matched_pred_indices:
+                pred_sub_value = getattr(pred_item, sub_field_name, None)
+                if pred_sub_value is not None and pred_sub_value != [] and pred_sub_value != "":
+                    # Count nested fields for hierarchical structures
+                    field_info = pred_item.__class__.model_fields.get(sub_field_name)
+                    if field_info and pred_item.__class__._is_structured_field_type(field_info):
+                        # Get nested field count
+                        from typing import get_origin, get_args
+                        field_type = field_info.annotation if hasattr(field_info, 'annotation') else None
+                        if field_type and get_origin(field_type) is list:
+                            args = get_args(field_type)
+                            if args and hasattr(args[0], 'model_fields'):
+                                nested_model_class = args[0]
+                                nested_field_count = len([f for f in nested_model_class.model_fields.keys() if f != 'extra_fields'])
+                                # Count the list items and their nested fields
+                                list_length = len(pred_sub_value) if isinstance(pred_sub_value, list) else 1
+                                unmatched_pred_fa_count += list_length * nested_field_count
+                            else:
+                                unmatched_pred_fa_count += 1
+                        else:
+                            unmatched_pred_fa_count += 1
+                    else:
+                        unmatched_pred_fa_count += 1
+        
+        if unmatched_pred_fa_count > 0:
+            # Add FA result for unmatched pred items
+            unmatched_result = {
+                "overall": {"tp": 0, "fa": unmatched_pred_fa_count, "fd": 0, "fp": unmatched_pred_fa_count, "tn": 0, "fn": 0},
+                "fields": {}
+            }
+            pair_results.append(unmatched_result)
+        
         # Use recursive aggregation function
         aggregated_result = self._recursive_aggregate_metrics(pair_results)
-
+        
         # Add derived metrics recursively
         self._add_derived_metrics_recursively(aggregated_result)
-
+        
         # Add metadata from first pair if available
         if pair_results:
             for key in [
@@ -396,29 +507,75 @@ class StructuredListComparator:
             ]:
                 if key in pair_results[0]:
                     aggregated_result[key] = pair_results[0][key]
-
+        
         return (
             aggregated_result
             if pair_results
             else {"overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}}
         )
 
-    def _recursive_aggregate_metrics(
-        self, pair_results: List[Dict[str, Any]]
-    ) -> Dict[str, Any]:
+    
+    def _expand_hierarchical_field_metrics(self, pair_result: Dict[str, Any], gt_value: Any, pred_value: Any, field_name: str, gt_item: 'StructuredModel') -> Dict[str, Any]:
+        """Expand hierarchical field metrics to include nested field contributions.
+        
+        When a hierarchical field (like List[StructuredModel]) is classified as FA or TN,
+        we need to add contributions for its nested fields to match the expected behavior.
+        
+        Args:
+            pair_result: The current pair result from field comparison
+            gt_value: Ground truth value for the field
+            pred_value: Predicted value for the field  
+            field_name: Name of the field
+            gt_item: The ground truth item containing the field
+            
+        Returns:
+            Updated pair result with expanded nested field metrics
+        """
+        # Get field info to determine if this is a hierarchical field
+        field_info = gt_item.__class__.model_fields.get(field_name)
+        if not field_info or not gt_item.__class__._is_structured_field_type(field_info):
+            return pair_result  # Not a hierarchical field, return as-is
+        
+        # Determine the nested model type
+        from typing import get_origin, get_args
+        field_type = field_info.annotation if hasattr(field_info, 'annotation') else None
+        if not field_type:
+            return pair_result
+        
+        # Handle List[StructuredModel] case
+        if get_origin(field_type) is list:
+            args = get_args(field_type)
+            if args and hasattr(args[0], 'model_fields'):
+                nested_model_class = args[0]
+                
+                # Get the number of nested fields in the model
+                nested_field_count = len([f for f in nested_model_class.model_fields.keys() if f != 'extra_fields'])
+                
+                # If this is a FA case (GT=None, Pred=non-None), add FA for each nested field
+                if pair_result["overall"].get("fa", 0) > 0:
+                    pair_result["overall"]["fa"] += nested_field_count
+                    pair_result["overall"]["fp"] += nested_field_count
+                
+                # If this is a TN case (GT=None, Pred=None), add TN for each nested field  
+                elif pair_result["overall"].get("tn", 0) > 0:
+                    pair_result["overall"]["tn"] += nested_field_count
+        
+        return pair_result
+    
+    def _recursive_aggregate_metrics(self, pair_results: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Recursively aggregate metrics from multiple pair results - handles arbitrary depth."""
         if not pair_results:
             return {
                 "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0},
                 "fields": {},
             }
-
+        
         # Initialize the aggregated result
         aggregated = {
             "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0},
             "fields": {},
         }
-
+        
         for pair_result in pair_results:
             # Aggregate overall metrics
             if "overall" in pair_result:
@@ -426,15 +583,15 @@ class StructuredListComparator:
                     aggregated["overall"][metric] += pair_result["overall"].get(
                         metric, 0
                     )
-
+            
             # Recursively aggregate fields
             if "fields" in pair_result:
                 aggregated["fields"] = self._recursive_merge_fields(
                     aggregated["fields"], pair_result["fields"]
                 )
-
+        
         return aggregated
-
+    
     def _recursive_merge_fields(
         self, target_fields: Dict[str, Any], source_fields: Dict[str, Any]
     ) -> Dict[str, Any]:
@@ -465,7 +622,7 @@ class StructuredListComparator:
                         "tn": 0,
                         "fn": 0,
                     }
-
+            
             # Aggregate metrics based on structure type
             if "overall" in field_metrics:
                 # Hierarchical structure - aggregate overall and recurse into fields
@@ -473,7 +630,7 @@ class StructuredListComparator:
                     target_fields[field_name]["overall"][metric] += field_metrics[
                         "overall"
                     ].get(metric, 0)
-
+                
                 # RECURSIVE CALL: Handle nested fields at arbitrary depth
                 if "fields" in field_metrics:
                     if "fields" not in target_fields[field_name]:
@@ -485,19 +642,19 @@ class StructuredListComparator:
                 # Flat structure - aggregate directly
                 for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
                     target_fields[field_name][metric] += field_metrics.get(metric, 0)
-
+        
         return target_fields
-
+    
     def _add_derived_metrics_recursively(self, metrics_dict: Dict[str, Any]) -> None:
         """Recursively add derived metrics to all levels of the structure."""
         metrics_helper = MetricsHelper()
-
+        
         # Add derived metrics to overall if present
         if "overall" in metrics_dict:
             metrics_dict["overall"]["derived"] = (
                 metrics_helper.calculate_derived_metrics(metrics_dict["overall"])
             )
-
+        
         # Recursively process fields
         if "fields" in metrics_dict:
             for field_name, field_data in metrics_dict["fields"].items():
@@ -513,57 +670,59 @@ class StructuredListComparator:
                         field_data
                     )
                 # If neither "overall" nor "tp" is present, it might be an empty structure - skip
-
+    
     def _handle_primitive_field(
         self,
         sub_field_name: str,
         gt_list: List["StructuredModel"],
         pred_list: List["StructuredModel"],
-        matched_pairs: List,
-        matched_gt_indices: set,
-        matched_pred_indices: set,
-    ) -> Dict[str, Any]:
-        """Handle primitive fields with simple aggregation across matched pairs.
-
-        PHASE 3 FIX: Now only processes good matched pairs (similarity >= match_threshold).
+                               matched_pairs: List,
+                               matched_gt_indices: set,
+                               matched_pred_indices: set) -> Dict[str, Any]:
+        """Handle primitive fields with proper threshold-based classification for matched pairs.
+        
+        CRITICAL FIX: Now properly handles threshold-based classification for matched pairs.
+        Pairs below threshold are treated as unmatched for field-level purposes.
         """
-
+        
         # Initialize collection for primitive fields across all objects
         sub_field_metrics = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
-
-        # PHASE 3 FIX: Now only processes pairs that passed the threshold filter
+        
+        # Get match threshold from the model class
+        match_threshold = getattr(gt_list[0].__class__, 'match_threshold', 0.7) if gt_list else 0.7
+        
+        # Process matched pairs with field-level classification (regardless of object-level similarity)
         for gt_idx, pred_idx, similarity in matched_pairs:
             if gt_idx < len(gt_list) and pred_idx < len(pred_list):
                 gt_item = gt_list[gt_idx]
                 pred_item = pred_list[pred_idx]
-                gt_sub_value = getattr(gt_item, sub_field_name)
-                pred_sub_value = getattr(pred_item, sub_field_name)
-
-                # Regular field - use flat classification
-                field_classification = gt_item._classify_field_for_confusion_matrix(
-                    sub_field_name, pred_sub_value
-                )
-
-                # Aggregate field metrics across all objects
+                gt_sub_value = getattr(gt_item, sub_field_name, None)
+                pred_sub_value = getattr(pred_item, sub_field_name, None)
+                
+                # CRITICAL FIX: Always use field-level classification for matched pairs
+                # The object-level similarity doesn't affect field-level metrics
+                field_classification = gt_item._classify_field_for_confusion_matrix(sub_field_name, pred_sub_value)
                 for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
                     sub_field_metrics[metric] += field_classification.get(metric, 0)
-
-        # Handle unmatched objects for primitive fields
-        # Handle unmatched GT objects (contribute FN to field-level)
+        
+        # Handle unmatched GT objects (contribute FN for non-null fields, TN for null fields)
         for gt_idx, gt_item in enumerate(gt_list):
             if gt_idx not in matched_gt_indices:
-                gt_sub_value = getattr(gt_item, sub_field_name)
-                if gt_sub_value is not None:  # Only count non-null values as FN
+                gt_sub_value = getattr(gt_item, sub_field_name, None)
+                if gt_sub_value is not None and gt_sub_value != "" and gt_sub_value != []:
                     sub_field_metrics["fn"] += 1
-
-        # Handle unmatched pred objects (contribute FA to field-level)
+                else:
+                    # GT field is None/empty - this is a TN (correctly predicted as absent)
+                    sub_field_metrics["tn"] += 1
+        
+        # Handle unmatched pred objects (contribute FA to field-level for each non-null field)  
         for pred_idx, pred_item in enumerate(pred_list):
             if pred_idx not in matched_pred_indices:
-                pred_sub_value = getattr(pred_item, sub_field_name)
-                if pred_sub_value is not None:  # Only count non-null values as FA
+                pred_sub_value = getattr(pred_item, sub_field_name, None)
+                if pred_sub_value is not None and pred_sub_value != "" and pred_sub_value != []:
                     sub_field_metrics["fa"] += 1
                     sub_field_metrics["fp"] += 1
-
+        
         # UNIFIED STRUCTURE: Wrap primitive field metrics in 'overall' for consistency
         # This ensures all fields use the same access pattern: field_data['overall']
         return {"overall": sub_field_metrics}

--- a/src/stickler/structured_object_evaluator/models/structured_list_comparator.py
+++ b/src/stickler/structured_object_evaluator/models/structured_list_comparator.py
@@ -1,12 +1,12 @@
 """
 Dedicated class for handling Hungarian matching of List[StructuredModel] fields.
 
-This class extracts the Hungarian matching logic from StructuredModel to improve 
+This class extracts the Hungarian matching logic from StructuredModel to improve
 code organization and maintainability. The extraction preserves existing behavior
 exactly, including current bugs that will be fixed in subsequent phases.
 
 Current Behavior Preserved (including bugs):
-- Uses parent field threshold instead of object match_threshold (bug)  
+- Uses parent field threshold instead of object match_threshold (bug)
 - Generates nested metrics for all matched pairs regardless of threshold (bug)
 - Object-level counting discrepancies in some scenarios (bug)
 """
@@ -22,15 +22,15 @@ if TYPE_CHECKING:
 
 class StructuredListComparator:
     """Handles comparison of List[StructuredModel] fields using Hungarian matching."""
-    
+
     def __init__(self, parent_model: "StructuredModel"):
         """Initialize the comparator with reference to parent model.
-        
+
         Args:
             parent_model: The StructuredModel instance that owns the list field
         """
         self.parent_model = parent_model
-    
+
     def compare_struct_list_with_scores(
         self,
         gt_list: List["StructuredModel"],
@@ -38,15 +38,15 @@ class StructuredListComparator:
         field_name: str,
     ) -> dict:
         """Enhanced structural list comparison that returns both metrics AND scores.
-        
+
         CRITICAL: This is the main entry point extracted from StructuredModel.
         Maintains identical behavior including current bugs for Phase 2 compatibility.
-        
+
         Args:
             gt_list: Ground truth list of StructuredModel objects
-            pred_list: Predicted list of StructuredModel objects  
+            pred_list: Predicted list of StructuredModel objects
             field_name: Name of the list field being compared
-            
+
         Returns:
             Dictionary with overall metrics, nested field details, and scores
         """
@@ -63,18 +63,18 @@ class StructuredListComparator:
             match_threshold = getattr(
                 self.parent_model.__class__, "match_threshold", 0.7
             )
-        
+
         # Handle empty list cases with beautiful match statements
         early_exit_result = self._handle_struct_list_empty_cases(
             gt_list, pred_list, weight
         )
         if early_exit_result is not None:
             return early_exit_result
-        
+
         # Normalize None to empty lists for consistent processing below
         gt_list = gt_list or []
         pred_list = pred_list or []
-        
+
         # Calculate object-level metrics using extracted method
         (
             object_level_metrics,
@@ -82,15 +82,15 @@ class StructuredListComparator:
             matched_gt_indices,
             matched_pred_indices,
         ) = self._calculate_object_level_metrics(gt_list, pred_list, match_threshold)
-        
+
         # Calculate raw similarity score using extracted method
         raw_similarity = self._calculate_struct_list_similarity(
             gt_list, pred_list, info
         )
-        
+
         # CRITICAL FIX: For structured lists, we NEVER clip under threshold - partial matches are important
         threshold_applied_score = raw_similarity  # Always use raw score for lists
-        
+
         # Get field-level details for nested structure (but DON'T aggregate to list level)
         # THRESHOLD-GATED RECURSION: Only generate field details for good matches
         field_details = self._calculate_nested_field_metrics(
@@ -102,7 +102,7 @@ class StructuredListComparator:
             matched_pred_indices,
             match_threshold,
         )
-        
+
         # Build final result structure
         final_result = {
             "overall": object_level_metrics,  # Count OBJECTS, not fields
@@ -112,9 +112,9 @@ class StructuredListComparator:
             "threshold_applied_score": threshold_applied_score,
             "weight": weight,
         }
-        
+
         return final_result
-    
+
     def _handle_struct_list_empty_cases(
         self,
         gt_list: List["StructuredModel"],
@@ -122,19 +122,19 @@ class StructuredListComparator:
         weight: float,
     ) -> dict:
         """Handle empty list cases with beautiful match statements.
-        
+
         Args:
             gt_list: Ground truth list (may be None)
-            pred_list: Predicted list (may be None) 
+            pred_list: Predicted list (may be None)
             weight: Field weight for scoring
-            
+
         Returns:
             Result dictionary if early exit needed, None if should continue processing
         """
         # Normalize None to empty lists for consistent handling
         gt_len = len(gt_list or [])
         pred_len = len(pred_list or [])
-        
+
         match (gt_len, pred_len):
             case (0, 0):
                 # Both empty lists → True Negative
@@ -191,12 +191,12 @@ class StructuredListComparator:
         match_threshold: float,
     ) -> tuple:
         """Calculate object-level metrics using Hungarian matching.
-        
+
         Args:
             gt_list: Ground truth list
             pred_list: Predicted list
             match_threshold: Threshold for considering objects as matches
-            
+
         Returns:
             Tuple of (object_metrics_dict, matched_pairs, matched_gt_indices, matched_pred_indices)
         """
@@ -204,7 +204,7 @@ class StructuredListComparator:
         hungarian_helper = HungarianHelper()
         hungarian_info = hungarian_helper.get_complete_matching_info(gt_list, pred_list)
         matched_pairs = hungarian_info["matched_pairs"]
-        
+
         # Count OBJECTS, not individual fields
         tp_objects = 0  # Objects with similarity >= match_threshold
         fd_objects = 0  # Objects with similarity < match_threshold
@@ -213,7 +213,7 @@ class StructuredListComparator:
                 tp_objects += 1
             else:
                 fd_objects += 1
-        
+
         # Count unmatched objects
         matched_gt_indices = {idx for idx, _, _ in matched_pairs}
         matched_pred_indices = {idx for _, idx, _ in matched_pairs}
@@ -221,17 +221,17 @@ class StructuredListComparator:
         fa_objects = len(pred_list) - len(
             matched_pred_indices
         )  # Unmatched pred objects
-        
+
         # Build list-level metrics counting OBJECTS (not fields)
         object_level_metrics = {
             "tp": tp_objects,
-            "fa": fa_objects,  
+            "fa": fa_objects,
             "fd": fd_objects,
             "fp": fa_objects + fd_objects,  # Total false positives
             "tn": 0,  # No true negatives at object level for non-empty lists
             "fn": fn_objects,
         }
-        
+
         return (
             object_level_metrics,
             matched_pairs,
@@ -246,12 +246,12 @@ class StructuredListComparator:
         info: "ComparableField",
     ) -> float:
         """Calculate raw similarity score for structured list.
-        
+
         Args:
             gt_list: Ground truth list
             pred_list: Predicted list
             info: Field comparison info
-            
+
         Returns:
             Raw similarity score between 0.0 and 1.0
         """
@@ -269,69 +269,84 @@ class StructuredListComparator:
         list_field_name: str,
         gt_list: List["StructuredModel"],
         pred_list: List["StructuredModel"],
-                                       matched_pairs: List,
-                                       matched_gt_indices: set,
-                                       matched_pred_indices: set,
+        matched_pairs: List,
+        matched_gt_indices: set,
+        matched_pred_indices: set,
         match_threshold: float,
     ) -> Dict[str, Dict[str, Any]]:
-        """Calculate field-level details with threshold-aware metric population.
-        
-        Process ALL matched pairs for field-level analysis, but populate metrics sections
-        based on object-level similarity threshold:
-        - Above threshold: populate both "overall" and "aggregate" sections
-        - Below threshold: populate only "aggregate" section
-        
+        """Calculate field-level details for nested structure with threshold-gated recursion.
+
+        PHASE 3 FIX: Implements proper threshold-gated recursion as documented.
+        Only generates nested field metrics for object pairs with similarity >= match_threshold.
+        Poor matches and unmatched items are treated as atomic units without field-level analysis.
+
         Args:
             list_field_name: Name of the parent list field
             gt_list: Ground truth list
-            pred_list: Predicted list  
+            pred_list: Predicted list
             matched_pairs: List of (gt_idx, pred_idx, similarity) tuples
             matched_gt_indices: Set of matched GT indices
             matched_pred_indices: Set of matched pred indices
-            match_threshold: Match threshold for determining metric section population
-            
+            match_threshold: Match threshold for threshold-gating (NOW PROPERLY USED!)
+
         Returns:
             Dictionary mapping field names to their metrics
         """
         field_details = {}
-        
+
         if gt_list and isinstance(gt_list[0], StructuredModel):
             model_class = gt_list[0].__class__
-            
-            # Process ALL matched pairs for field-level analysis
-            all_matched_pairs = matched_pairs
-            
-            # Generate field details if we have any matched pairs OR unmatched objects
-            has_matched_pairs = len(all_matched_pairs) > 0
-            has_unmatched = (len(matched_gt_indices) < len(gt_list)) or (len(matched_pred_indices) < len(pred_list))
-            
-            if has_matched_pairs or has_unmatched:
+
+            # PHASE 3 FIX: Only process pairs that meet the match_threshold
+            # Filter to good matches only - poor matches get no recursive analysis
+            good_matched_pairs = [
+                (gt_idx, pred_idx, similarity)
+                for gt_idx, pred_idx, similarity in matched_pairs
+                if similarity >= match_threshold
+            ]
+
+            # Only generate field details if we have good matched pairs OR unmatched objects
+            has_good_matches = len(good_matched_pairs) > 0
+            has_unmatched = (len(matched_gt_indices) < len(gt_list)) or (
+                len(matched_pred_indices) < len(pred_list)
+            )
+
+            if has_good_matches or has_unmatched:
                 for sub_field_name in model_class.model_fields:
                     if sub_field_name == "extra_fields":
                         continue
-                    
+
                     # Check if this field is a List[StructuredModel] that needs hierarchical treatment
                     field_info = model_class.model_fields.get(sub_field_name)
                     is_hierarchical_field = (
                         field_info and model_class._is_structured_field_type(field_info)
                     )
-                    
+
                     if is_hierarchical_field:
-                        # Handle hierarchical fields with threshold-aware metric population
-                        field_details[sub_field_name] = self._handle_hierarchical_field_threshold_aware(
-                            sub_field_name, gt_list, pred_list, all_matched_pairs, 
-                            matched_gt_indices, matched_pred_indices, match_threshold
+                        # Handle hierarchical fields with recursive aggregation - ONLY for good matches
+                        field_details[sub_field_name] = self._handle_hierarchical_field(
+                            sub_field_name,
+                            gt_list,
+                            pred_list,
+                            good_matched_pairs,
+                            matched_gt_indices,
+                            matched_pred_indices,
+                            match_threshold,
                         )
                     else:
-                        # Handle primitive fields with threshold-aware metric population
-                        field_details[sub_field_name] = self._handle_primitive_field_threshold_aware(
-                            sub_field_name, gt_list, pred_list, all_matched_pairs,
-                            matched_gt_indices, matched_pred_indices, match_threshold
+                        # Handle primitive fields with simple aggregation - ONLY for good matches
+                        field_details[sub_field_name] = self._handle_primitive_field(
+                            sub_field_name,
+                            gt_list,
+                            pred_list,
+                            good_matched_pairs,
+                            matched_gt_indices,
+                            matched_pred_indices,
                         )
-        
+
         return field_details
-    
-    def _handle_hierarchical_field_threshold_aware(
+
+    def _handle_hierarchical_field(
         self,
         sub_field_name: str,
         gt_list: List["StructuredModel"],
@@ -339,441 +354,36 @@ class StructuredListComparator:
         matched_pairs: List,
         matched_gt_indices: set,
         matched_pred_indices: set,
-        match_threshold: float) -> Dict[str, Any]:
-        """Handle hierarchical List[StructuredModel] fields with threshold-aware metric population.
-        
-        This method processes ALL matched pairs for field-level analysis but populates
-        metrics sections based on object-level similarity threshold.
+        match_threshold: float,
+    ) -> Dict[str, Any]:
+        """Handle hierarchical List[StructuredModel] fields with TRUE recursive aggregation.
+
+        CRITICAL FIX: Now uses proper recursion to handle arbitrary nesting depth.
         """
-        
-        # Collect pair results for recursive aggregation
-        above_threshold_results = []  # For overall metrics
-        all_pair_results = []  # For aggregate metrics
-        
-        # Process matched pairs with threshold-aware field-level comparison
-        for gt_idx, pred_idx, similarity in matched_pairs:
-            if gt_idx < len(gt_list) and pred_idx < len(pred_list):
-                gt_item = gt_list[gt_idx]
-                pred_item = pred_list[pred_idx]
-                gt_sub_value = getattr(gt_item, sub_field_name, None)
-                pred_sub_value = getattr(pred_item, sub_field_name, None)
-                
-                # Always perform field-level comparison for aggregate metrics
-                pair_result = gt_item._dispatch_field_comparison(
-                    sub_field_name, gt_sub_value, pred_sub_value
-                )
-                
-                # Create aggregate section by summing nested field contributions
-                aggregate_metrics = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
-                
-                # Check if both GT and Pred are null
-                gt_is_null = (gt_sub_value is None or gt_sub_value == [] or gt_sub_value == "")
-                pred_is_null = (pred_sub_value is None or pred_sub_value == [] or pred_sub_value == "")
-                
-                if gt_is_null and pred_is_null:
-                    # Both GT and Pred are null - create nested field entries with TN contributions
-                    nested_field_count = gt_item._get_nested_field_count(sub_field_name)
-                    if nested_field_count > 0:
-                        self._create_nested_field_entries_for_null_case(pair_result, gt_item, sub_field_name)
-                        aggregate_metrics["tn"] = nested_field_count
-                else:
-                    # Sum up contributions from nested fields (for non-null cases)
-                    if "fields" in pair_result:
-                        for nested_field_name, nested_field_result in pair_result["fields"].items():
-                            if "aggregate" in nested_field_result:
-                                # Use aggregate metrics from nested fields
-                                for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                                    aggregate_metrics[metric] += nested_field_result["aggregate"].get(metric, 0)
-                            elif "overall" in nested_field_result:
-                                # Fallback to overall metrics if no aggregate
-                                for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                                    aggregate_metrics[metric] += nested_field_result["overall"].get(metric, 0)
-                
-                # Set the aggregate section
-                pair_result["aggregate"] = aggregate_metrics
-                
-                # Add to all results for aggregate calculation
-                all_pair_results.append(pair_result)
-                
-                # Only add to above-threshold results if similarity meets threshold
-                if self._should_populate_overall_metrics(similarity, match_threshold):
-                    above_threshold_results.append(pair_result)
-        
-        # Handle unmatched objects (contribute to aggregate only)
-        unmatched_results = self._create_unmatched_results_for_hierarchical_field(
-            sub_field_name, gt_list, pred_list, matched_gt_indices, matched_pred_indices
-        )
-        all_pair_results.extend(unmatched_results)
-        
-        # Calculate overall metrics from above-threshold results only
-        overall_aggregated = self._recursive_aggregate_metrics(above_threshold_results)
-        
-        # Calculate aggregate metrics from all results
-        aggregate_aggregated = self._recursive_aggregate_metrics(all_pair_results)
-        
-        # Preserve hierarchical fields structure from the first valid result
-        hierarchical_fields = {}
-        for pair_result in all_pair_results:
-            if "fields" in pair_result and pair_result["fields"]:
-                hierarchical_fields = pair_result["fields"]
-                break
-        
-        # Combine results with proper structure
-        final_result = {
-            "overall": overall_aggregated.get("overall", {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}),
-            "aggregate": aggregate_aggregated.get("aggregate", {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}),
-            "fields": hierarchical_fields
-        }
-        
-        # Merge field-level results with threshold-aware logic
-        if above_threshold_results:
-            overall_fields = overall_aggregated.get("fields", {})
-            for field_name, field_data in overall_fields.items():
-                if field_name not in final_result["fields"]:
-                    final_result["fields"][field_name] = {
-                        "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0},
-                        "aggregate": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
-                    }
-                final_result["fields"][field_name]["overall"] = field_data.get("overall", {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0})
-        
-        if all_pair_results:
-            aggregate_fields = aggregate_aggregated.get("fields", {})
-            for field_name, field_data in aggregate_fields.items():
-                if field_name not in final_result["fields"]:
-                    final_result["fields"][field_name] = {
-                        "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0},
-                        "aggregate": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
-                    }
-                final_result["fields"][field_name]["aggregate"] = field_data.get("aggregate", {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0})
-        
-        # Add derived metrics recursively
-        self._add_derived_metrics_recursively(final_result)
-        
-        # Add metadata from first pair if available
-        if all_pair_results:
-            for key in [
-                "raw_similarity_score",
-                "similarity_score", 
-                "threshold_applied_score",
-                "weight",
-            ]:
-                if key in all_pair_results[0]:
-                    final_result[key] = all_pair_results[0][key]
-        
-        return final_result
 
-    def _create_nested_field_entries_for_null_case(self, pair_result: Dict[str, Any], 
-                                                  gt_item: 'StructuredModel', 
-                                                  sub_field_name: str) -> None:
-        """Create nested field entries for null cases to support metric aggregation."""
-        if "fields" not in pair_result:
-            pair_result["fields"] = {}
-        
-        # Get the nested model class to find field names
-        field_info = gt_item.__class__.model_fields.get(sub_field_name)
-        if field_info:
-            from typing import get_origin, get_args, Union
-            field_type = field_info.annotation if hasattr(field_info, 'annotation') else None
-            if field_type:
-                # Handle Union types (Optional[List[StructuredModel]])
-                if get_origin(field_type) is Union:
-                    # Find the List type in the Union
-                    for arg in get_args(field_type):
-                        if get_origin(arg) is list:
-                            field_type = arg
-                            break
-                
-                # Check if it's a List[StructuredModel]
-                if get_origin(field_type) is list:
-                    args = get_args(field_type)
-                    if args and hasattr(args[0], 'model_fields'):
-                        nested_model_class = args[0]
-                        # Create TN entries for each nested field
-                        for nested_field_name in nested_model_class.model_fields:
-                            if nested_field_name != "extra_fields":
-                                pair_result["fields"][nested_field_name] = {
-                                    "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0},  # Empty for unmatched objects
-                                    "aggregate": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 1, "fn": 0}  # Add to aggregate only
-                                }
-
-    def _create_unmatched_results_for_hierarchical_field(self, sub_field_name: str,
-                                                        gt_list: List["StructuredModel"],
-                                                        pred_list: List["StructuredModel"],
-                                                        matched_gt_indices: set,
-                                                        matched_pred_indices: set) -> List[Dict[str, Any]]:
-        """Create results for unmatched objects in hierarchical fields."""
-        unmatched_results = []
-        
-        # Handle unmatched GT objects (contribute FN for non-null fields, TN for null fields)
-        for gt_idx, gt_item in enumerate(gt_list):
-            if gt_idx not in matched_gt_indices:
-                gt_sub_value = getattr(gt_item, sub_field_name, None)
-                
-                if gt_sub_value is not None and gt_sub_value != [] and gt_sub_value != "":
-                    # Non-null field - count as FN with nested field contributions
-                    nested_field_count = gt_item._get_nested_field_count(sub_field_name)
-                    if nested_field_count > 0 and isinstance(gt_sub_value, list):
-                        # Count the list items and their nested fields
-                        list_length = len(gt_sub_value)
-                        fn_count = list_length * nested_field_count
-                    else:
-                        # Not a hierarchical field or empty list, count as 1
-                        fn_count = 1
-                    
-                    unmatched_result = {
-                        "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0},  # Empty for unmatched objects
-                        "fields": {},
-                        "aggregate": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": fn_count}  # Add to aggregate only
-                    }
-                    unmatched_results.append(unmatched_result)
-                else:
-                    # Null/empty field - count as TN with nested field contributions
-                    nested_field_count = gt_item._get_nested_field_count(sub_field_name)
-                    if nested_field_count > 0:
-                        # For hierarchical fields, count nested fields as TN
-                        tn_count = nested_field_count
-                        
-                        # Create nested field entries so that _collect_all_primitive_metrics can find them
-                        unmatched_result = {
-                            "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0},  # Empty for unmatched objects
-                            "fields": {},
-                            "aggregate": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": tn_count, "fn": 0}  # Add to aggregate only
-                        }
-                        
-                        self._create_nested_field_entries_for_null_case(unmatched_result, gt_item, sub_field_name)
-                    else:
-                        # Not a hierarchical field, count as 1
-                        tn_count = 1
-                        unmatched_result = {
-                            "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0},  # Empty for unmatched objects
-                            "fields": {},
-                            "aggregate": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": tn_count, "fn": 0}  # Add to aggregate only
-                        }
-                    
-                    unmatched_results.append(unmatched_result)
-        
-        # Handle unmatched pred objects (contribute FA for hierarchical fields)
-        for pred_idx, pred_item in enumerate(pred_list):
-            if pred_idx not in matched_pred_indices:
-                pred_sub_value = getattr(pred_item, sub_field_name, None)
-                
-                if pred_sub_value is not None and pred_sub_value != [] and pred_sub_value != "":
-                    # Non-null field - count as FA with nested field contributions
-                    nested_field_count = pred_item._get_nested_field_count(sub_field_name)
-                    if nested_field_count > 0 and isinstance(pred_sub_value, list):
-                        # Count the list items and their nested fields
-                        list_length = len(pred_sub_value)
-                        fa_count = list_length * nested_field_count
-                    else:
-                        # Not a hierarchical field or empty list, count as 1
-                        fa_count = 1
-                    
-                    unmatched_result = {
-                        "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0},  # Empty for unmatched objects
-                        "fields": {},
-                        "aggregate": {"tp": 0, "fa": fa_count, "fd": 0, "fp": fa_count, "tn": 0, "fn": 0}  # Add to aggregate only
-                    }
-                    unmatched_results.append(unmatched_result)
-        
-        return unmatched_results
-
-    def _handle_hierarchical_field(
-        self,
-        sub_field_name: str,
-        gt_list: List["StructuredModel"],
-        pred_list: List["StructuredModel"],
-                                  matched_pairs: List,
-                                  matched_gt_indices: set,
-                                  matched_pred_indices: set,
-                                  match_threshold: float) -> Dict[str, Any]:
-        """Handle hierarchical List[StructuredModel] fields with proper nested field counting.
-        
-        This method properly counts nested field contributions for unmatched objects
-        in hierarchical fields (List[StructuredModel] types).
-        """
-        
         # Collect all pair results for recursive aggregation
         pair_results = []
-        
-        # Process matched pairs with field-level comparison (regardless of object-level similarity)
+
+        # Process good matched pairs only
         for gt_idx, pred_idx, similarity in matched_pairs:
             if gt_idx < len(gt_list) and pred_idx < len(pred_list):
                 gt_item = gt_list[gt_idx]
                 pred_item = pred_list[pred_idx]
-                gt_sub_value = getattr(gt_item, sub_field_name, None)
-                pred_sub_value = getattr(pred_item, sub_field_name, None)
-                
-                # Always use field-level comparison for matched pairs
-                # The object-level similarity doesn't affect field-level metrics
+                gt_sub_value = getattr(gt_item, sub_field_name)
+                pred_sub_value = getattr(pred_item, sub_field_name)
+
+                # Get hierarchical comparison for this pair
                 pair_result = gt_item._dispatch_field_comparison(
                     sub_field_name, gt_sub_value, pred_sub_value
                 )
-                
-                # For hierarchical fields, create aggregate section by summing nested field contributions
-                # The aggregate should include contributions from nested fields
-                aggregate_metrics = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
-                
-                # Check if both GT and Pred are null
-                gt_is_null = (gt_sub_value is None or gt_sub_value == [] or gt_sub_value == "")
-                pred_is_null = (pred_sub_value is None or pred_sub_value == [] or pred_sub_value == "")
-                
-                if gt_is_null and pred_is_null:
-                    # Both GT and Pred are null - create nested field entries with TN contributions
-                    nested_field_count = gt_item._get_nested_field_count(sub_field_name)
-                    if nested_field_count > 0:
-                        # Create nested field entries so that _collect_all_primitive_metrics can find them
-                        if "fields" not in pair_result:
-                            pair_result["fields"] = {}
-                        
-                        # Get the nested model class to find field names
-                        field_info = gt_item.__class__.model_fields.get(sub_field_name)
-                        if field_info:
-                            from typing import get_origin, get_args, Union
-                            field_type = field_info.annotation if hasattr(field_info, 'annotation') else None
-                            if field_type:
-                                # Handle Union types (Optional[List[StructuredModel]])
-                                if get_origin(field_type) is Union:
-                                    # Find the List type in the Union
-                                    for arg in get_args(field_type):
-                                        if get_origin(arg) is list:
-                                            field_type = arg
-                                            break
-                                
-                                # Check if it's a List[StructuredModel]
-                                if get_origin(field_type) is list:
-                                    args = get_args(field_type)
-                                    if args and hasattr(args[0], 'model_fields'):
-                                        nested_model_class = args[0]
-                                        # Create TN entries for each nested field
-                                        for nested_field_name in nested_model_class.model_fields:
-                                            if nested_field_name != "extra_fields":
-                                                pair_result["fields"][nested_field_name] = {
-                                                    "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 1, "fn": 0},
-                                                    "aggregate": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 1, "fn": 0}
-                                                }
-                        
-                        # Set aggregate to sum of nested fields
-                        aggregate_metrics["tn"] = nested_field_count
-                else:
-                    # Sum up contributions from nested fields (for non-null cases)
-                    if "fields" in pair_result:
-                        for nested_field_name, nested_field_result in pair_result["fields"].items():
-                            if "aggregate" in nested_field_result:
-                                # Use aggregate metrics from nested fields
-                                for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                                    aggregate_metrics[metric] += nested_field_result["aggregate"].get(metric, 0)
-                            elif "overall" in nested_field_result:
-                                # Fallback to overall metrics if no aggregate
-                                for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                                    aggregate_metrics[metric] += nested_field_result["overall"].get(metric, 0)
-                
-                # Set the aggregate section
-                pair_result["aggregate"] = aggregate_metrics
-                
                 pair_results.append(pair_result)
-        
-        # Handle unmatched GT objects (contribute FN for non-null fields, TN for null fields)
-        for gt_idx, gt_item in enumerate(gt_list):
-            if gt_idx not in matched_gt_indices:
-                gt_sub_value = getattr(gt_item, sub_field_name, None)
-                
-                if gt_sub_value is not None and gt_sub_value != [] and gt_sub_value != "":
-                    # Non-null field - count as FN with nested field contributions
-                    nested_field_count = gt_item._get_nested_field_count(sub_field_name)
-                    if nested_field_count > 0 and isinstance(gt_sub_value, list):
-                        # Count the list items and their nested fields
-                        list_length = len(gt_sub_value)
-                        fn_count = list_length * nested_field_count
-                    else:
-                        # Not a hierarchical field or empty list, count as 1
-                        fn_count = 1
-                    
-                    unmatched_result = {
-                        "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0},  # Empty for unmatched objects
-                        "fields": {},
-                        "aggregate": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": fn_count}  # Add to aggregate only
-                    }
-                    pair_results.append(unmatched_result)
-                else:
-                    # Null/empty field - count as TN with nested field contributions
-                    nested_field_count = gt_item._get_nested_field_count(sub_field_name)
-                    if nested_field_count > 0:
-                        # For hierarchical fields, count nested fields as TN
-                        tn_count = nested_field_count
-                        
-                        # Create nested field entries so that _collect_all_primitive_metrics can find them
-                        unmatched_result = {
-                            "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0},  # Empty for unmatched objects
-                            "fields": {},
-                            "aggregate": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": tn_count, "fn": 0}  # Add to aggregate only
-                        }
-                        
-                        # Get the nested model class to create field entries
-                        field_info = gt_item.__class__.model_fields.get(sub_field_name)
-                        if field_info:
-                            from typing import get_origin, get_args, Union
-                            field_type = field_info.annotation if hasattr(field_info, 'annotation') else None
-                            if field_type:
-                                # Handle Union types (Optional[List[StructuredModel]])
-                                if get_origin(field_type) is Union:
-                                    # Find the List type in the Union
-                                    for arg in get_args(field_type):
-                                        if get_origin(arg) is list:
-                                            field_type = arg
-                                            break
-                                
-                                # Check if it's a List[StructuredModel]
-                                if get_origin(field_type) is list:
-                                    args = get_args(field_type)
-                                    if args and hasattr(args[0], 'model_fields'):
-                                        nested_model_class = args[0]
-                                        # Create TN entries for each nested field
-                                        for nested_field_name in nested_model_class.model_fields:
-                                            if nested_field_name != "extra_fields":
-                                                unmatched_result["fields"][nested_field_name] = {
-                                                    "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0},  # Empty for unmatched objects
-                                                    "aggregate": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 1, "fn": 0}  # Add to aggregate only
-                                                }
-                    else:
-                        # Not a hierarchical field, count as 1
-                        tn_count = 1
-                        unmatched_result = {
-                            "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0},  # Empty for unmatched objects
-                            "fields": {},
-                            "aggregate": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": tn_count, "fn": 0}  # Add to aggregate only
-                        }
-                    
-                    pair_results.append(unmatched_result)
-        
-        # Handle unmatched pred objects (contribute FA for hierarchical fields)
-        for pred_idx, pred_item in enumerate(pred_list):
-            if pred_idx not in matched_pred_indices:
-                pred_sub_value = getattr(pred_item, sub_field_name, None)
-                
-                if pred_sub_value is not None and pred_sub_value != [] and pred_sub_value != "":
-                    # Non-null field - count as FA with nested field contributions
-                    nested_field_count = pred_item._get_nested_field_count(sub_field_name)
-                    if nested_field_count > 0 and isinstance(pred_sub_value, list):
-                        # Count the list items and their nested fields
-                        list_length = len(pred_sub_value)
-                        fa_count = list_length * nested_field_count
-                    else:
-                        # Not a hierarchical field or empty list, count as 1
-                        fa_count = 1
-                    
-                    unmatched_result = {
-                        "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0},  # Empty for unmatched objects
-                        "fields": {},
-                        "aggregate": {"tp": 0, "fa": fa_count, "fd": 0, "fp": fa_count, "tn": 0, "fn": 0}  # Add to aggregate only
-                    }
-                    pair_results.append(unmatched_result)
-        
+
         # Use recursive aggregation function
         aggregated_result = self._recursive_aggregate_metrics(pair_results)
-        
+
         # Add derived metrics recursively
         self._add_derived_metrics_recursively(aggregated_result)
-        
+
         # Add metadata from first pair if available
         if pair_results:
             for key in [
@@ -784,74 +394,29 @@ class StructuredListComparator:
             ]:
                 if key in pair_results[0]:
                     aggregated_result[key] = pair_results[0][key]
-        
+
         return (
             aggregated_result
             if pair_results
             else {"overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}}
         )
 
-    
-    def _expand_hierarchical_field_metrics(self, pair_result: Dict[str, Any], gt_value: Any, pred_value: Any, field_name: str, gt_item: 'StructuredModel') -> Dict[str, Any]:
-        """Expand hierarchical field metrics to include nested field contributions.
-        
-        When a hierarchical field (like List[StructuredModel]) is classified as FA or TN,
-        we need to add contributions for its nested fields to match the expected behavior.
-        
-        Args:
-            pair_result: The current pair result from field comparison
-            gt_value: Ground truth value for the field
-            pred_value: Predicted value for the field  
-            field_name: Name of the field
-            gt_item: The ground truth item containing the field
-            
-        Returns:
-            Updated pair result with expanded nested field metrics
-        """
-        # Use the helper method to get nested field count
-        nested_field_count = gt_item._get_nested_field_count(field_name)
-        
-        if nested_field_count > 0:
-            # If this is a FA case (GT=None, Pred=non-None), add FA for each nested field
-            if pair_result["overall"].get("fa", 0) > 0:
-                pair_result["overall"]["fa"] += nested_field_count
-                pair_result["overall"]["fp"] += nested_field_count
-                # Also update aggregate section if present
-                if "aggregate" in pair_result:
-                    pair_result["aggregate"]["fa"] += nested_field_count
-                    pair_result["aggregate"]["fp"] += nested_field_count
-            
-            # If this is a TN case (GT=None, Pred=None), add TN for each nested field  
-            elif pair_result["overall"].get("tn", 0) > 0:
-                pair_result["overall"]["tn"] += nested_field_count
-                # Also update aggregate section if present
-                if "aggregate" in pair_result:
-                    pair_result["aggregate"]["tn"] += nested_field_count
-            
-            # If this is a FN case (GT=non-None, Pred=None), add FN for each nested field
-            elif pair_result["overall"].get("fn", 0) > 0:
-                pair_result["overall"]["fn"] += nested_field_count
-                # Also update aggregate section if present
-                if "aggregate" in pair_result:
-                    pair_result["aggregate"]["fn"] += nested_field_count
-        
-        return pair_result
-    
-    def _recursive_aggregate_metrics(self, pair_results: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def _recursive_aggregate_metrics(
+        self, pair_results: List[Dict[str, Any]]
+    ) -> Dict[str, Any]:
         """Recursively aggregate metrics from multiple pair results - handles arbitrary depth."""
         if not pair_results:
             return {
                 "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0},
                 "fields": {},
             }
-        
+
         # Initialize the aggregated result
         aggregated = {
             "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0},
             "fields": {},
-            "aggregate": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0},
         }
-        
+
         for pair_result in pair_results:
             # Aggregate overall metrics
             if "overall" in pair_result:
@@ -859,22 +424,15 @@ class StructuredListComparator:
                     aggregated["overall"][metric] += pair_result["overall"].get(
                         metric, 0
                     )
-            
-            # Aggregate aggregate metrics
-            if "aggregate" in pair_result:
-                for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                    aggregated["aggregate"][metric] += pair_result["aggregate"].get(
-                        metric, 0
-                    )
-            
+
             # Recursively aggregate fields
             if "fields" in pair_result:
                 aggregated["fields"] = self._recursive_merge_fields(
                     aggregated["fields"], pair_result["fields"]
                 )
-        
+
         return aggregated
-    
+
     def _recursive_merge_fields(
         self, target_fields: Dict[str, Any], source_fields: Dict[str, Any]
     ) -> Dict[str, Any]:
@@ -894,14 +452,6 @@ class StructuredListComparator:
                             "fn": 0,
                         },
                         "fields": {},
-                        "aggregate": {
-                            "tp": 0,
-                            "fa": 0,
-                            "fd": 0,
-                            "fp": 0,
-                            "tn": 0,
-                            "fn": 0,
-                        },
                     }
                 else:
                     # Flat structure
@@ -913,22 +463,15 @@ class StructuredListComparator:
                         "tn": 0,
                         "fn": 0,
                     }
-            
+
             # Aggregate metrics based on structure type
             if "overall" in field_metrics:
-                # Hierarchical structure - aggregate overall and aggregate sections, and recurse into fields
+                # Hierarchical structure - aggregate overall and recurse into fields
                 for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
                     target_fields[field_name]["overall"][metric] += field_metrics[
                         "overall"
                     ].get(metric, 0)
-                
-                # Aggregate the aggregate section if present
-                if "aggregate" in field_metrics:
-                    for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                        target_fields[field_name]["aggregate"][metric] += field_metrics[
-                            "aggregate"
-                        ].get(metric, 0)
-                
+
                 # RECURSIVE CALL: Handle nested fields at arbitrary depth
                 if "fields" in field_metrics:
                     if "fields" not in target_fields[field_name]:
@@ -940,25 +483,19 @@ class StructuredListComparator:
                 # Flat structure - aggregate directly
                 for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
                     target_fields[field_name][metric] += field_metrics.get(metric, 0)
-        
+
         return target_fields
-    
+
     def _add_derived_metrics_recursively(self, metrics_dict: Dict[str, Any]) -> None:
         """Recursively add derived metrics to all levels of the structure."""
         metrics_helper = MetricsHelper()
-        
+
         # Add derived metrics to overall if present
         if "overall" in metrics_dict:
             metrics_dict["overall"]["derived"] = (
                 metrics_helper.calculate_derived_metrics(metrics_dict["overall"])
             )
-        
-        # Add derived metrics to aggregate if present
-        if "aggregate" in metrics_dict:
-            metrics_dict["aggregate"]["derived"] = (
-                metrics_helper.calculate_derived_metrics(metrics_dict["aggregate"])
-            )
-        
+
         # Recursively process fields
         if "fields" in metrics_dict:
             for field_name, field_data in metrics_dict["fields"].items():
@@ -967,10 +504,6 @@ class StructuredListComparator:
                     field_data["overall"]["derived"] = (
                         metrics_helper.calculate_derived_metrics(field_data["overall"])
                     )
-                    if "aggregate" in field_data:
-                        field_data["aggregate"]["derived"] = (
-                            metrics_helper.calculate_derived_metrics(field_data["aggregate"])
-                        )
                     self._add_derived_metrics_recursively(field_data)  # RECURSIVE CALL
                 elif "tp" in field_data:
                     # Flat structure with metrics - add derived metrics directly
@@ -979,7 +512,7 @@ class StructuredListComparator:
                     )
                 # If neither "overall" nor "tp" is present, it might be an empty structure - skip
 
-    def _handle_primitive_field_threshold_aware(
+    def _handle_primitive_field(
         self,
         sub_field_name: str,
         gt_list: List["StructuredModel"],
@@ -987,122 +520,52 @@ class StructuredListComparator:
         matched_pairs: List,
         matched_gt_indices: set,
         matched_pred_indices: set,
-        match_threshold: float) -> Dict[str, Any]:
-        """Handle primitive fields with threshold-aware metric population.
-        
-        Process ALL matched pairs for field-level analysis, but populate metrics sections
-        based on object-level similarity threshold.
+    ) -> Dict[str, Any]:
+        """Handle primitive fields with simple aggregation across matched pairs.
+
+        PHASE 3 FIX: Now only processes good matched pairs (similarity >= match_threshold).
         """
-        
-        # Initialize metrics sections
-        overall_metrics = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
-        aggregate_metrics = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
-        
-        # Process matched pairs with threshold-aware metric population
+
+        # Initialize collection for primitive fields across all objects
+        sub_field_metrics = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
+
+        # PHASE 3 FIX: Now only processes pairs that passed the threshold filter
         for gt_idx, pred_idx, similarity in matched_pairs:
             if gt_idx < len(gt_list) and pred_idx < len(pred_list):
                 gt_item = gt_list[gt_idx]
                 pred_item = pred_list[pred_idx]
-                gt_sub_value = getattr(gt_item, sub_field_name, None)
-                pred_sub_value = getattr(pred_item, sub_field_name, None)
-                
-                # Get field-level classification for this pair
-                field_classification = gt_item._classify_field_for_confusion_matrix(sub_field_name, pred_sub_value)
-                
-                # Add to appropriate sections based on threshold
-                self._add_to_metric_sections(field_classification, similarity, match_threshold,
-                                           overall_metrics, aggregate_metrics)
-        
-        # Handle unmatched GT objects (contribute to aggregate only)
+                gt_sub_value = getattr(gt_item, sub_field_name)
+                pred_sub_value = getattr(pred_item, sub_field_name)
+
+                # Regular field - use flat classification
+                field_classification = gt_item._classify_field_for_confusion_matrix(
+                    sub_field_name, pred_sub_value
+                )
+
+                # Aggregate field metrics across all objects
+                for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
+                    sub_field_metrics[metric] += field_classification.get(metric, 0)
+
+        # Handle unmatched objects for primitive fields
+        # Handle unmatched GT objects (contribute FN to field-level)
         for gt_idx, gt_item in enumerate(gt_list):
             if gt_idx not in matched_gt_indices:
-                gt_sub_value = getattr(gt_item, sub_field_name, None)
-                if gt_sub_value is not None and gt_sub_value != "" and gt_sub_value != []:
-                    aggregate_metrics["fn"] += 1
-                else:
-                    # GT field is None/empty - this is a TN (correctly predicted as absent)
-                    aggregate_metrics["tn"] += 1
-        
-        # Handle unmatched pred objects (contribute to aggregate only)
+                gt_sub_value = getattr(gt_item, sub_field_name)
+                if gt_sub_value is not None:  # Only count non-null values as FN
+                    sub_field_metrics["fn"] += 1
+
+        # Handle unmatched pred objects (contribute FA to field-level)
         for pred_idx, pred_item in enumerate(pred_list):
             if pred_idx not in matched_pred_indices:
-                pred_sub_value = getattr(pred_item, sub_field_name, None)
-                if pred_sub_value is not None and pred_sub_value != "" and pred_sub_value != []:
-                    aggregate_metrics["fa"] += 1
-                    aggregate_metrics["fp"] += 1
-        
-        # Return both overall and aggregate sections
-        return {
-            "overall": overall_metrics,
-            "aggregate": aggregate_metrics
-        }
+                pred_sub_value = getattr(pred_item, sub_field_name)
+                if pred_sub_value is not None:  # Only count non-null values as FA
+                    sub_field_metrics["fa"] += 1
+                    sub_field_metrics["fp"] += 1
 
-    def _should_populate_overall_metrics(self, similarity: float, match_threshold: float) -> bool:
-        """Determine if metrics should populate the "overall" section based on threshold.
-        
-        This method implements threshold validation logic to determine whether field-level
-        metrics from a matched pair should be included in the "overall" section.
-        
-        Args:
-            similarity: The similarity score between the matched objects
-            match_threshold: The threshold for considering objects as matches
-            
-        Returns:
-            True if metrics should populate "overall" section, False otherwise
-        """
-        # Handle None or invalid threshold cases - populate both sections for backward compatibility
-        if match_threshold is None:
-            return True
-            
-        # Validate threshold is in valid range
-        if not isinstance(match_threshold, (int, float)) or not (0.0 <= match_threshold <= 1.0):
-            # Invalid threshold - default to populating both sections
-            return True
-            
-        # Use ThresholdHelper for consistent threshold checking with floating point precision
-        from .threshold_helper import ThresholdHelper
-        return ThresholdHelper.is_above_threshold(similarity, match_threshold)
+        # UNIFIED STRUCTURE: Wrap primitive field metrics in 'overall' for consistency
+        # This ensures all fields use the same access pattern: field_data['overall']
+        return {"overall": sub_field_metrics}
 
-    def _should_populate_aggregate_metrics(self, similarity: float, match_threshold: float) -> bool:
-        """Determine if metrics should populate the "aggregate" section.
-        
-        The aggregate section is always populated for universal aggregation functionality,
-        regardless of threshold or similarity score.
-        
-        Args:
-            similarity: The similarity score between the matched objects (unused)
-            match_threshold: The threshold for considering objects as matches (unused)
-            
-        Returns:
-            Always True - aggregate metrics are always populated
-        """
-        return True
-
-    def _add_to_metric_sections(self, field_classification: dict, similarity: float, 
-                               match_threshold: float, overall_metrics: dict, 
-                               aggregate_metrics: dict) -> None:
-        """Add field classification results to appropriate metric sections based on threshold.
-        
-        This method implements the core threshold-aware metric population logic:
-        - Above threshold: populate both "overall" and "aggregate" sections
-        - Below threshold: populate only "aggregate" section
-        
-        Args:
-            field_classification: Dictionary with metric counts (tp, fa, fd, fp, tn, fn)
-            similarity: The similarity score between the matched objects
-            match_threshold: The threshold for considering objects as matches
-            overall_metrics: Dictionary to accumulate overall metrics
-            aggregate_metrics: Dictionary to accumulate aggregate metrics
-        """
-        # Always populate aggregate section for universal aggregation
-        if self._should_populate_aggregate_metrics(similarity, match_threshold):
-            for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                aggregate_metrics[metric] += field_classification.get(metric, 0)
-        
-        # Only populate overall section if above threshold
-        if self._should_populate_overall_metrics(similarity, match_threshold):
-            for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                overall_metrics[metric] += field_classification.get(metric, 0)
 
 # Import needed at bottom to avoid circular imports
 from .structured_model import StructuredModel

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -32,7 +32,7 @@ from .evaluator_format_helper import EvaluatorFormatHelper
 
 class StructuredModel(BaseModel):
     """Base class for models with structured comparison capabilities.
-    
+
     This class extends Pydantic's BaseModel with the ability to compare
     instances using configurable comparison metrics for each field.
     It supports:
@@ -43,31 +43,31 @@ class StructuredModel(BaseModel):
     - Unordered list comparison using Hungarian matching
     - Retention of extra fields not defined in the model
     """
-    
+
     # Default match threshold - can be overridden in subclasses
     match_threshold: ClassVar[float] = 0.7
-    
+
     extra_fields: Dict[str, Any] = Field(default_factory=dict, exclude=True)
-    
+
     model_config = {
         "arbitrary_types_allowed": True,
         "extra": "allow",  # Allow extra fields to be stored in extra_fields
     }
-    
+
     def __init_subclass__(cls, **kwargs):
         """Validate field configurations when a StructuredModel subclass is defined."""
         super().__init_subclass__(**kwargs)
-        
+
         # Validate field configurations using class annotations since model_fields isn't populated yet
         if hasattr(cls, "__annotations__"):
             for field_name, field_type in cls.__annotations__.items():
                 if field_name == "extra_fields":
                     continue
-                
+
                 # Get the field default value if it exists
                 field_default = getattr(cls, field_name, None)
-                
-                # Since ComparableField is now always a function that returns a Field, 
+
+                # Since ComparableField is now always a function that returns a Field,
                 # we need to check if field_default has comparison metadata
                 if hasattr(field_default, "json_schema_extra") and callable(
                     field_default.json_schema_extra
@@ -79,7 +79,7 @@ class StructuredModel(BaseModel):
                         # This field was created with ComparableField function - validate constraints
                         if cls._is_list_of_structured_model_type(field_type):
                             comparison_config = temp_schema["x-comparison"]
-                            
+
                             # Threshold validation - only flag if explicitly set to non-default value
                             threshold = comparison_config.get("threshold", 0.5)
                             if threshold != 0.5:  # Default threshold value
@@ -89,7 +89,7 @@ class StructuredModel(BaseModel):
                                     f"StructuredModel's 'match_threshold' class attribute instead. "
                                     f"Set 'match_threshold = {threshold}' on the list element class."
                                 )
-                            
+
                             # Comparator validation - only flag if explicitly set to non-default type
                             comparator_type = comparison_config.get(
                                 "comparator_type", "LevenshteinComparator"
@@ -102,14 +102,14 @@ class StructuredModel(BaseModel):
                                     f"'comparator' parameter in ComparableField. Object comparison uses each "
                                     f"StructuredModel's individual field comparators instead."
                                 )
-    
+
     @classmethod
     def _is_list_of_structured_model_type(cls, field_type) -> bool:
         """Check if a field type annotation represents List[StructuredModel].
-        
+
         Args:
             field_type: The field type annotation
-            
+
         Returns:
             True if the field is a List[StructuredModel] type
         """
@@ -126,46 +126,46 @@ class StructuredModel(BaseModel):
                     )
                 except (TypeError, AttributeError):
                     return False
-        
+
         # Handle Union types (like Optional[List[StructuredModel]])
         elif origin is Union:
             args = get_args(field_type)
             for arg in args:
                 if cls._is_list_of_structured_model_type(arg):
                     return True
-        
+
         return False
-    
+
     @classmethod
     def from_json(cls, json_data: Dict[str, Any]) -> "StructuredModel":
         """Create a StructuredModel instance from JSON data.
-        
+
         This method handles missing fields gracefully and stores extra fields
         in the extra_fields attribute.
-        
+
         Args:
             json_data: Dictionary containing the JSON data
-            
+
         Returns:
             StructuredModel instance created from the JSON data
         """
         return ConfigurationHelper.from_json(cls, json_data)
-    
+
     @classmethod
     def model_from_json(cls, config: Dict[str, Any]) -> Type["StructuredModel"]:
         """Create a StructuredModel subclass from JSON configuration using Pydantic's create_model().
-        
+
         This method leverages Pydantic's native dynamic model creation capabilities to ensure
         full compatibility with all Pydantic features while adding structured comparison
         functionality through inherited StructuredModel methods.
-        
+
         The generated model inherits all StructuredModel capabilities:
         - compare_with() method for detailed comparisons
-        - Field-level comparison configuration  
+        - Field-level comparison configuration
         - Hungarian algorithm for list matching
         - Confusion matrix generation
         - JSON schema with comparison metadata
-        
+
         Args:
             config: JSON configuration with fields, comparators, and model settings.
                    Required keys:
@@ -173,7 +173,7 @@ class StructuredModel(BaseModel):
                    Optional keys:
                    - model_name: Name for the generated class (default: "DynamicModel")
                    - match_threshold: Overall matching threshold (default: 0.7)
-                   
+
                    Field configuration format:
                    {
                        "type": "str|int|float|bool|List[str]|etc.",  # Required
@@ -186,14 +186,14 @@ class StructuredModel(BaseModel):
                        "alias": "field_alias",  # Optional
                        "examples": ["example1", "example2"]  # Optional
                    }
-                   
+
         Returns:
             A fully functional StructuredModel subclass created with create_model()
-            
+
         Raises:
             ValueError: If configuration is invalid or contains unsupported types/comparators
             KeyError: If required configuration keys are missing
-            
+
         Examples:
             >>> config = {
             ...     "model_name": "Product",
@@ -201,7 +201,7 @@ class StructuredModel(BaseModel):
             ...     "fields": {
             ...         "name": {
             ...             "type": "str",
-            ...             "comparator": "LevenshteinComparator", 
+            ...             "comparator": "LevenshteinComparator",
             ...             "threshold": 0.8,
             ...             "weight": 2.0,
             ...             "required": True
@@ -225,44 +225,44 @@ class StructuredModel(BaseModel):
         """
         from pydantic import create_model
         from .field_converter import convert_fields_config, validate_fields_config
-        
+
         # Validate configuration structure
         if not isinstance(config, dict):
             raise ValueError("Configuration must be a dictionary")
-        
+
         if "fields" not in config:
             raise ValueError("Configuration must contain 'fields' key")
-        
+
         fields_config = config["fields"]
         if not isinstance(fields_config, dict) or len(fields_config) == 0:
             raise ValueError("'fields' must be a non-empty dictionary")
-        
+
         # Validate all field configurations before proceeding (including nested schema validation)
         try:
             from .field_converter import get_global_converter
 
             converter = get_global_converter()
-            
+
             # First validate basic field configurations
             validate_fields_config(fields_config)
-            
+
             # Then validate nested schema rules
             for field_name, field_config in fields_config.items():
                 converter.validate_nested_field_schema(field_name, field_config)
-                
+
         except ValueError as e:
             raise ValueError(f"Invalid field configuration: {e}")
-        
+
         # Extract model configuration
         model_name = config.get("model_name", "DynamicModel")
         match_threshold = config.get("match_threshold", 0.7)
-        
+
         # Validate model name
         if not isinstance(model_name, str) or not model_name.isidentifier():
             raise ValueError(
                 f"model_name must be a valid Python identifier, got: {model_name}"
             )
-        
+
         # Validate match threshold
         if not isinstance(match_threshold, (int, float)) or not (
             0.0 <= match_threshold <= 1.0
@@ -270,13 +270,13 @@ class StructuredModel(BaseModel):
             raise ValueError(
                 f"match_threshold must be a number between 0.0 and 1.0, got: {match_threshold}"
             )
-        
+
         # Convert field configurations to Pydantic field definitions
         try:
             field_definitions = convert_fields_config(fields_config)
         except ValueError as e:
             raise ValueError(f"Error converting field configurations: {e}")
-        
+
         # Create the dynamic model extending StructuredModel
         try:
             DynamicClass = create_model(
@@ -286,34 +286,34 @@ class StructuredModel(BaseModel):
             )
         except Exception as e:
             raise ValueError(f"Error creating dynamic model: {e}")
-        
+
         # Set class-level attributes
         DynamicClass.match_threshold = match_threshold
-        
+
         # Add configuration metadata for debugging/introspection
         DynamicClass._model_config = config
-        
+
         return DynamicClass
-    
+
     @classmethod
     def _is_structured_field_type(cls, field_info) -> bool:
         """Check if a field represents a structured type that needs special handling.
-        
+
         Args:
             field_info: Pydantic field info object
-            
+
         Returns:
             True if the field is a List[StructuredModel] or StructuredModel type
         """
         return ConfigurationHelper.is_structured_field_type(field_info)
-    
+
     @classmethod
     def _get_comparison_info(cls, field_name: str) -> ComparableField:
         """Extract comparison info from a field.
-        
+
         Args:
             field_name: Name of the field to get comparison info for
-            
+
         Returns:
             ComparableField object with comparison configuration
         """
@@ -322,19 +322,29 @@ class StructuredModel(BaseModel):
     # Remove legacy ComparableField handling since ComparableField is now always a function
     # that returns proper Pydantic Fields
     pass
-    
+
     # No special __init__ needed since ComparableField is now always a function
     # that returns proper Pydantic Fields
     pass
-    
 
+    @classmethod
+    def _is_aggregate_field(cls, field_name: str) -> bool:
+        """Check if field is marked for confusion matrix aggregation.
+
+        Args:
+            field_name: Name of the field to check
+
+        Returns:
+            True if the field is marked for aggregation, False otherwise
+        """
+        return ConfigurationHelper.is_aggregate_field(cls, field_name)
 
     def _is_truly_null(self, val: Any) -> bool:
         """Check if a value is truly null (None).
-        
+
         Args:
             val: Value to check
-            
+
         Returns:
             True if the value is None, False otherwise
         """
@@ -342,14 +352,14 @@ class StructuredModel(BaseModel):
 
     def _should_use_hierarchical_structure(self, val: Any, field_name: str) -> bool:
         """Check if a list value should maintain hierarchical structure.
-        
+
         For lists, we need to check if they should maintain hierarchical structure
         based on their field type configuration.
-        
+
         Args:
             val: Value to check (typically a list)
             field_name: Name of the field being evaluated
-            
+
         Returns:
             True if the value should use hierarchical structure, False otherwise
         """
@@ -361,27 +371,24 @@ class StructuredModel(BaseModel):
         return False
 
     def _is_effectively_null_for_lists(self, val: Any) -> bool:
-        """Check if a list value is effectively null (None, empty list, or empty string).
-        
-        For list fields, empty strings should be treated as equivalent to empty lists
-        since both represent the absence of data.
-        
+        """Check if a list value is effectively null (None or empty list).
+
         Args:
             val: Value to check
-            
+
         Returns:
-            True if the value is None, an empty list, or an empty string, False otherwise
+            True if the value is None or an empty list, False otherwise
         """
-        return val is None or (isinstance(val, list) and len(val) == 0) or (isinstance(val, str) and val == "")
+        return val is None or (isinstance(val, list) and len(val) == 0)
 
     def _is_effectively_null_for_primitives(self, val: Any) -> bool:
         """Check if a primitive value is effectively null.
-        
+
         Treats empty strings and None as equivalent for string fields.
-        
+
         Args:
             val: Value to check
-            
+
         Returns:
             True if the value is None or an empty string, False otherwise
         """
@@ -389,17 +396,17 @@ class StructuredModel(BaseModel):
 
     def _is_list_field(self, field_name: str) -> bool:
         """Check if a field is ANY list type.
-        
+
         Args:
             field_name: Name of the field to check
-            
+
         Returns:
             True if the field is a list type (List[str], List[StructuredModel], etc.)
         """
         field_info = self.__class__.model_fields.get(field_name)
         if not field_info:
             return False
-            
+
         field_type = field_info.annotation
         # Handle Optional types and direct List types
         if hasattr(field_type, "__origin__"):
@@ -419,18 +426,18 @@ class StructuredModel(BaseModel):
         self, gt_val: Any, pred_val: Any, weight: float
     ) -> dict:
         """Handle list field comparison using match statements.
-        
+
         Args:
             gt_val: Ground truth list value
             pred_val: Predicted list value
             weight: Field weight for scoring
-            
+
         Returns:
             Comparison result dictionary
         """
         gt_effectively_null = self._is_effectively_null_for_lists(gt_val)
         pred_effectively_null = self._is_effectively_null_for_lists(pred_val)
-        
+
         match (gt_effectively_null, pred_effectively_null):
             case (True, True):
                 # Both None or empty lists → True Negative
@@ -488,64 +495,17 @@ class StructuredModel(BaseModel):
                 # Both non-null and non-empty, return None to continue processing
                 return None
 
-    def _get_nested_field_count(self, field_name: str) -> int:
-        """Get the count of nested fields for List[StructuredModel] types.
-        
-        Args:
-            field_name: Name of the field to analyze
-            
-        Returns:
-            Number of nested fields in the StructuredModel, or 0 if not a hierarchical field
-        """
-        if not field_name:
-            return 0
-            
-        field_info = self.__class__.model_fields.get(field_name)
-        if not field_info or not self._is_structured_field_type(field_info):
-            return 0
-            
-        from typing import get_origin, get_args, Union
-        field_type = field_info.annotation if hasattr(field_info, 'annotation') else None
-        if not field_type:
-            return 0
-            
-        # Handle Union types (Optional[List[StructuredModel]])
-        if get_origin(field_type) is Union:
-            # Find the List type in the Union
-            for arg in get_args(field_type):
-                if get_origin(arg) is list:
-                    field_type = arg
-                    break
-        
-        # Check if it's a List[StructuredModel]
-        if get_origin(field_type) is list:
-            args = get_args(field_type)
-            if args and hasattr(args[0], 'model_fields'):
-                nested_model_class = args[0]
-                # Count non-extra_fields
-                return len([f for f in nested_model_class.model_fields.keys() if f != 'extra_fields'])
-        
-        return 0
-
-    def _create_true_negative_result(self, weight: float, field_name: str = None) -> dict:
+    def _create_true_negative_result(self, weight: float) -> dict:
         """Create a true negative result.
-        
+
         Args:
             weight: Field weight for scoring
-            field_name: Name of the field (for hierarchical field detection)
-            
+
         Returns:
             True negative result dictionary
         """
-        tn_count = 1
-        
-        # For hierarchical fields, count nested field contributions
-        nested_field_count = self._get_nested_field_count(field_name)
-        if nested_field_count > 0:
-            tn_count += nested_field_count  # Both GT and Pred are None, so count nested fields as TN
-        
         return {
-            "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": tn_count, "fn": 0},
+            "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 1, "fn": 0},
             "fields": {},
             "raw_similarity_score": 1.0,
             "similarity_score": 1.0,
@@ -553,31 +513,17 @@ class StructuredModel(BaseModel):
             "weight": weight,
         }
 
-    def _create_false_alarm_result(self, weight: float, field_name: str = None, pred_val: Any = None) -> dict:
+    def _create_false_alarm_result(self, weight: float) -> dict:
         """Create a false alarm result.
-        
+
         Args:
             weight: Field weight for scoring
-            field_name: Name of the field (for hierarchical field detection)
-            pred_val: Predicted value (for counting nested fields)
-            
+
         Returns:
             False alarm result dictionary
         """
-        fa_count = 1
-        fp_count = 1
-        
-        # For hierarchical fields, count nested field contributions
-        nested_field_count = self._get_nested_field_count(field_name)
-        if nested_field_count > 0 and pred_val is not None:
-            # Count the list items and their nested fields
-            if isinstance(pred_val, list):
-                list_length = len(pred_val)
-                fa_count += list_length * nested_field_count
-                fp_count += list_length * nested_field_count
-        
         return {
-            "overall": {"tp": 0, "fa": fa_count, "fd": 0, "fp": fp_count, "tn": 0, "fn": 0},
+            "overall": {"tp": 0, "fa": 1, "fd": 0, "fp": 1, "tn": 0, "fn": 0},
             "fields": {},
             "raw_similarity_score": 0.0,
             "similarity_score": 0.0,
@@ -585,29 +531,17 @@ class StructuredModel(BaseModel):
             "weight": weight,
         }
 
-    def _create_false_negative_result(self, weight: float, field_name: str = None, gt_val: Any = None) -> dict:
+    def _create_false_negative_result(self, weight: float) -> dict:
         """Create a false negative result.
-        
+
         Args:
             weight: Field weight for scoring
-            field_name: Name of the field (for hierarchical field detection)
-            gt_val: Ground truth value (for counting nested fields)
-            
+
         Returns:
             False negative result dictionary
         """
-        fn_count = 1
-        
-        # For hierarchical fields, count nested field contributions
-        nested_field_count = self._get_nested_field_count(field_name)
-        if nested_field_count > 0 and gt_val is not None:
-            # Count the list items and their nested fields
-            if isinstance(gt_val, list):
-                list_length = len(gt_val)
-                fn_count += list_length * nested_field_count
-        
         return {
-            "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": fn_count},
+            "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 1},
             "fields": {},
             "raw_similarity_score": 0.0,
             "similarity_score": 0.0,
@@ -622,19 +556,19 @@ class StructuredModel(BaseModel):
         weight: float,
     ) -> dict:
         """Handle empty list cases with beautiful match statements.
-        
+
         Args:
             gt_list: Ground truth list (may be None)
-            pred_list: Predicted list (may be None) 
+            pred_list: Predicted list (may be None)
             weight: Field weight for scoring
-            
+
         Returns:
             Result dictionary if early exit needed, None if should continue processing
         """
         # Normalize None to empty lists for consistent handling
         gt_len = len(gt_list or [])
         pred_len = len(pred_list or [])
-        
+
         match (gt_len, pred_len):
             case (0, 0):
                 # Both empty lists → True Negative
@@ -691,12 +625,12 @@ class StructuredModel(BaseModel):
         match_threshold: float,
     ) -> tuple:
         """Calculate object-level metrics using Hungarian matching.
-        
+
         Args:
             gt_list: Ground truth list
             pred_list: Predicted list
             match_threshold: Threshold for considering objects as matches
-            
+
         Returns:
             Tuple of (object_metrics_dict, matched_pairs, matched_gt_indices, matched_pred_indices)
         """
@@ -704,7 +638,7 @@ class StructuredModel(BaseModel):
         hungarian_helper = HungarianHelper()
         hungarian_info = hungarian_helper.get_complete_matching_info(gt_list, pred_list)
         matched_pairs = hungarian_info["matched_pairs"]
-        
+
         # Count OBJECTS, not individual fields
         tp_objects = 0  # Objects with similarity >= match_threshold
         fd_objects = 0  # Objects with similarity < match_threshold
@@ -713,7 +647,7 @@ class StructuredModel(BaseModel):
                 tp_objects += 1
             else:
                 fd_objects += 1
-        
+
         # Count unmatched objects
         matched_gt_indices = {idx for idx, _, _ in matched_pairs}
         matched_pred_indices = {idx for _, idx, _ in matched_pairs}
@@ -721,17 +655,17 @@ class StructuredModel(BaseModel):
         fa_objects = len(pred_list) - len(
             matched_pred_indices
         )  # Unmatched pred objects
-        
+
         # Build list-level metrics counting OBJECTS (not fields)
         object_level_metrics = {
             "tp": tp_objects,
-            "fa": fa_objects,  
+            "fa": fa_objects,
             "fd": fd_objects,
             "fp": fa_objects + fd_objects,  # Total false positives
             "tn": 0,  # No true negatives at object level for non-empty lists
             "fn": fn_objects,
         }
-        
+
         return (
             object_level_metrics,
             matched_pairs,
@@ -746,12 +680,12 @@ class StructuredModel(BaseModel):
         info: "ComparableField",
     ) -> float:
         """Calculate raw similarity score for structured list.
-        
+
         Args:
             gt_list: Ground truth list
             pred_list: Predicted list
             info: Field comparison info
-            
+
         Returns:
             Raw similarity score between 0.0 and 1.0
         """
@@ -764,7 +698,7 @@ class StructuredModel(BaseModel):
             return 0.0
 
     # Necessary/sufficient field methods removed - no longer used
-    
+
     def _compare_unordered_lists(
         self,
         list1: List[Any],
@@ -773,13 +707,13 @@ class StructuredModel(BaseModel):
         threshold: float,
     ) -> Dict[str, Any]:
         """Compare two lists as unordered collections using Hungarian matching.
-        
+
         Args:
             list1: First list
             list2: Second list
             comparator: Comparator to use for item comparison
             threshold: Minimum score to consider a match
-            
+
         Returns:
             Dictionary with confusion matrix metrics including:
             - tp: True positives (matches >= threshold)
@@ -795,17 +729,17 @@ class StructuredModel(BaseModel):
 
     def compare_field(self, field_name: str, other_value: Any) -> float:
         """Compare a single field with a value using the configured comparator.
-        
+
         Args:
             field_name: Name of the field to compare
             other_value: Value to compare with
-            
+
         Returns:
             Similarity score between 0.0 and 1.0
         """
         # Get our field value
         my_value = getattr(self, field_name)
-        
+
         # If both values are StructuredModel instances, use recursive compare_with
         if isinstance(my_value, StructuredModel) and isinstance(
             other_value, StructuredModel
@@ -813,9 +747,9 @@ class StructuredModel(BaseModel):
             # Use compare_with for rich comparison
             comparison_result = my_value.compare_with(
                 other_value,
-                                                    include_confusion_matrix=False,
-                                                    document_non_matches=False,
-                                                    evaluator_format=False,
+                include_confusion_matrix=False,
+                document_non_matches=False,
+                evaluator_format=False,
                 recall_with_fd=False,
             )
             # Apply field-level threshold if configured
@@ -826,40 +760,40 @@ class StructuredModel(BaseModel):
                 if raw_score >= info.threshold or not info.clip_under_threshold
                 else 0.0
             )
-        
+
         # CRITICAL FIX: For lists, don't clip under threshold for partial matches
         if isinstance(my_value, list) and isinstance(other_value, list):
             # Get field info
             info = self._get_comparison_info(field_name)
-            
+
             # Use the raw comparison result without threshold clipping for lists
             result = ComparisonHelper.compare_unordered_lists(
                 my_value, other_value, info.comparator, info.threshold
             )
-            
+
             # Return the overall score directly (don't clip based on threshold for lists)
             return result["overall_score"]
-        
+
         # For other fields, use existing logic
         return ComparisonHelper.compare_field_with_threshold(
             self, field_name, other_value
         )
-    
+
     def compare_field_raw(self, field_name: str, other_value: Any) -> float:
         """Compare a single field with a value WITHOUT applying thresholds.
-        
+
         This version is used by the compare method to get raw similarity scores.
-        
+
         Args:
             field_name: Name of the field to compare
             other_value: Value to compare with
-            
+
         Returns:
             Raw similarity score between 0.0 and 1.0 without threshold filtering
         """
         # Get our field value
         my_value = getattr(self, field_name)
-        
+
         # If both values are StructuredModel instances, use recursive compare_with
         if isinstance(my_value, StructuredModel) and isinstance(
             other_value, StructuredModel
@@ -867,25 +801,25 @@ class StructuredModel(BaseModel):
             # Use compare_with for rich comparison, but extract the raw score
             comparison_result = my_value.compare_with(
                 other_value,
-                                                    include_confusion_matrix=False,
-                                                    document_non_matches=False,
-                                                    evaluator_format=False,
+                include_confusion_matrix=False,
+                document_non_matches=False,
+                evaluator_format=False,
                 recall_with_fd=False,
             )
             return comparison_result["overall_score"]
-        
+
         # For non-StructuredModel fields, use existing logic
         return ComparisonHelper.compare_field_raw(self, field_name, other_value)
-    
+
     def compare_recursive(self, other: "StructuredModel") -> dict:
         """The ONE clean recursive function that handles everything.
-        
+
         Enhanced to capture BOTH confusion matrix metrics AND similarity scores
         in a single traversal to eliminate double traversal inefficiency.
-        
+
         Args:
             other: Another instance of the same model to compare with
-            
+
         Returns:
             Dictionary with clean hierarchical structure:
             - overall: TP, FP, TN, FN, FD, FA counts + similarity_score + all_fields_matched
@@ -906,48 +840,48 @@ class StructuredModel(BaseModel):
             "fields": {},
             "non_matches": [],
         }
-        
+
         # Score percolation variables
         total_score = 0.0
         total_weight = 0.0
         threshold_matched_fields = set()
-        
+
         for field_name in self.__class__.model_fields:
             if field_name == "extra_fields":
                 continue
-                
+
             gt_val = getattr(self, field_name)
             pred_val = getattr(other, field_name, None)
-            
+
             # Enhanced dispatch returns both metrics AND scores
             field_result = self._dispatch_field_comparison(field_name, gt_val, pred_val)
-            
+
             result["fields"][field_name] = field_result
-            
+
             # Simple aggregation to overall metrics
             self._aggregate_to_overall(field_result, result["overall"])
-            
+
             # Score percolation - aggregate scores upward
             if "similarity_score" in field_result and "weight" in field_result:
                 weight = field_result["weight"]
                 threshold_applied_score = field_result["threshold_applied_score"]
                 total_score += threshold_applied_score * weight
                 total_weight += weight
-                
+
                 # Track threshold-matched fields
                 info = self._get_comparison_info(field_name)
                 if field_result["raw_similarity_score"] >= info.threshold:
                     threshold_matched_fields.add(field_name)
-        
+
         # CRITICAL FIX: Handle hallucinated fields (extra fields) as False Alarms
         extra_fields_fa = self._count_extra_fields_as_false_alarms(other)
         result["overall"]["fa"] += extra_fields_fa
         result["overall"]["fp"] += extra_fields_fa
-        
+
         # Calculate overall similarity score from percolated scores
         if total_weight > 0:
             result["overall"]["similarity_score"] = total_score / total_weight
-        
+
         # Determine all_fields_matched
         model_fields_for_comparison = set(self.__class__.model_fields.keys()) - {
             "extra_fields"
@@ -955,22 +889,22 @@ class StructuredModel(BaseModel):
         result["overall"]["all_fields_matched"] = len(threshold_matched_fields) == len(
             model_fields_for_comparison
         )
-        
+
         return result
-    
+
     def _dispatch_field_comparison(
         self, field_name: str, gt_val: Any, pred_val: Any
     ) -> dict:
         """Enhanced case-based dispatch using match statements for clean logic flow."""
-        
+
         # Get field configuration for scoring
         info = self._get_comparison_info(field_name)
         weight = info.weight
         threshold = info.threshold
-        
+
         # Check if this field is ANY list type (including Optional[List[str]], Optional[List[StructuredModel]], etc.)
         is_list_field = self._is_list_field(field_name)
-        
+
         # Get null states and hierarchical needs
         gt_is_null = self._is_truly_null(gt_val)
         pred_is_null = self._is_truly_null(pred_val)
@@ -978,32 +912,32 @@ class StructuredModel(BaseModel):
         pred_needs_hierarchy = self._should_use_hierarchical_structure(
             pred_val, field_name
         )
-        
+
         # Handle list fields with match statements
         if is_list_field:
             list_result = self._handle_list_field_dispatch(gt_val, pred_val, weight)
             if list_result is not None:
                 return list_result
             # If None returned, continue to regular type-based dispatch
-        
+
         # Handle non-hierarchical primitive null cases with match statements
         if not (gt_needs_hierarchy or pred_needs_hierarchy):
             gt_effectively_null_prim = self._is_effectively_null_for_primitives(gt_val)
             pred_effectively_null_prim = self._is_effectively_null_for_primitives(
                 pred_val
             )
-            
+
             match (gt_effectively_null_prim, pred_effectively_null_prim):
                 case (True, True):
-                    return self._create_true_negative_result(weight, field_name)
+                    return self._create_true_negative_result(weight)
                 case (True, False):
-                    return self._create_false_alarm_result(weight, field_name, pred_val)
+                    return self._create_false_alarm_result(weight)
                 case (False, True):
-                    return self._create_false_negative_result(weight, field_name, gt_val)
+                    return self._create_false_negative_result(weight)
                 case _:
                     # Both non-null, continue to type-based dispatch
                     pass
-        
+
         # Type-based dispatch
         if isinstance(gt_val, (str, int, float)) and isinstance(
             pred_val, (str, int, float)
@@ -1032,7 +966,7 @@ class StructuredModel(BaseModel):
                     gt_val, pred_val, field_name
                 )
         elif isinstance(pred_val, list) and len(pred_val) == 0:
-            # Handle empty pred list - check if it should be structured  
+            # Handle empty pred list - check if it should be structured
             field_info = self.__class__.model_fields.get(field_name)
             if field_info and self._is_structured_field_type(field_info):
                 # Empty structured list - should still return hierarchical structure
@@ -1046,27 +980,27 @@ class StructuredModel(BaseModel):
         elif isinstance(gt_val, StructuredModel) and isinstance(
             pred_val, StructuredModel
         ):
-            # CRITICAL FIX: For StructuredModel fields, object-level metrics should be based on 
+            # CRITICAL FIX: For StructuredModel fields, object-level metrics should be based on
             # object similarity, not rollup of nested field metrics
-            
+
             # Get object-level similarity score
             raw_score = gt_val.compare(pred_val)  # Overall object similarity
-            
+
             # Apply object-level binary classification based on threshold
             if raw_score >= threshold:
                 # Object matches threshold -> True Positive
                 object_metrics = {"tp": 1, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
                 threshold_applied_score = raw_score
             else:
-                # Object below threshold -> False Discovery  
+                # Object below threshold -> False Discovery
                 object_metrics = {"tp": 0, "fa": 0, "fd": 1, "fp": 1, "tn": 0, "fn": 0}
                 threshold_applied_score = (
                     0.0 if info.clip_under_threshold else raw_score
                 )
-            
+
             # Still generate nested field details for debugging, but don't roll them up
             nested_details = gt_val.compare_recursive(pred_val)["fields"]
-            
+
             # Return structure with object-level metrics and nested field details kept separate
             return {
                 "overall": {
@@ -1076,7 +1010,7 @@ class StructuredModel(BaseModel):
                 },
                 "fields": nested_details,  # Nested details available for debugging
                 "raw_similarity_score": raw_score,
-                "similarity_score": raw_score, 
+                "similarity_score": raw_score,
                 "threshold_applied_score": threshold_applied_score,
                 "weight": weight,
                 "non_matches": [],  # Add empty non_matches for consistency
@@ -1091,7 +1025,7 @@ class StructuredModel(BaseModel):
                 "threshold_applied_score": 0.0,
                 "weight": weight,
             }
-    
+
     def _compare_primitive_with_scores(
         self, gt_val: Any, pred_val: Any, field_name: str
     ) -> dict:
@@ -1100,7 +1034,7 @@ class StructuredModel(BaseModel):
         raw_similarity = info.comparator.compare(gt_val, pred_val)
         weight = info.weight
         threshold = info.threshold
-        
+
         # For binary classification metrics, always use threshold
         if raw_similarity >= threshold:
             metrics = {"tp": 1, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
@@ -1111,7 +1045,7 @@ class StructuredModel(BaseModel):
             threshold_applied_score = (
                 0.0 if info.clip_under_threshold else raw_similarity
             )
-        
+
         # UNIFIED STRUCTURE: Always use 'overall' for metrics
         # 'fields' key omitted for primitive leaf nodes (semantic meaning: not a parent container)
         return {
@@ -1121,32 +1055,32 @@ class StructuredModel(BaseModel):
             "threshold_applied_score": threshold_applied_score,
             "weight": weight,
         }
-    
+
     def _compare_primitive_list_with_scores(
         self, gt_list: List[Any], pred_list: List[Any], field_name: str
     ) -> dict:
         """Enhanced primitive list comparison that returns both metrics AND scores with hierarchical structure.
-        
+
         DESIGN DECISION: Universal Hierarchical Structure
         ===============================================
-        This method returns a hierarchical structure {"overall": {...}, "fields": {...}} even for 
+        This method returns a hierarchical structure {"overall": {...}, "fields": {...}} even for
         primitive lists (List[str], List[int], etc.) to maintain API consistency across all field types.
-        
+
         Why this approach:
         - CONSISTENCY: All list fields use the same access pattern: cm["fields"][name]["overall"]
         - TEST COMPATIBILITY: Multiple test files expect this pattern for both primitive and structured lists
         - PREDICTABLE API: Consumers don't need to check field type before accessing metrics
-        
+
         Trade-offs:
         - Creates vestigial "fields": {} objects for primitive lists that will never be populated
         - Slightly more verbose structure than necessary for leaf nodes
         - Architecturally less pure than type-based structure (primitives flat, structured hierarchical)
-        
+
         Alternative considered but rejected:
         - Type-based structure where List[primitive] → flat, List[StructuredModel] → hierarchical
         - Would require updating multiple test files and consumer code to handle mixed access patterns
         - More architecturally pure but breaks backward compatibility
-        
+
         Future consideration: If we ever refactor the entire confusion matrix API, we could move to
         type-based structure where the presence of "fields" key indicates structured vs primitive.
         """
@@ -1154,14 +1088,14 @@ class StructuredModel(BaseModel):
         info = self.__class__._get_comparison_info(field_name)
         weight = info.weight
         threshold = info.threshold
-        
+
         # CRITICAL FIX: Handle None values before checking length
         # Convert None to empty list for consistent handling
         if gt_list is None:
             gt_list = []
         if pred_list is None:
             pred_list = []
-        
+
         # Handle empty/null list cases first - FIXED: Empty lists should be TN=1
         if len(gt_list) == 0 and len(pred_list) == 0:
             # Both empty lists should be TN=1
@@ -1191,7 +1125,7 @@ class StructuredModel(BaseModel):
                 "weight": weight,
             }
         elif len(pred_list) == 0:
-            # GT has items, pred empty → False Negatives  
+            # GT has items, pred empty → False Negatives
             return {
                 "overall": {
                     "tp": 0,
@@ -1207,26 +1141,26 @@ class StructuredModel(BaseModel):
                 "threshold_applied_score": 0.0,
                 "weight": weight,
             }
-        
+
         # For primitive lists, use the comparison logic from _compare_unordered_lists
         # which properly handles the threshold-based matching
         comparator = info.comparator
         match_result = self._compare_unordered_lists(
             gt_list, pred_list, comparator, threshold
         )
-        
+
         # Extract the counts from the match result
         tp = match_result.get("tp", 0)
-        fd = match_result.get("fd", 0) 
+        fd = match_result.get("fd", 0)
         fa = match_result.get("fa", 0)
         fn = match_result.get("fn", 0)
-        
+
         # Use the overall_score from the match result for raw similarity
         raw_similarity = match_result.get("overall_score", 0.0)
-        
+
         # CRITICAL FIX: For lists, we NEVER clip under threshold - partial matches are important
         threshold_applied_score = raw_similarity  # Always use raw score for lists
-        
+
         # Return hierarchical structure expected by tests
         return {
             "overall": {"tp": tp, "fa": fa, "fd": fd, "fp": fa + fd, "tn": 0, "fn": fn},
@@ -1236,7 +1170,7 @@ class StructuredModel(BaseModel):
             "threshold_applied_score": threshold_applied_score,
             "weight": weight,
         }
-    
+
     def _compare_struct_list_with_scores(
         self,
         gt_list: List["StructuredModel"],
@@ -1244,48 +1178,48 @@ class StructuredModel(BaseModel):
         field_name: str,
     ) -> dict:
         """Enhanced structural list comparison that returns both metrics AND scores.
-        
+
         PHASE 2: Delegates to StructuredListComparator while maintaining identical behavior.
         """
         # Import here to avoid circular imports
         from .structured_list_comparator import StructuredListComparator
-        
+
         # Create comparator and delegate
         comparator = StructuredListComparator(self)
         return comparator.compare_struct_list_with_scores(
             gt_list, pred_list, field_name
         )
-    
+
     def _count_extra_fields_as_false_alarms(self, other: "StructuredModel") -> int:
         """Count hallucinated fields (extra fields) in the prediction as False Alarms.
-        
+
         Args:
             other: The predicted StructuredModel instance to check for extra fields
-            
+
         Returns:
             Number of hallucinated fields that should count as False Alarms
         """
         fa_count = 0
-        
+
         # Check if the other model has extra fields (hallucinated content)
         if hasattr(other, "__pydantic_extra__"):
             # Count each extra field as one False Alarm
             fa_count += len(other.__pydantic_extra__)
-        
+
         # Also recursively check nested StructuredModel objects for extra fields
         for field_name in self.__class__.model_fields:
             if field_name == "extra_fields":
                 continue
-                
+
             gt_val = getattr(self, field_name, None)
             pred_val = getattr(other, field_name, None)
-            
+
             # Check nested StructuredModel objects
             if isinstance(gt_val, StructuredModel) and isinstance(
                 pred_val, StructuredModel
             ):
                 fa_count += gt_val._count_extra_fields_as_false_alarms(pred_val)
-            
+
             # Check lists of StructuredModel objects
             elif (
                 isinstance(gt_val, list)
@@ -1296,14 +1230,14 @@ class StructuredModel(BaseModel):
                 and isinstance(pred_val[0], StructuredModel)
             ):
                 # For lists, we need to match them up properly using Hungarian matching - OPTIMIZED: Single call gets all info
-                # to avoid double-counting in cases where the list comparison already 
+                # to avoid double-counting in cases where the list comparison already
                 # handles unmatched items as FA. For now, let's recursively check each item.
                 hungarian_helper = HungarianHelper()
                 hungarian_info = hungarian_helper.get_complete_matching_info(
                     gt_val, pred_val
                 )
                 matched_pairs = hungarian_info["matched_pairs"]
-                
+
                 # Count extra fields in matched pairs
                 for gt_idx, pred_idx, similarity in matched_pairs:
                     if gt_idx < len(gt_val) and pred_idx < len(pred_val):
@@ -1312,7 +1246,7 @@ class StructuredModel(BaseModel):
                         fa_count += gt_item._count_extra_fields_as_false_alarms(
                             pred_item
                         )
-                
+
                 # For unmatched prediction items, count their extra fields too
                 matched_pred_indices = {pred_idx for _, pred_idx, _ in matched_pairs}
                 for pred_idx, pred_item in enumerate(pred_val):
@@ -1329,9 +1263,9 @@ class StructuredModel(BaseModel):
                             # If no GT items, count all extra fields in this pred item
                             if hasattr(pred_item, "__pydantic_extra__"):
                                 fa_count += len(pred_item.__pydantic_extra__)
-        
+
         return fa_count
-    
+
     def _aggregate_to_overall(self, field_result: dict, overall: dict) -> None:
         """Simple aggregation to overall metrics."""
         for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
@@ -1340,100 +1274,29 @@ class StructuredModel(BaseModel):
                     overall[metric] += field_result[metric]
                 elif "overall" in field_result and metric in field_result["overall"]:
                     overall[metric] += field_result["overall"][metric]
-    
-    def _collect_all_primitive_metrics(self, node: dict, path: str = "") -> dict:
-        """Collect ALL primitive field metrics from entire subtree.
-        
-        This method performs a comprehensive traversal to find all primitive confusion matrix
-        metrics, including those from Hungarian matching results and deeply nested structures.
-        It uses a comprehensive approach to ensure all metrics are collected.
-        
-        CRITICAL FIX: Now properly handles both 'nested_fields' from Hungarian matching results
-        and regular 'fields' structures to ensure all primitive metrics are included in aggregates.
-        
-        Args:
-            node: Dictionary node to traverse
-            path: Current path for debugging/logging
-            
-        Returns:
-            Dictionary with aggregated primitive counts: {tp, fa, fd, fp, tn, fn}
-        """
-        total_counts = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
-        
-        if not isinstance(node, dict):
-            return total_counts
-        
-        # Check if this node has subfields
-        has_subfields = ("fields" in node and 
-                        isinstance(node["fields"], dict) and 
-                        len(node["fields"]) > 0)
-        
-        # Check for nested_fields from Hungarian matching (legacy structure)
-        has_nested_fields = ("nested_fields" in node and 
-                           isinstance(node["nested_fields"], dict) and 
-                           len(node["nested_fields"]) > 0)
-        
-        # CRITICAL FIX: For nodes with subfields, we need to recursively collect from all children
-        if has_subfields:
-            # This is a parent node - collect from children to avoid double counting
-            for field_name, field_data in node["fields"].items():
-                if isinstance(field_data, dict):
-                    child_counts = self._collect_all_primitive_metrics(field_data, f"{path}.{field_name}" if path else field_name)
-                    for metric in total_counts:
-                        total_counts[metric] += child_counts[metric]
-        
-        # CRITICAL FIX: For nodes with nested_fields (Hungarian matching results), 
-        # we should use nested_fields instead of fields for more accurate metrics
-        if has_nested_fields:
-            # This is a Hungarian matching result node - collect from nested_fields
-            # These contain the individual field metrics from matched pairs and include TN counts
-            for nested_field_name, nested_field_data in node["nested_fields"].items():
-                if isinstance(nested_field_data, dict) and self._has_basic_metrics(nested_field_data):
-                    # These are primitive metrics from individual fields within matched objects
-                    for metric in total_counts:
-                        total_counts[metric] += nested_field_data.get(metric, 0)
-            # If we have nested_fields, don't also collect from fields to avoid double counting
-            return total_counts
-        
-        # If this is a leaf node (no subfields and no nested_fields), collect its metrics
-        if not has_subfields and not has_nested_fields:
-            # CRITICAL FIX: For aggregate calculation, prefer "aggregate" section over "overall"
-            # This ensures we collect metrics from ALL matches, not just those above threshold
-            if "aggregate" in node and isinstance(node["aggregate"], dict) and self._has_basic_metrics(node["aggregate"]):
-                # Hierarchical leaf node with aggregate: collect from aggregate (includes all matches)
-                aggregate = node["aggregate"]
-                for metric in total_counts:
-                    total_counts[metric] += aggregate.get(metric, 0)
-            elif "overall" in node and isinstance(node["overall"], dict) and self._has_basic_metrics(node["overall"]):
-                # Hierarchical leaf node: collect from overall (fallback for nodes without aggregate)
-                overall = node["overall"]
-                for metric in total_counts:
-                    total_counts[metric] += overall.get(metric, 0)
-            elif self._has_basic_metrics(node):
-                # Flat leaf node: collect directly
-                for metric in total_counts:
-                    total_counts[metric] += node.get(metric, 0)
-        
-        return total_counts
 
     def _calculate_aggregate_metrics(self, result: dict) -> dict:
         """Calculate aggregate metrics for all nodes in the result tree.
-        
-        CRITICAL FIX: Now uses comprehensive primitive metric collection to ensure
-        all leaf-level metrics are included in aggregates, including Hungarian matching results.
-        
+
+        CRITICAL FIX: Enhanced deep nesting traversal to handle arbitrary nesting depth.
+        The aggregate field contains the sum of all primitive field confusion matrices
+        below that node in the tree. This provides universal field-level granularity.
+
         Args:
             result: Result from compare_recursive with hierarchical structure
-            
+
         Returns:
             Modified result with 'aggregate' fields added at each level
         """
         if not isinstance(result, dict):
             return result
-        
+
         # Make a copy to avoid modifying the original
         result_copy = result.copy()
-        
+
+        # Calculate aggregate for this node
+        aggregate_metrics = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
+
         # Recursively process 'fields' first to get child aggregates
         if "fields" in result_copy and isinstance(result_copy["fields"], dict):
             fields_copy = {}
@@ -1442,48 +1305,112 @@ class StructuredModel(BaseModel):
                     # Recursively calculate aggregate for child field
                     processed_field = self._calculate_aggregate_metrics(field_result)
                     fields_copy[field_name] = processed_field
+
+                    # CRITICAL FIX: Sum child's aggregate metrics to parent
+                    if "aggregate" in processed_field and self._has_basic_metrics(
+                        processed_field["aggregate"]
+                    ):
+                        child_aggregate = processed_field["aggregate"]
+                        for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
+                            aggregate_metrics[metric] += child_aggregate.get(metric, 0)
                 else:
                     # Non-dict field - keep as is
                     fields_copy[field_name] = field_result
             result_copy["fields"] = fields_copy
-        
-        # CRITICAL FIX: Use comprehensive primitive metric collection
-        # This ensures ALL primitive metrics are included, including Hungarian matching results
-        aggregate_metrics = self._collect_all_primitive_metrics(result_copy)
-        
-        # Only add aggregate if this node has subfields (non-leaf nodes)
-        has_subfields = ("fields" in result_copy and 
-                        isinstance(result_copy["fields"], dict) and 
-                        len(result_copy["fields"]) > 0)
-        
-        if has_subfields or any(aggregate_metrics.values()):
-            # Add aggregate as a sibling of 'overall' and 'fields'
-            result_copy["aggregate"] = aggregate_metrics
-        
+
+        # CRITICAL FIX: Enhanced leaf node detection for deep nesting
+        # Handle both empty fields dict and missing fields key as leaf indicators
+        is_leaf_node = (
+            "fields" not in result_copy
+            or not result_copy["fields"]
+            or (
+                isinstance(result_copy["fields"], dict)
+                and len(result_copy["fields"]) == 0
+            )
+        )
+
+        if is_leaf_node:
+            # Check if this is a leaf node with basic metrics (either in "overall" or directly)
+            if "overall" in result_copy and self._has_basic_metrics(
+                result_copy["overall"]
+            ):
+                # Hierarchical leaf node: aggregate = overall metrics
+                overall = result_copy["overall"]
+                for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
+                    aggregate_metrics[metric] = overall.get(metric, 0)
+            elif self._has_basic_metrics(result_copy):
+                # CRITICAL FIX: Legacy primitive leaf node - wrap in "overall" structure
+                # This preserves Universal Aggregate Field structure compliance
+                legacy_metrics = {}
+                for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
+                    legacy_metrics[metric] = result_copy.get(metric, 0)
+                    aggregate_metrics[metric] = result_copy.get(metric, 0)
+
+                # Wrap legacy structure in "overall" key to maintain consistency
+                if not "overall" in result_copy:
+                    # Move all basic metrics to "overall" key
+                    result_copy["overall"] = legacy_metrics
+                    # Remove basic metrics from top level to avoid duplication
+                    for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
+                        if metric in result_copy:
+                            del result_copy[metric]
+                    # Preserve other keys like derived, raw_similarity_score, etc.
+
+        # CRITICAL FIX: Always sum child field metrics if no child aggregates were found
+        # This handles the deep nesting case where leaf nodes have overall metrics but empty fields
+        if (
+            aggregate_metrics["tp"] == 0
+            and aggregate_metrics["fa"] == 0
+            and aggregate_metrics["fd"] == 0
+            and aggregate_metrics["fp"] == 0
+            and aggregate_metrics["tn"] == 0
+            and aggregate_metrics["fn"] == 0
+        ):
+            # Check if we have fields with overall metrics that we can sum
+            if "fields" in result_copy and isinstance(result_copy["fields"], dict):
+                for field_name, field_result in result_copy["fields"].items():
+                    if isinstance(field_result, dict):
+                        # ENHANCED: Check for both direct metrics and overall metrics
+                        if "overall" in field_result and self._has_basic_metrics(
+                            field_result["overall"]
+                        ):
+                            field_overall = field_result["overall"]
+                            for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
+                                aggregate_metrics[metric] += field_overall.get(
+                                    metric, 0
+                                )
+                        elif self._has_basic_metrics(field_result):
+                            # Direct metrics (legacy format)
+                            for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
+                                aggregate_metrics[metric] += field_result.get(metric, 0)
+
+        # Add aggregate as a sibling of 'overall' and 'fields'
+        result_copy["aggregate"] = aggregate_metrics
+
         return result_copy
-    
+
     def _add_derived_metrics_to_result(self, result: dict) -> dict:
         """Walk through result and add 'derived' fields with F1, precision, recall, accuracy.
-        
+
         Args:
             result: Result from compare_recursive with basic TP, FP, FN, etc. metrics
-            
+
         Returns:
             Modified result with 'derived' fields added at each level
         """
         if not isinstance(result, dict):
             return result
-        
+
         # Make a copy to avoid modifying the original
         result_copy = result.copy()
-        
+
         # Add derived metrics to 'overall' if it exists and has basic metrics
         if "overall" in result_copy and isinstance(result_copy["overall"], dict):
             overall = result_copy["overall"]
             if self._has_basic_metrics(overall):
                 metrics_helper = MetricsHelper()
                 overall["derived"] = metrics_helper.calculate_derived_metrics(overall)
-                
+
                 # Also add derived metrics to aggregate if it exists
                 if "aggregate" in overall and self._has_basic_metrics(
                     overall["aggregate"]
@@ -1491,7 +1418,7 @@ class StructuredModel(BaseModel):
                     overall["aggregate"]["derived"] = (
                         metrics_helper.calculate_derived_metrics(overall["aggregate"])
                     )
-        
+
         # Add derived metrics to top-level aggregate if it exists
         if "aggregate" in result_copy and self._has_basic_metrics(
             result_copy["aggregate"]
@@ -1500,7 +1427,7 @@ class StructuredModel(BaseModel):
             result_copy["aggregate"]["derived"] = (
                 metrics_helper.calculate_derived_metrics(result_copy["aggregate"])
             )
-        
+
         # Recursively process 'fields' if it exists
         if "fields" in result_copy and isinstance(result_copy["fields"], dict):
             fields_copy = {}
@@ -1523,7 +1450,7 @@ class StructuredModel(BaseModel):
                                 field_result["overall"]
                             )
                         )
-                        
+
                         # Also add derived metrics to aggregate if it exists
                         if "aggregate" in field_copy and self._has_basic_metrics(
                             field_copy["aggregate"]
@@ -1533,28 +1460,28 @@ class StructuredModel(BaseModel):
                                     field_copy["aggregate"]
                                 )
                             )
-                        
+
                         fields_copy[field_name] = field_copy
                     elif self._has_basic_metrics(field_result):
                         # CRITICAL FIX: Legacy leaf field with basic metrics - wrap in "overall" structure
                         field_copy = field_result.copy()
                         metrics_helper = MetricsHelper()
-                        
+
                         # Extract basic metrics and wrap in "overall" structure
                         legacy_metrics = {}
                         for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
                             if metric in field_copy:
                                 legacy_metrics[metric] = field_copy[metric]
                                 del field_copy[metric]  # Remove from top level
-                        
+
                         # Add derived metrics to the legacy metrics
                         legacy_metrics["derived"] = (
                             metrics_helper.calculate_derived_metrics(legacy_metrics)
                         )
-                        
+
                         # Wrap in "overall" structure
                         field_copy["overall"] = legacy_metrics
-                        
+
                         fields_copy[field_name] = field_copy
                     else:
                         # Other structure - keep as is
@@ -1563,48 +1490,48 @@ class StructuredModel(BaseModel):
                     # Non-dict field - keep as is
                     fields_copy[field_name] = field_result
             result_copy["fields"] = fields_copy
-        
+
         return result_copy
-    
+
     def _has_basic_metrics(self, metrics_dict: dict) -> bool:
         """Check if a dictionary has basic confusion matrix metrics.
-        
+
         Args:
             metrics_dict: Dictionary to check
-            
+
         Returns:
             True if it has the basic metrics (tp, fp, fn, etc.)
         """
         basic_metrics = ["tp", "fp", "fn", "tn", "fa", "fd"]
         return all(metric in metrics_dict for metric in basic_metrics)
-    
+
     def _classify_field_for_confusion_matrix(
         self, field_name: str, other_value: Any, threshold: float = None
     ) -> Dict[str, Any]:
         """Classify a field comparison according to the confusion matrix rules.
-        
+
         Args:
             field_name: Name of the field being compared
             other_value: Value to compare with
             threshold: Threshold for matching (uses field's threshold if None)
-            
+
         Returns:
             Dictionary with TP, FP, TN, FN, FD counts and derived metrics
         """
         # Get field values
         gt_value = getattr(self, field_name)
         pred_value = other_value
-        
-        # Get field configuration 
+
+        # Get field configuration
         info = self.__class__._get_comparison_info(field_name)
         if threshold is None:
             threshold = info.threshold
         comparator = info.comparator
-        
+
         # Determine if values are null
         gt_is_null = FieldHelper.is_null_value(gt_value)
         pred_is_null = FieldHelper.is_null_value(pred_value)
-        
+
         # Calculate similarity if both aren't null
         similarity = None
         if not gt_is_null and not pred_is_null:
@@ -1619,59 +1546,40 @@ class StructuredModel(BaseModel):
             values_match = similarity >= threshold
         else:
             values_match = False
-        
+
         # Apply confusion matrix classification
         if gt_is_null and pred_is_null:
             # TN: Both null
-            tn_count = 1
-            # CRITICAL FIX: For hierarchical fields, count nested field contributions
-            nested_field_count = self._get_nested_field_count(field_name)
-            if nested_field_count > 0:
-                tn_count += nested_field_count
-            result = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": tn_count, "fn": 0}
+            result = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 1, "fn": 0}
         elif gt_is_null and not pred_is_null:
             # FA: GT null, prediction non-null (False Alarm)
-            fa_count = 1
-            fp_count = 1
-            # CRITICAL FIX: For hierarchical fields, count nested field contributions
-            nested_field_count = self._get_nested_field_count(field_name)
-            if nested_field_count > 0 and isinstance(pred_value, list):
-                list_length = len(pred_value)
-                fa_count += list_length * nested_field_count
-                fp_count += list_length * nested_field_count
-            result = {"tp": 0, "fa": fa_count, "fd": 0, "fp": fp_count, "tn": 0, "fn": 0}
+            result = {"tp": 0, "fa": 1, "fd": 0, "fp": 1, "tn": 0, "fn": 0}
         elif not gt_is_null and pred_is_null:
             # FN: GT non-null, prediction null
-            fn_count = 1
-            # CRITICAL FIX: For hierarchical fields, count nested field contributions
-            nested_field_count = self._get_nested_field_count(field_name)
-            if nested_field_count > 0 and isinstance(gt_value, list):
-                list_length = len(gt_value)
-                fn_count += list_length * nested_field_count
-            result = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": fn_count}
+            result = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 1}
         elif values_match:
             # TP: Both non-null and match
             result = {"tp": 1, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
         else:
             # FD: Both non-null but don't match (False Discovery)
             result = {"tp": 0, "fa": 0, "fd": 1, "fp": 1, "tn": 0, "fn": 0}
-        
+
         # Add derived metrics
         metrics_helper = MetricsHelper()
         result["derived"] = metrics_helper.calculate_derived_metrics(result)
         # Don't include similarity_score in the result as tests don't expect it
-        
+
         return result
-    
+
     def _calculate_list_confusion_matrix(
         self, field_name: str, other_list: List[Any]
     ) -> Dict[str, Any]:
         """Calculate confusion matrix for a list field, including nested field metrics.
-        
+
         Args:
             field_name: Name of the list field being compared
             other_list: Predicted list to compare with
-            
+
         Returns:
             Dictionary with:
             - Top-level TP, FP, TN, FN, FD, FA counts and derived metrics for the list field
@@ -1680,7 +1588,7 @@ class StructuredModel(BaseModel):
         """
         gt_list = getattr(self, field_name)
         pred_list = other_list
-        
+
         # Initialize result structure
         result = {
             "tp": 0,
@@ -1692,7 +1600,7 @@ class StructuredModel(BaseModel):
             "nested_fields": {},  # Store nested field metrics here
             "non_matches": [],  # Store individual object-level non-matches here
         }
-        
+
         # Handle null cases first
         if FieldHelper.is_null_value(gt_list) and FieldHelper.is_null_value(pred_list):
             result.update({"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 1, "fn": 0})
@@ -1726,28 +1634,28 @@ class StructuredModel(BaseModel):
             info = self.__class__._get_comparison_info(field_name)
             comparator = info.comparator
             threshold = info.threshold
-            
+
             # Reuse existing Hungarian matching logic
             match_result = self._compare_unordered_lists(
                 gt_list, pred_list, comparator, threshold
             )
-            
+
             # Use the detailed confusion matrix results directly from Hungarian matcher
             result.update(
                 {
-                "tp": match_result["tp"],
+                    "tp": match_result["tp"],
                     "fa": match_result[
                         "fa"
                     ],  # False alarms (unmatched prediction items)
                     "fd": match_result[
                         "fd"
                     ],  # False discoveries (matches below threshold)
-                "fp": match_result["fp"],  # Total false positives (fa + fd)
-                "tn": 0,
+                    "fp": match_result["fp"],  # Total false positives (fa + fd)
+                    "tn": 0,
                     "fn": match_result["fn"],  # False negatives (unmatched GT items)
                 }
             )
-            
+
             # Collect individual object-level non-matches using NonMatchesHelper
             if gt_list and isinstance(gt_list[0], StructuredModel):
                 non_matches_helper = NonMatchesHelper()
@@ -1755,104 +1663,44 @@ class StructuredModel(BaseModel):
                     field_name, gt_list, pred_list
                 )
                 result["non_matches"] = non_matches
-            
+
             # If list contains StructuredModel objects, calculate nested field metrics
             if gt_list and isinstance(gt_list[0], StructuredModel):
-                nested_metrics, hierarchical_fields = self._calculate_nested_field_metrics(
+                nested_metrics = self._calculate_nested_field_metrics(
                     field_name, gt_list, pred_list, threshold
                 )
                 result["nested_fields"] = nested_metrics
-                
-                # Also preserve hierarchical fields structure if available
-                if hierarchical_fields:
-                    if "fields" not in result:
-                        result["fields"] = {}
-                    result["fields"].update(hierarchical_fields)
 
         # For List[StructuredModel], we should NOT aggregate nested fields to list level
         # List level metrics represent object-level matches from Hungarian algorithm
         # Nested field metrics represent field-level matches within those objects
         # They are separate concerns and should not be aggregated
-        
-        # Convert nested_fields to hierarchical fields structure for deep nesting support
-        if "nested_fields" in result and result["nested_fields"]:
-            hierarchical_fields = self._convert_nested_fields_to_hierarchical(
-                result["nested_fields"], field_name
-            )
-            if hierarchical_fields:
-                result["fields"] = hierarchical_fields
 
-        
-        # Add derived metrics  
+        # Only aggregate if this is explicitly marked as an aggregate field AND it's not a list
+        is_aggregate = self.__class__._is_aggregate_field(field_name)
+        if is_aggregate and not isinstance(gt_list, list):
+            # Initialize top-level confusion matrix values to 0
+            result["tp"] = 0
+            result["fa"] = 0
+            result["fd"] = 0
+            result["fp"] = 0
+            result["tn"] = 0
+            result["fn"] = 0
+            # Sum up the confusion matrix values from nested fields
+            for field, field_metrics in result["nested_fields"].items():
+                result["tp"] += field_metrics["tp"]
+                result["fa"] += field_metrics["fa"]
+                result["fd"] += field_metrics["fd"]
+                result["fp"] += field_metrics["fp"]
+                result["tn"] += field_metrics["tn"]
+                result["fn"] += field_metrics["fn"]
+
+        # Add derived metrics
         metrics_helper = MetricsHelper()
         result["derived"] = metrics_helper.calculate_derived_metrics(result)
-        
+
         return result
-    
-    def _convert_nested_fields_to_hierarchical(
-        self, nested_fields: Dict[str, Dict[str, Any]], parent_field_name: str
-    ) -> Dict[str, Any]:
-        """Convert flat nested_fields structure to hierarchical fields structure.
-        
-        Args:
-            nested_fields: Flat structure like {"products.attributes.name": {...}, "products.attributes.properties.key": {...}}
-            parent_field_name: Name of the parent field (e.g., "products")
-            
-        Returns:
-            Hierarchical structure with nested "fields" sections
-        """
-        hierarchical = {}
-        
-        # First, collect all the paths and group them by their immediate parent
-        path_groups = {}
-        
-        for field_path, metrics in nested_fields.items():
-            # Remove the parent field name prefix to get the relative path
-            if field_path.startswith(f"{parent_field_name}."):
-                relative_path = field_path[len(f"{parent_field_name}."):]
-                path_parts = relative_path.split(".")
-                
-                # Group by immediate parent path
-                if len(path_parts) == 1:
-                    # This is a direct child field
-                    field_name = path_parts[0]
-                    hierarchical[field_name] = {
-                        "overall": metrics.copy(),
-                        "aggregate": metrics.copy()
-                    }
-                else:
-                    # This is a nested field - group by immediate parent
-                    immediate_parent = path_parts[0]
-                    remaining_path = ".".join(path_parts[1:])
-                    
-                    if immediate_parent not in path_groups:
-                        path_groups[immediate_parent] = {}
-                    
-                    # Store with the remaining path
-                    path_groups[immediate_parent][f"{immediate_parent}.{remaining_path}"] = metrics
-        
-        # Now recursively build the hierarchical structure for grouped paths
-        for parent_field, child_paths in path_groups.items():
-            if parent_field not in hierarchical:
-                # Create the parent field structure
-                hierarchical[parent_field] = {
-                    "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0},
-                    "aggregate": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
-                }
-                
-                # Aggregate metrics from all child paths for the parent
-                for child_path, child_metrics in child_paths.items():
-                    for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                        hierarchical[parent_field]["overall"][metric] += child_metrics.get(metric, 0)
-                        hierarchical[parent_field]["aggregate"][metric] += child_metrics.get(metric, 0)
-            
-            # Recursively convert child paths
-            child_hierarchical = self._convert_nested_fields_to_hierarchical(child_paths, parent_field)
-            if child_hierarchical:
-                hierarchical[parent_field]["fields"] = child_hierarchical
-        
-        return hierarchical
-    
+
     def _calculate_nested_field_metrics(
         self,
         list_field_name: str,
@@ -1861,47 +1709,47 @@ class StructuredModel(BaseModel):
         threshold: float,
     ) -> Dict[str, Dict[str, Any]]:
         """Calculate confusion matrix metrics for individual fields within list items.
-        
+
         THRESHOLD-GATED RECURSION: Only perform recursive field analysis for object pairs
-        with similarity >= StructuredModel.match_threshold. Poor matches and unmatched 
+        with similarity >= StructuredModel.match_threshold. Poor matches and unmatched
         items are treated as atomic units.
-        
+
         Args:
             list_field_name: Name of the parent list field (e.g., "transactions")
             gt_list: Ground truth list of StructuredModel objects
             pred_list: Predicted list of StructuredModel objects
             threshold: Matching threshold (not used for threshold-gating)
-            
+
         Returns:
             Dictionary mapping nested field paths to their confusion matrix metrics
             E.g., {"transactions.date": {...}, "transactions.description": {...}}
         """
         nested_metrics = {}
-        
+
         if not gt_list or not isinstance(gt_list[0], StructuredModel):
             return nested_metrics
-        
+
         # Get the model class from the first item
         model_class = gt_list[0].__class__
-        
+
         # CRITICAL FIX: Use field's threshold, not class's match_threshold
         # Get the field info from the parent object to use the correct threshold
         parent_field_info = self.__class__._get_comparison_info(list_field_name)
         match_threshold = parent_field_info.threshold
-        
+
         # For each field in the nested model
         for field_name in model_class.model_fields:
             if field_name == "extra_fields":
                 continue
-                
+
             nested_field_path = f"{list_field_name}.{field_name}"
-            
+
             # Initialize aggregated counts for this nested field
             total_tp = total_fa = total_fd = total_fp = total_tn = total_fn = 0
-            
+
             # Use HungarianHelper for Hungarian matching operations - OPTIMIZED: Single call gets all info
             hungarian_helper = HungarianHelper()
-            
+
             # Use HungarianHelper to get optimal assignments with similarity scores
             assignments = []
             matched_pairs_with_scores = []
@@ -1912,25 +1760,25 @@ class StructuredModel(BaseModel):
                 matched_pairs_with_scores = hungarian_info["matched_pairs"]
                 # Extract (gt_idx, pred_idx) pairs from the matched_pairs
                 assignments = [(i, j) for i, j, score in matched_pairs_with_scores]
-            
+
             # THRESHOLD-GATED RECURSION: Only process pairs that meet the match_threshold
             for gt_idx, pred_idx, similarity_score in matched_pairs_with_scores:
                 if gt_idx < len(gt_list) and pred_idx < len(pred_list):
                     gt_item = gt_list[gt_idx]
                     pred_item = pred_list[pred_idx]
-                    
+
                     # Handle floating point precision issues
                     is_above_threshold = (
                         similarity_score >= match_threshold
                         or abs(similarity_score - match_threshold) < 1e-10
                     )
-                    
+
                     # Only perform recursive field analysis if similarity meets threshold
                     if is_above_threshold:
                         # Get field values
                         gt_value = getattr(gt_item, field_name, None)
                         pred_value = getattr(pred_item, field_name, None)
-                        
+
                         # Check if this field is a List[StructuredModel] that needs recursive processing
                         if (
                             isinstance(gt_value, list)
@@ -1944,7 +1792,7 @@ class StructuredModel(BaseModel):
                                     field_name, pred_value
                                 )
                             )
-                            
+
                             # Aggregate the list-level counts
                             total_tp += list_classification["tp"]
                             total_fa += list_classification["fa"]
@@ -1952,7 +1800,7 @@ class StructuredModel(BaseModel):
                             total_fp += list_classification["fp"]
                             total_tn += list_classification["tn"]
                             total_fn += list_classification["fn"]
-                            
+
                             # IMPORTANT: Also collect the deeper nested field metrics
                             if "nested_fields" in list_classification:
                                 for (
@@ -1963,7 +1811,7 @@ class StructuredModel(BaseModel):
                                     full_deeper_path = (
                                         f"{list_field_name}.{deeper_field_path}"
                                     )
-                                    
+
                                     # Initialize or aggregate into the deeper nested metrics
                                     if full_deeper_path not in nested_metrics:
                                         nested_metrics[full_deeper_path] = {
@@ -1974,7 +1822,7 @@ class StructuredModel(BaseModel):
                                             "tn": 0,
                                             "fn": 0,
                                         }
-                                    
+
                                     nested_metrics[full_deeper_path]["tp"] += (
                                         deeper_metrics["tp"]
                                     )
@@ -2002,7 +1850,7 @@ class StructuredModel(BaseModel):
                                     None,  # Use field's own threshold
                                 )
                             )
-                            
+
                             # Aggregate counts
                             total_tp += field_classification["tp"]
                             total_fa += field_classification["fa"]
@@ -2014,7 +1862,7 @@ class StructuredModel(BaseModel):
                         # Skip recursive analysis for pairs below threshold
                         # These will be handled as FD at the object level
                         pass
-            
+
             # Handle unmatched ground truth items (false negatives)
             matched_gt_indices = set(idx for idx, _ in assignments)
             for gt_idx, gt_item in enumerate(gt_list):
@@ -2030,7 +1878,7 @@ class StructuredModel(BaseModel):
                             # For List[StructuredModel], count each item in the list as a separate FN
                             # and handle deeper nested fields
                             total_fn += len(gt_value)  # Each list item is a separate FN
-                            
+
                             # Also handle deeper nested fields for unmatched items
                             dummy_empty_list = []  # Empty list for comparison
                             list_classification = (
@@ -2061,7 +1909,7 @@ class StructuredModel(BaseModel):
                         else:
                             # Handle primitive fields or single StructuredModel fields
                             total_fn += 1
-            
+
             # Handle unmatched prediction items (false alarms)
             matched_pred_indices = set(idx for _, idx in assignments)
             for pred_idx, pred_item in enumerate(pred_list):
@@ -2082,7 +1930,7 @@ class StructuredModel(BaseModel):
                             total_fp += len(
                                 pred_value
                             )  # Each list item is also a separate FP
-                            
+
                             # Also handle deeper nested fields for unmatched items
                             dummy_empty_list = []  # Empty list for comparison
                             # We need to create a dummy GT item for comparison to get the structure
@@ -2120,7 +1968,7 @@ class StructuredModel(BaseModel):
                             # Handle primitive fields or single StructuredModel fields
                             total_fa += 1
                             total_fp += 1
-            
+
             # Store the aggregated metrics for this nested field
             nested_metrics[nested_field_path] = {
                 "tp": total_tp,
@@ -2140,7 +1988,7 @@ class StructuredModel(BaseModel):
                     }
                 ),
             }
-        
+
         # Add derived metrics for all deeper nested fields that were collected
         for deeper_path, deeper_metrics in nested_metrics.items():
             if deeper_path != nested_field_path and "derived" not in deeper_metrics:
@@ -2154,83 +2002,30 @@ class StructuredModel(BaseModel):
                         "fn": deeper_metrics["fn"],
                     }
                 )
-        
-        # Also collect hierarchical fields structures from recursive list comparisons
-        hierarchical_fields = {}
-        
-        # Re-process the matched pairs to collect hierarchical structures
-        for gt_idx, pred_idx, similarity_score in matched_pairs_with_scores:
-            if gt_idx < len(gt_list) and pred_idx < len(pred_list):
-                gt_item = gt_list[gt_idx]
-                pred_item = pred_list[pred_idx]
-                
-                # Handle floating point precision issues
-                is_above_threshold = (
-                    similarity_score >= match_threshold
-                    or abs(similarity_score - match_threshold) < 1e-10
-                )
-                
-                # Only perform recursive field analysis if similarity meets threshold
-                if is_above_threshold:
-                    for field_name in model_class.model_fields:
-                        if field_name == "extra_fields":
-                            continue
-                            
-                        gt_value = getattr(gt_item, field_name, None)
-                        pred_value = getattr(pred_item, field_name, None)
-                        
-                        # Check if this field is a List[StructuredModel] that needs recursive processing
-                        if (
-                            isinstance(gt_value, list)
-                            and isinstance(pred_value, list)
-                            and gt_value
-                            and isinstance(gt_value[0], StructuredModel)
-                        ):
-                            # Get the hierarchical structure from the recursive call
-                            list_classification = (
-                                gt_item._calculate_list_confusion_matrix(
-                                    field_name, pred_value
-                                )
-                            )
-                            
-                            # Preserve the hierarchical fields structure
-                            if "fields" in list_classification and list_classification["fields"]:
-                                if field_name not in hierarchical_fields:
-                                    hierarchical_fields[field_name] = {}
-                                
-                                # Merge the hierarchical structure
-                                for sub_field_name, sub_field_data in list_classification["fields"].items():
-                                    if sub_field_name not in hierarchical_fields[field_name]:
-                                        hierarchical_fields[field_name][sub_field_name] = {
-                                            "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0},
-                                            "aggregate": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
-                                        }
-                                        if "fields" in sub_field_data:
-                                            hierarchical_fields[field_name][sub_field_name]["fields"] = sub_field_data["fields"]
-                                    
-                                    # Aggregate the metrics
-                                    for section in ["overall", "aggregate"]:
-                                        if section in sub_field_data:
-                                            for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                                                hierarchical_fields[field_name][sub_field_name][section][metric] += sub_field_data[section].get(metric, 0)
-        
-        return nested_metrics, hierarchical_fields
-    
-    def _calculate_single_nested_field_metrics(self, parent_field_name: str, gt_nested: 'StructuredModel', 
-                        pred_nested: 'StructuredModel') -> Dict[str, Dict[str, Any]]:
+
+        return nested_metrics
+
+    def _calculate_single_nested_field_metrics(
+        self,
+        parent_field_name: str,
+        gt_nested: "StructuredModel",
+        pred_nested: "StructuredModel",
+        parent_is_aggregate: bool = False,
+    ) -> Dict[str, Dict[str, Any]]:
         """Calculate confusion matrix metrics for fields within a single nested StructuredModel.
-        
+
         Args:
             parent_field_name: Name of the parent field (e.g., "address")
             gt_nested: Ground truth nested StructuredModel
             pred_nested: Predicted nested StructuredModel
-            
+            parent_is_aggregate: Whether the parent field should aggregate child metrics
+
         Returns:
             Dictionary mapping nested field paths to their confusion matrix metrics
             E.g., {"address.street": {...}, "address.city": {...}}
         """
         nested_metrics = {}
-        
+
         if not isinstance(gt_nested, StructuredModel) or not isinstance(
             pred_nested, StructuredModel
         ):
@@ -2242,22 +2037,35 @@ class StructuredModel(BaseModel):
             ):
                 return nested_metrics
             return nested_metrics
-        
 
+        # Initialize aggregation metrics for parent field if it's an aggregated field
+        parent_metrics = (
+            {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
+            if parent_is_aggregate
+            else None
+        )
+
+        # Track which fields are aggregate fields themselves to avoid double counting
+        child_aggregate_fields = set()
 
         # For each field in the nested model
         for field_name in gt_nested.__class__.model_fields:
             if field_name == "extra_fields":
                 continue
-                
-            nested_field_path = f"{parent_field_name}.{field_name}"
-            
 
-            
+            nested_field_path = f"{parent_field_name}.{field_name}"
+
+            # Check if this nested field is itself an aggregate field
+            is_child_aggregate = False
+            if hasattr(gt_nested.__class__, "_is_aggregate_field"):
+                is_child_aggregate = gt_nested.__class__._is_aggregate_field(field_name)
+                if is_child_aggregate:
+                    child_aggregate_fields.add(field_name)
+
             # Get the field value from the prediction
             pred_value = getattr(pred_nested, field_name, None)
             gt_value = getattr(gt_nested, field_name)
-            
+
             # Handle lists of StructuredModel objects
             if (
                 isinstance(gt_value, list)
@@ -2269,14 +2077,14 @@ class StructuredModel(BaseModel):
                 list_metrics = gt_nested._calculate_list_confusion_matrix(
                     field_name, pred_value
                 )
-                
+
                 # Store the metrics for this nested field
                 nested_metrics[nested_field_path] = {
                     key: value
                     for key, value in list_metrics.items()
                     if key != "nested_fields"
                 }
-                
+
                 # Add nested field metrics if available
                 if "nested_fields" in list_metrics:
                     for sub_field, sub_metrics in list_metrics["nested_fields"].items():
@@ -2287,39 +2095,79 @@ class StructuredModel(BaseModel):
                 field_classification = gt_nested._classify_field_for_confusion_matrix(
                     field_name, pred_value
                 )
-                
+
                 # Store the metrics for this nested field
                 nested_metrics[nested_field_path] = field_classification
 
                 # Recursively calculate metrics for deeper nesting
                 deeper_metrics = self._calculate_single_nested_field_metrics(
-                    nested_field_path, gt_value, pred_value)
+                    nested_field_path, gt_value, pred_value, is_child_aggregate
+                )
                 nested_metrics.update(deeper_metrics)
 
+                # If this is an aggregate child field, we need to use its aggregated metrics
+                # instead of the direct field comparison metrics
+                if is_child_aggregate and nested_field_path in deeper_metrics:
+                    # For an aggregate child field, we replace its direct metrics with
+                    # the aggregation of its children's metrics
+                    nested_metrics[nested_field_path] = deeper_metrics[
+                        nested_field_path
+                    ]
 
+            # For parent aggregation, we need to be careful not to double count metrics
+            if parent_is_aggregate:
+                if is_child_aggregate:
+                    # If child is an aggregate, use its aggregated metrics for parent
+                    if nested_field_path in deeper_metrics:
+                        child_agg_metrics = deeper_metrics[nested_field_path]
+                        for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
+                            parent_metrics[metric] += child_agg_metrics.get(metric, 0)
+                else:
+                    # If child is not an aggregate, use its direct field metrics
+                    field_metrics = nested_metrics[nested_field_path]
+                    for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
+                        parent_metrics[metric] += field_metrics.get(metric, 0)
+
+        # If parent is an aggregated field, add the aggregated metrics to the result
+        if parent_is_aggregate:
+            # Don't include metrics from child aggregate fields in the parent's metrics
+            # as they've already been counted through their own aggregation
+            for field_name in child_aggregate_fields:
+                nested_field_path = f"{parent_field_name}.{field_name}"
+                if nested_field_path in nested_metrics:
+                    # Don't double count these metrics in the parent
+                    field_metrics = nested_metrics[nested_field_path]
+                    # Subtract these metrics from parent_metrics to avoid double counting
+                    for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
+                        parent_metrics[metric] -= field_metrics.get(metric, 0)
+
+            nested_metrics[parent_field_name] = parent_metrics
+            # Add derived metrics
+            nested_metrics[parent_field_name]["derived"] = (
+                MetricsHelper().calculate_derived_metrics(parent_metrics)
+            )
 
         return nested_metrics
-    
-    
 
-    
-    def _collect_enhanced_non_matches(self, recursive_result: dict, other: 'StructuredModel') -> List[Dict[str, Any]]:
+    def _collect_enhanced_non_matches(
+        self, recursive_result: dict, other: "StructuredModel"
+    ) -> List[Dict[str, Any]]:
         """Collect enhanced non-matches with object-level granularity.
-        
+
         Args:
             recursive_result: Result from compare_recursive containing field comparison details
             other: The predicted StructuredModel instance
-            
+
         Returns:
             List of non-match dictionaries with enhanced object-level information
         """
         all_non_matches = []
-        
+
         # Walk through the recursive result and collect non-matches
         for field_name, field_result in recursive_result.get("fields", {}).items():
             gt_val = getattr(self, field_name)
             pred_val = getattr(other, field_name, None)
-            
+
             # Check if this is a list field that should use object-level collection
             if (
                 isinstance(gt_val, list)
@@ -2333,43 +2181,8 @@ class StructuredModel(BaseModel):
                     field_name, gt_val, pred_val
                 )
                 all_non_matches.extend(object_non_matches)
-                
-                # NEW: Also collect field-level non-matches from within matched objects
-                # Get the Hungarian matching information to find matched pairs
-                hungarian_helper = HungarianHelper()
-                if gt_val and pred_val:
-                    hungarian_info = hungarian_helper.get_complete_matching_info(gt_val, pred_val)
-                    matched_pairs = hungarian_info["matched_pairs"]
-                    
-                    # For each matched pair, collect field-level non-matches from the individual comparison
-                    for gt_idx, pred_idx, similarity_score in matched_pairs:
-                        if gt_idx < len(gt_val) and pred_idx < len(pred_val):
-                            gt_item = gt_val[gt_idx]
-                            pred_item = pred_val[pred_idx]
-                            
-                            # Get the match threshold for this object type
-                            match_threshold = getattr(gt_item.__class__, 'match_threshold', 0.7)
-                            
-                            # Only collect field-level non-matches if this pair is above threshold (TP)
-                            # or if it's below threshold but we want to see why it failed (FD)
-                            if similarity_score >= match_threshold or similarity_score > 0.0:
-                                # Perform individual comparison to get field-level details
-                                individual_result = gt_item.compare_with(
-                                    pred_item, 
-                                    include_confusion_matrix=True, 
-                                    document_non_matches=True
-                                )
-                                
-                                # Collect field-level non-matches from the individual comparison
-                                if "non_matches" in individual_result:
-                                    for field_nm in individual_result["non_matches"]:
-                                        # Prefix the field path with the list index
-                                        indexed_field_path = f"{field_name}[{gt_idx}].{field_nm['field_path']}"
-                                        field_nm_copy = field_nm.copy()
-                                        field_nm_copy["field_path"] = indexed_field_path
-                                        all_non_matches.append(field_nm_copy)
-            
-            # Handle null list cases  
+
+            # Handle null list cases
             elif (
                 (gt_val is None or (isinstance(gt_val, list) and len(gt_val) == 0))
                 and isinstance(pred_val, list)
@@ -2381,7 +2194,7 @@ class StructuredModel(BaseModel):
                     field_name, gt_val, pred_val
                 )
                 all_non_matches.extend(null_non_matches)
-                
+
             elif (
                 isinstance(gt_val, list)
                 and len(gt_val) > 0
@@ -2396,7 +2209,7 @@ class StructuredModel(BaseModel):
                     field_name, gt_val, pred_val
                 )
                 all_non_matches.extend(null_non_matches)
-                
+
             else:
                 # Use existing field-level logic for non-list fields
                 # Extract metrics from field result to determine non-match type
@@ -2406,66 +2219,43 @@ class StructuredModel(BaseModel):
                     metrics = field_result
                 else:
                     continue  # Skip if we can't extract metrics
-                
-                # NEW: Collect leaf-level non_matches for primitive fields
-                helper = NonMatchesHelper()
-                
-                # Check if this is a primitive field (not a StructuredModel or list)
-                if not isinstance(gt_val, (StructuredModel, list)) and not isinstance(pred_val, (StructuredModel, list)):
-                    # This is a primitive field - collect leaf-level non_matches ONLY
-                    leaf_non_matches = helper.collect_primitive_field_non_matches(
-                        field_name, gt_val, pred_val, field_result
-                    )
-                    all_non_matches.extend(leaf_non_matches)
-                    # Skip object-level entries for primitive fields to avoid duplication
-                
-                # Check if this is a primitive list field
-                elif (isinstance(gt_val, list) and isinstance(pred_val, list) and 
-                      (not gt_val or not isinstance(gt_val[0], StructuredModel))):
-                    # This is a primitive list - collect leaf-level non_matches ONLY
-                    leaf_non_matches = helper.collect_primitive_list_non_matches(
-                        field_name, gt_val, pred_val, field_result
-                    )
-                    all_non_matches.extend(leaf_non_matches)
-                    # Skip object-level entries for primitive lists to avoid duplication
-                
-                else:
-                    # For non-primitive fields, create object-level non-match entries (legacy format for backward compatibility)
-                    if metrics.get("fa", 0) > 0:  # False Alarm
-                        entry = {
-                            "field_path": field_name,
-                            "non_match_type": NonMatchType.FALSE_ALARM,  # Use enum value
-                            "ground_truth_value": gt_val,
-                            "prediction_value": pred_val,
+
+                # Create field-level non-match entries based on metrics (legacy format for backward compatibility)
+                if metrics.get("fa", 0) > 0:  # False Alarm
+                    entry = {
+                        "field_path": field_name,
+                        "non_match_type": NonMatchType.FALSE_ALARM,  # Use enum value
+                        "ground_truth_value": gt_val,
+                        "prediction_value": pred_val,
                         "details": {"reason": "unmatched prediction"},
-                        }
-                        all_non_matches.append(entry)
-                    elif metrics.get("fn", 0) > 0:  # False Negative
-                        entry = {
-                            "field_path": field_name,
-                            "non_match_type": NonMatchType.FALSE_NEGATIVE,  # Use enum value
-                            "ground_truth_value": gt_val,
-                            "prediction_value": pred_val,
+                    }
+                    all_non_matches.append(entry)
+                elif metrics.get("fn", 0) > 0:  # False Negative
+                    entry = {
+                        "field_path": field_name,
+                        "non_match_type": NonMatchType.FALSE_NEGATIVE,  # Use enum value
+                        "ground_truth_value": gt_val,
+                        "prediction_value": pred_val,
                         "details": {"reason": "unmatched ground truth"},
-                        }
-                        all_non_matches.append(entry)
-                    elif metrics.get("fd", 0) > 0:  # False Discovery
-                        similarity = field_result.get("raw_similarity_score")
-                        entry = {
-                            "field_path": field_name,
-                            "non_match_type": NonMatchType.FALSE_DISCOVERY,  # Use enum value
-                            "ground_truth_value": gt_val,
-                            "prediction_value": pred_val,
-                            "similarity_score": similarity,
+                    }
+                    all_non_matches.append(entry)
+                elif metrics.get("fd", 0) > 0:  # False Discovery
+                    similarity = field_result.get("raw_similarity_score")
+                    entry = {
+                        "field_path": field_name,
+                        "non_match_type": NonMatchType.FALSE_DISCOVERY,  # Use enum value
+                        "ground_truth_value": gt_val,
+                        "prediction_value": pred_val,
+                        "similarity_score": similarity,
                         "details": {"reason": "below threshold"},
-                        }
-                        if similarity is not None:
-                            info = self._get_comparison_info(field_name)
+                    }
+                    if similarity is not None:
+                        info = self._get_comparison_info(field_name)
                         entry["details"]["reason"] = (
                             f"below threshold ({similarity:.3f} < {info.threshold})"
                         )
-                        all_non_matches.append(entry)
-                
+                    all_non_matches.append(entry)
+
                 # ADDITIONAL: Handle nested StructuredModel objects for detailed non-match collection
                 if (
                     isinstance(gt_val, StructuredModel)
@@ -2482,68 +2272,44 @@ class StructuredModel(BaseModel):
                             f"{field_name}.{nested_nm['field_path']}"
                         )
                         all_non_matches.append(nested_nm)
-        
-        # NEW: Add hierarchical debugging support
-        if all_non_matches:
-            helper = NonMatchesHelper()
-            
-            # Add aggregate contribution tracing if we have aggregate metrics
-            if "aggregate" in recursive_result:
-                all_non_matches = helper.add_aggregate_contribution_tracing(
-                    all_non_matches, recursive_result["aggregate"]
-                )
-            
-            # Add hierarchical organization metadata
-            hierarchical_info = helper.organize_non_matches_hierarchically(all_non_matches)
-            
-            # Add debugging metadata to the first non_match entry for easy access
-            if all_non_matches:
-                all_non_matches[0]["_debugging_metadata"] = {
-                    "hierarchical_summary": hierarchical_info["summary"],
-                    "field_paths_affected": list(hierarchical_info["by_field_path"].keys()),
-                    "leaf_vs_object_breakdown": {
-                        "leaf_level": hierarchical_info["summary"]["leaf_level_count"],
-                        "object_level": hierarchical_info["summary"]["object_level_count"]
-                    }
-                }
-        
+
         return all_non_matches
-    
+
     def _collect_non_matches(
         self, other: "StructuredModel", base_path: str = ""
     ) -> List[NonMatchField]:
         """Collect non-matches for detailed analysis.
-        
+
         Args:
             other: Other model to compare with
             base_path: Base path for field naming (e.g., "address")
-            
+
         Returns:
             List of NonMatchField objects documenting non-matches
         """
         non_matches = []
-        
+
         # Handle null cases
         if other is None:
             non_matches.append(
                 NonMatchField(
-                field_path=base_path or "root",
-                non_match_type=NonMatchType.FALSE_NEGATIVE,
-                ground_truth_value=self,
+                    field_path=base_path or "root",
+                    non_match_type=NonMatchType.FALSE_NEGATIVE,
+                    ground_truth_value=self,
                     prediction_value=None,
                 )
             )
             return non_matches
-        
+
         # Compare each field
         for field_name in self.__class__.model_fields:
             if field_name == "extra_fields":
                 continue
-                
+
             field_path = f"{base_path}.{field_name}" if base_path else field_name
             gt_value = getattr(self, field_name)
             pred_value = getattr(other, field_name, None)
-            
+
             # Use existing field classification logic
             if isinstance(pred_value, list):
                 classification = self._calculate_list_confusion_matrix(
@@ -2553,38 +2319,38 @@ class StructuredModel(BaseModel):
                 classification = self._classify_field_for_confusion_matrix(
                     field_name, pred_value
                 )
-            
+
             # Document non-matches based on classification
             if classification["fa"] > 0:  # False Alarm
                 non_matches.append(
                     NonMatchField(
-                    field_path=field_path,
-                    non_match_type=NonMatchType.FALSE_ALARM,
-                    ground_truth_value=gt_value,
-                    prediction_value=pred_value,
+                        field_path=field_path,
+                        non_match_type=NonMatchType.FALSE_ALARM,
+                        ground_truth_value=gt_value,
+                        prediction_value=pred_value,
                         similarity_score=classification.get("similarity_score"),
                     )
                 )
             elif classification["fn"] > 0:  # False Negative
                 non_matches.append(
                     NonMatchField(
-                    field_path=field_path,
-                    non_match_type=NonMatchType.FALSE_NEGATIVE,
-                    ground_truth_value=gt_value,
+                        field_path=field_path,
+                        non_match_type=NonMatchType.FALSE_NEGATIVE,
+                        ground_truth_value=gt_value,
                         prediction_value=pred_value,
                     )
                 )
             elif classification["fd"] > 0:  # False Discovery
                 non_matches.append(
                     NonMatchField(
-                    field_path=field_path,
-                    non_match_type=NonMatchType.FALSE_DISCOVERY,
-                    ground_truth_value=gt_value,
-                    prediction_value=pred_value,
+                        field_path=field_path,
+                        non_match_type=NonMatchType.FALSE_DISCOVERY,
+                        ground_truth_value=gt_value,
+                        prediction_value=pred_value,
                         similarity_score=classification.get("similarity_score"),
                     )
                 )
-            
+
             # Handle nested models recursively
             if isinstance(gt_value, StructuredModel) and isinstance(
                 pred_value, StructuredModel
@@ -2593,28 +2359,28 @@ class StructuredModel(BaseModel):
                     pred_value, field_path
                 )
                 non_matches.extend(nested_non_matches)
-        
+
         return non_matches
-    
+
     def compare(self, other: "StructuredModel") -> float:
         """Compare this model with another and return a scalar similarity score.
-        
+
         Returns the overall weighted average score regardless of sufficient/necessary field matching.
         This provides a more nuanced score for use in comparators.
-        
+
         Args:
             other: Another instance of the same model to compare with
-            
+
         Returns:
             Similarity score between 0.0 and 1.0
         """
         # We'll calculate the overall weighted score directly instead of using compare_with
         # This ensures that sufficient/necessary field rules don't cause a zero score
         # when at least some fields match
-        
+
         total_score = 0.0
         total_weight = 0.0
-        
+
         for field_name in self.__class__.model_fields:
             # Skip the extra_fields attribute in comparison
             if field_name == "extra_fields":
@@ -2624,22 +2390,22 @@ class StructuredModel(BaseModel):
                 info = self.__class__._get_comparison_info(field_name)
                 # Use weight from ComparableField object
                 weight = info.weight
-                
+
                 # Compare field values WITHOUT applying thresholds
                 field_score = self.compare_field_raw(
                     field_name, getattr(other, field_name)
                 )
-                
+
                 # Update total score
                 total_score += field_score * weight
                 total_weight += weight
-        
+
         # Calculate overall score
         if total_weight > 0:
             return total_score / total_weight
         else:
             return 0.0
-    
+
     def compare_with(
         self,
         other: "StructuredModel",
@@ -2650,7 +2416,7 @@ class StructuredModel(BaseModel):
         add_derived_metrics: bool = True,
     ) -> Dict[str, Any]:
         """Compare this model with another instance using SINGLE TRAVERSAL optimization.
-        
+
         Args:
             other: Another instance of the same model to compare with
             include_confusion_matrix: Whether to include confusion matrix calculations
@@ -2659,7 +2425,7 @@ class StructuredModel(BaseModel):
             recall_with_fd: If True, include FD in recall denominator (TP/(TP+FN+FD))
                             If False, use traditional recall (TP/(TP+FN))
             add_derived_metrics: Whether to add derived metrics to confusion matrix
-            
+
         Returns:
             Dictionary with comparison results including:
             - field_scores: Scores for each field
@@ -2670,7 +2436,7 @@ class StructuredModel(BaseModel):
         """
         # SINGLE TRAVERSAL: Get everything in one pass
         recursive_result = self.compare_recursive(other)
-        
+
         # Extract scoring information from recursive result
         field_scores = {}
         for field_name, field_result in recursive_result["fields"].items():
@@ -2681,59 +2447,59 @@ class StructuredModel(BaseModel):
                 # Fallback to raw_similarity_score if threshold_applied_score not available
                 elif "raw_similarity_score" in field_result:
                     field_scores[field_name] = field_result["raw_similarity_score"]
-        
+
         # Extract overall metrics
         overall_result = recursive_result["overall"]
         overall_score = overall_result.get("similarity_score", 0.0)
         all_fields_matched = overall_result.get("all_fields_matched", False)
-        
+
         # Build basic result structure
         result = {
             "field_scores": field_scores,
             "overall_score": overall_score,
             "all_fields_matched": all_fields_matched,
         }
-        
+
         # Add optional features using already-computed recursive result
         if include_confusion_matrix:
             confusion_matrix = recursive_result
-            
+
             # Add universal aggregate metrics to all nodes
             confusion_matrix = self._calculate_aggregate_metrics(confusion_matrix)
-            
+
             # Add derived metrics if requested
             if add_derived_metrics:
                 confusion_matrix = self._add_derived_metrics_to_result(confusion_matrix)
-            
+
             result["confusion_matrix"] = confusion_matrix
-        
+
         # Add optional non-match documentation
         if document_non_matches:
             # NEW: Collect enhanced object-level non-matches
             non_matches = self._collect_enhanced_non_matches(recursive_result, other)
             result["non_matches"] = non_matches
-        
+
         # If evaluator_format is requested, transform the result
         if evaluator_format:
             return self._format_for_evaluator(result, other, recall_with_fd)
-            
+
         return result
-    
+
     def _convert_score_to_binary_metrics(
         self, score: float, threshold: float = 0.5
     ) -> Dict[str, float]:
         """Convert similarity score to binary classification metrics using MetricsHelper.
-        
+
         Args:
             score: Similarity score [0-1]
             threshold: Threshold for considering a match
-            
+
         Returns:
             Dictionary with TP, FP, FN, TN counts converted to metrics
         """
         metrics_helper = MetricsHelper()
         return metrics_helper.convert_score_to_binary_metrics(score, threshold)
-    
+
     def _format_for_evaluator(
         self,
         result: Dict[str, Any],
@@ -2741,19 +2507,19 @@ class StructuredModel(BaseModel):
         recall_with_fd: bool = False,
     ) -> Dict[str, Any]:
         """Format comparison results for evaluator compatibility.
-        
+
         Args:
             result: Standard comparison result from compare_with
             other: The other model being compared
             recall_with_fd: Whether to include FD in recall denominator
-            
+
         Returns:
             Dictionary in evaluator format with overall, fields, confusion_matrix
         """
         return EvaluatorFormatHelper.format_for_evaluator(
             self, result, other, recall_with_fd
         )
-    
+
     def _calculate_list_item_metrics(
         self,
         field_name: str,
@@ -2762,46 +2528,46 @@ class StructuredModel(BaseModel):
         recall_with_fd: bool = False,
     ) -> List[Dict[str, Any]]:
         """Calculate metrics for individual items in a list field.
-        
+
         Args:
             field_name: Name of the list field
             gt_list: Ground truth list
             pred_list: Prediction list
             recall_with_fd: Whether to include FD in recall denominator
-            
+
         Returns:
             List of metrics dictionaries for each matched item pair
         """
         return EvaluatorFormatHelper.calculate_list_item_metrics(
             field_name, gt_list, pred_list, recall_with_fd
         )
-    
+
     @classmethod
     def model_json_schema(cls, **kwargs):
         """Override to add model-level comparison metadata.
-        
+
         Extends the standard Pydantic JSON schema with comparison metadata
         at the field level.
-        
+
         Args:
             **kwargs: Arguments to pass to the parent method
-            
+
         Returns:
             JSON schema with added comparison metadata
         """
         schema = super().model_json_schema(**kwargs)
-        
+
         # Add comparison metadata to each field in the schema
         for field_name, field_info in cls.model_fields.items():
             if field_name == "extra_fields":
                 continue
-                
+
             # Get the schema property for this field
             if field_name not in schema.get("properties", {}):
                 continue
-                
+
             field_props = schema["properties"][field_name]
-            
+
             # Since ComparableField is now always a function, check for json_schema_extra
             if hasattr(field_info, "json_schema_extra") and callable(
                 field_info.json_schema_extra
@@ -2809,120 +2575,9 @@ class StructuredModel(BaseModel):
                 # Fallback: Check for json_schema_extra function
                 temp_schema = {}
                 field_info.json_schema_extra(temp_schema)
-                
+
                 if "x-comparison" in temp_schema:
                     # Copy the comparison metadata from the temp schema to the real schema
                     field_props["x-comparison"] = temp_schema["x-comparison"]
-        
+
         return schema
-    
-    def _calculate_aggregate_metrics(self, confusion_matrix: Dict[str, Any]) -> Dict[str, Any]:
-        """Calculate universal aggregate metrics by summing from aggregate sections.
-        
-        This method implements the universal aggregate functionality by:
-        1. Summing field-level "aggregate" metrics to compute root-level aggregate totals
-        2. Ensuring consistency between field-level and root-level aggregate calculations
-        3. Using "aggregate" sections instead of "overall" sections for universal aggregation
-        
-        Args:
-            confusion_matrix: The confusion matrix result from compare_recursive
-            
-        Returns:
-            Updated confusion matrix with universal aggregate metrics added
-        """
-        # Create a copy to avoid modifying the original
-        result = confusion_matrix.copy()
-        
-        # First, recursively calculate aggregate sections for all nested fields
-        result = self._calculate_nested_aggregate_sections(result)
-        
-        # Calculate root-level aggregate metrics by summing field-level aggregate metrics
-        root_aggregate = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
-        
-        # Process all fields to sum their aggregate contributions
-        if "fields" in result:
-            for field_name, field_data in result["fields"].items():
-                if isinstance(field_data, dict) and "aggregate" in field_data:
-                    for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                        root_aggregate[metric] += field_data["aggregate"].get(metric, 0)
-        
-        # Add the calculated aggregate metrics to the root level
-        result["aggregate"] = root_aggregate
-        
-        return result
-    
-    def _calculate_nested_aggregate_sections(self, result: Dict[str, Any]) -> Dict[str, Any]:
-        """Calculate aggregate sections for all nested fields by summing their child contributions.
-        
-        This method recursively processes the confusion matrix structure and calculates
-        aggregate sections for fields that have nested fields by summing the aggregate
-        contributions from their children. It preserves existing aggregate sections that
-        are already correctly set by the threshold-gated recursion logic.
-        
-        Args:
-            result: The confusion matrix result structure
-            
-        Returns:
-            Updated result with calculated aggregate sections
-        """
-        if "fields" in result:
-            for field_name, field_data in result["fields"].items():
-                if isinstance(field_data, dict):
-                    # Recursively process nested fields first
-                    if "fields" in field_data and len(field_data["fields"]) > 0:
-                        field_data = self._calculate_nested_aggregate_sections(field_data)
-                        
-                        # For parent fields with non-empty nested fields, calculate aggregate by summing children's aggregates
-                        nested_aggregate = self._expand_hierarchical_field_metrics(field_data["fields"])
-                        
-                        # Only use nested aggregate if it has meaningful data
-                        if any(nested_aggregate.get(metric, 0) > 0 for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]):
-                            field_data["aggregate"] = nested_aggregate
-                        elif "aggregate" not in field_data and "overall" in field_data:
-                            # Fallback to overall if nested fields don't contribute
-                            field_data["aggregate"] = field_data["overall"].copy()
-                        
-                    elif "aggregate" not in field_data and "overall" in field_data:
-                        # For leaf fields or fields with empty nested fields, aggregate should match overall
-                        field_data["aggregate"] = field_data["overall"].copy()
-                    
-                    # Update the field data in the result
-                    result["fields"][field_name] = field_data
-        
-        return result
-    
-    def _expand_hierarchical_field_metrics(self, fields_dict: Dict[str, Any]) -> Dict[str, int]:
-        """Expand hierarchical field metrics by summing nested field contributions to aggregate section.
-        
-        This method recursively processes nested fields and sums their aggregate contributions
-        to support universal aggregate calculation for hierarchical structures.
-        
-        Args:
-            fields_dict: Dictionary of field data with potential nested structures
-            
-        Returns:
-            Dictionary with summed aggregate metrics from all nested levels
-        """
-        aggregate_sum = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
-        
-        for field_name, field_data in fields_dict.items():
-            if isinstance(field_data, dict):
-                # If field has an aggregate section, use it (it already represents the sum of nested fields)
-                if "aggregate" in field_data:
-                    field_aggregate = field_data["aggregate"]
-                    for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                        aggregate_sum[metric] += field_aggregate.get(metric, 0)
-                
-                # If field doesn't have aggregate but has nested fields, recurse into nested fields
-                elif "fields" in field_data and len(field_data["fields"]) > 0:
-                    nested_sum = self._expand_hierarchical_field_metrics(field_data["fields"])
-                    for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                        aggregate_sum[metric] += nested_sum.get(metric, 0)
-                
-                # If field has neither aggregate nor nested fields, use overall
-                elif "overall" in field_data:
-                    field_overall = field_data["overall"]
-                    for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                        aggregate_sum[metric] += field_overall.get(metric, 0)
-        
-        return aggregate_sum

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -38,7 +38,7 @@ from .evaluator_format_helper import EvaluatorFormatHelper
 
 class StructuredModel(BaseModel):
     """Base class for models with structured comparison capabilities.
-
+    
     This class extends Pydantic's BaseModel with the ability to compare
     instances using configurable comparison metrics for each field.
     It supports:
@@ -49,31 +49,31 @@ class StructuredModel(BaseModel):
     - Unordered list comparison using Hungarian matching
     - Retention of extra fields not defined in the model
     """
-
+    
     # Default match threshold - can be overridden in subclasses
     match_threshold: ClassVar[float] = 0.7
-
+    
     extra_fields: Dict[str, Any] = Field(default_factory=dict, exclude=True)
-
+    
     model_config = {
         "arbitrary_types_allowed": True,
         "extra": "allow",  # Allow extra fields to be stored in extra_fields
     }
-
+    
     def __init_subclass__(cls, **kwargs):
         """Validate field configurations when a StructuredModel subclass is defined."""
         super().__init_subclass__(**kwargs)
-
+        
         # Validate field configurations using class annotations since model_fields isn't populated yet
         if hasattr(cls, "__annotations__"):
             for field_name, field_type in cls.__annotations__.items():
                 if field_name == "extra_fields":
                     continue
-
+                
                 # Get the field default value if it exists
                 field_default = getattr(cls, field_name, None)
-
-                # Since ComparableField is now always a function that returns a Field,
+                
+                # Since ComparableField is now always a function that returns a Field, 
                 # we need to check if field_default has comparison metadata
                 if hasattr(field_default, "json_schema_extra") and callable(
                     field_default.json_schema_extra
@@ -85,7 +85,7 @@ class StructuredModel(BaseModel):
                         # This field was created with ComparableField function - validate constraints
                         if cls._is_list_of_structured_model_type(field_type):
                             comparison_config = temp_schema["x-comparison"]
-
+                            
                             # Threshold validation - only flag if explicitly set to non-default value
                             threshold = comparison_config.get("threshold", 0.5)
                             if threshold != 0.5:  # Default threshold value
@@ -95,7 +95,7 @@ class StructuredModel(BaseModel):
                                     f"StructuredModel's 'match_threshold' class attribute instead. "
                                     f"Set 'match_threshold = {threshold}' on the list element class."
                                 )
-
+                            
                             # Comparator validation - only flag if explicitly set to non-default type
                             comparator_type = comparison_config.get(
                                 "comparator_type", "LevenshteinComparator"
@@ -108,14 +108,14 @@ class StructuredModel(BaseModel):
                                     f"'comparator' parameter in ComparableField. Object comparison uses each "
                                     f"StructuredModel's individual field comparators instead."
                                 )
-
+    
     @classmethod
     def _is_list_of_structured_model_type(cls, field_type) -> bool:
         """Check if a field type annotation represents List[StructuredModel].
-
+        
         Args:
             field_type: The field type annotation
-
+            
         Returns:
             True if the field is a List[StructuredModel] type
         """
@@ -132,46 +132,46 @@ class StructuredModel(BaseModel):
                     )
                 except (TypeError, AttributeError):
                     return False
-
+        
         # Handle Union types (like Optional[List[StructuredModel]])
         elif origin is Union:
             args = get_args(field_type)
             for arg in args:
                 if cls._is_list_of_structured_model_type(arg):
                     return True
-
+        
         return False
-
+    
     @classmethod
     def from_json(cls, json_data: Dict[str, Any]) -> "StructuredModel":
         """Create a StructuredModel instance from JSON data.
-
+        
         This method handles missing fields gracefully and stores extra fields
         in the extra_fields attribute.
-
+        
         Args:
             json_data: Dictionary containing the JSON data
-
+            
         Returns:
             StructuredModel instance created from the JSON data
         """
         return ConfigurationHelper.from_json(cls, json_data)
-
+    
     @classmethod
     def model_from_json(cls, config: Dict[str, Any]) -> Type["StructuredModel"]:
         """Create a StructuredModel subclass from JSON configuration using Pydantic's create_model().
-
+        
         This method leverages Pydantic's native dynamic model creation capabilities to ensure
         full compatibility with all Pydantic features while adding structured comparison
         functionality through inherited StructuredModel methods.
-
+        
         The generated model inherits all StructuredModel capabilities:
         - compare_with() method for detailed comparisons
-        - Field-level comparison configuration
+        - Field-level comparison configuration  
         - Hungarian algorithm for list matching
         - Confusion matrix generation
         - JSON schema with comparison metadata
-
+        
         Args:
             config: JSON configuration with fields, comparators, and model settings.
                    Required keys:
@@ -179,7 +179,7 @@ class StructuredModel(BaseModel):
                    Optional keys:
                    - model_name: Name for the generated class (default: "DynamicModel")
                    - match_threshold: Overall matching threshold (default: 0.7)
-
+                   
                    Field configuration format:
                    {
                        "type": "str|int|float|bool|List[str]|etc.",  # Required
@@ -192,14 +192,14 @@ class StructuredModel(BaseModel):
                        "alias": "field_alias",  # Optional
                        "examples": ["example1", "example2"]  # Optional
                    }
-
+                   
         Returns:
             A fully functional StructuredModel subclass created with create_model()
-
+            
         Raises:
             ValueError: If configuration is invalid or contains unsupported types/comparators
             KeyError: If required configuration keys are missing
-
+            
         Examples:
             >>> config = {
             ...     "model_name": "Product",
@@ -207,7 +207,7 @@ class StructuredModel(BaseModel):
             ...     "fields": {
             ...         "name": {
             ...             "type": "str",
-            ...             "comparator": "LevenshteinComparator",
+            ...             "comparator": "LevenshteinComparator", 
             ...             "threshold": 0.8,
             ...             "weight": 2.0,
             ...             "required": True
@@ -231,44 +231,44 @@ class StructuredModel(BaseModel):
         """
         from pydantic import create_model
         from .field_converter import convert_fields_config, validate_fields_config
-
+        
         # Validate configuration structure
         if not isinstance(config, dict):
             raise ValueError("Configuration must be a dictionary")
-
+        
         if "fields" not in config:
             raise ValueError("Configuration must contain 'fields' key")
-
+        
         fields_config = config["fields"]
         if not isinstance(fields_config, dict) or len(fields_config) == 0:
             raise ValueError("'fields' must be a non-empty dictionary")
-
+        
         # Validate all field configurations before proceeding (including nested schema validation)
         try:
             from .field_converter import get_global_converter
 
             converter = get_global_converter()
-
+            
             # First validate basic field configurations
             validate_fields_config(fields_config)
-
+            
             # Then validate nested schema rules
             for field_name, field_config in fields_config.items():
                 converter.validate_nested_field_schema(field_name, field_config)
-
+                
         except ValueError as e:
             raise ValueError(f"Invalid field configuration: {e}")
-
+        
         # Extract model configuration
         model_name = config.get("model_name", "DynamicModel")
         match_threshold = config.get("match_threshold", 0.7)
-
+        
         # Validate model name
         if not isinstance(model_name, str) or not model_name.isidentifier():
             raise ValueError(
                 f"model_name must be a valid Python identifier, got: {model_name}"
             )
-
+        
         # Validate match threshold
         if not isinstance(match_threshold, (int, float)) or not (
             0.0 <= match_threshold <= 1.0
@@ -276,13 +276,13 @@ class StructuredModel(BaseModel):
             raise ValueError(
                 f"match_threshold must be a number between 0.0 and 1.0, got: {match_threshold}"
             )
-
+        
         # Convert field configurations to Pydantic field definitions
         try:
             field_definitions = convert_fields_config(fields_config)
         except ValueError as e:
             raise ValueError(f"Error converting field configurations: {e}")
-
+        
         # Create the dynamic model extending StructuredModel
         try:
             DynamicClass = create_model(
@@ -292,34 +292,34 @@ class StructuredModel(BaseModel):
             )
         except Exception as e:
             raise ValueError(f"Error creating dynamic model: {e}")
-
+        
         # Set class-level attributes
         DynamicClass.match_threshold = match_threshold
-
+        
         # Add configuration metadata for debugging/introspection
         DynamicClass._model_config = config
-
+        
         return DynamicClass
-
+    
     @classmethod
     def _is_structured_field_type(cls, field_info) -> bool:
         """Check if a field represents a structured type that needs special handling.
-
+        
         Args:
             field_info: Pydantic field info object
-
+            
         Returns:
             True if the field is a List[StructuredModel] or StructuredModel type
         """
         return ConfigurationHelper.is_structured_field_type(field_info)
-
+    
     @classmethod
     def _get_comparison_info(cls, field_name: str) -> ComparableField:
         """Extract comparison info from a field.
-
+        
         Args:
             field_name: Name of the field to get comparison info for
-
+            
         Returns:
             ComparableField object with comparison configuration
         """
@@ -328,29 +328,19 @@ class StructuredModel(BaseModel):
     # Remove legacy ComparableField handling since ComparableField is now always a function
     # that returns proper Pydantic Fields
     pass
-
+    
     # No special __init__ needed since ComparableField is now always a function
     # that returns proper Pydantic Fields
     pass
+    
 
-    @classmethod
-    def _is_aggregate_field(cls, field_name: str) -> bool:
-        """Check if field is marked for confusion matrix aggregation.
-
-        Args:
-            field_name: Name of the field to check
-
-        Returns:
-            True if the field is marked for aggregation, False otherwise
-        """
-        return ConfigurationHelper.is_aggregate_field(cls, field_name)
 
     def _is_truly_null(self, val: Any) -> bool:
         """Check if a value is truly null (None).
-
+        
         Args:
             val: Value to check
-
+            
         Returns:
             True if the value is None, False otherwise
         """
@@ -358,14 +348,14 @@ class StructuredModel(BaseModel):
 
     def _should_use_hierarchical_structure(self, val: Any, field_name: str) -> bool:
         """Check if a list value should maintain hierarchical structure.
-
+        
         For lists, we need to check if they should maintain hierarchical structure
         based on their field type configuration.
-
+        
         Args:
             val: Value to check (typically a list)
             field_name: Name of the field being evaluated
-
+            
         Returns:
             True if the value should use hierarchical structure, False otherwise
         """
@@ -377,24 +367,27 @@ class StructuredModel(BaseModel):
         return False
 
     def _is_effectively_null_for_lists(self, val: Any) -> bool:
-        """Check if a list value is effectively null (None or empty list).
-
+        """Check if a list value is effectively null (None, empty list, or empty string).
+        
+        For list fields, empty strings should be treated as equivalent to empty lists
+        since both represent the absence of data.
+        
         Args:
             val: Value to check
-
+            
         Returns:
-            True if the value is None or an empty list, False otherwise
+            True if the value is None, an empty list, or an empty string, False otherwise
         """
-        return val is None or (isinstance(val, list) and len(val) == 0)
+        return val is None or (isinstance(val, list) and len(val) == 0) or (isinstance(val, str) and val == "")
 
     def _is_effectively_null_for_primitives(self, val: Any) -> bool:
         """Check if a primitive value is effectively null.
-
+        
         Treats empty strings and None as equivalent for string fields.
-
+        
         Args:
             val: Value to check
-
+            
         Returns:
             True if the value is None or an empty string, False otherwise
         """
@@ -402,17 +395,17 @@ class StructuredModel(BaseModel):
 
     def _is_list_field(self, field_name: str) -> bool:
         """Check if a field is ANY list type.
-
+        
         Args:
             field_name: Name of the field to check
-
+            
         Returns:
             True if the field is a list type (List[str], List[StructuredModel], etc.)
         """
         field_info = self.__class__.model_fields.get(field_name)
         if not field_info:
             return False
-
+            
         field_type = field_info.annotation
         # Handle Optional types and direct List types
         if hasattr(field_type, "__origin__"):
@@ -432,18 +425,18 @@ class StructuredModel(BaseModel):
         self, gt_val: Any, pred_val: Any, weight: float
     ) -> dict:
         """Handle list field comparison using match statements.
-
+        
         Args:
             gt_val: Ground truth list value
             pred_val: Predicted list value
             weight: Field weight for scoring
-
+            
         Returns:
             Comparison result dictionary
         """
         gt_effectively_null = self._is_effectively_null_for_lists(gt_val)
         pred_effectively_null = self._is_effectively_null_for_lists(pred_val)
-
+        
         match (gt_effectively_null, pred_effectively_null):
             case (True, True):
                 # Both None or empty lists → True Negative
@@ -501,17 +494,34 @@ class StructuredModel(BaseModel):
                 # Both non-null and non-empty, return None to continue processing
                 return None
 
-    def _create_true_negative_result(self, weight: float) -> dict:
+    def _create_true_negative_result(self, weight: float, field_name: str = None) -> dict:
         """Create a true negative result.
-
+        
         Args:
             weight: Field weight for scoring
-
+            field_name: Name of the field (for hierarchical field detection)
+            
         Returns:
             True negative result dictionary
         """
+        tn_count = 1
+        
+        # CRITICAL FIX: For hierarchical fields, count nested field contributions
+        if field_name:
+            field_info = self.__class__.model_fields.get(field_name)
+            if field_info and self._is_structured_field_type(field_info):
+                # This is a hierarchical field - count nested fields
+                from typing import get_origin, get_args
+                field_type = field_info.annotation if hasattr(field_info, 'annotation') else None
+                if field_type and get_origin(field_type) is list:
+                    args = get_args(field_type)
+                    if args and hasattr(args[0], 'model_fields'):
+                        nested_model_class = args[0]
+                        nested_field_count = len([f for f in nested_model_class.model_fields.keys() if f != 'extra_fields'])
+                        tn_count += nested_field_count  # Both GT and Pred are None, so count nested fields as TN
+        
         return {
-            "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 1, "fn": 0},
+            "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": tn_count, "fn": 0},
             "fields": {},
             "raw_similarity_score": 1.0,
             "similarity_score": 1.0,
@@ -519,17 +529,41 @@ class StructuredModel(BaseModel):
             "weight": weight,
         }
 
-    def _create_false_alarm_result(self, weight: float) -> dict:
+    def _create_false_alarm_result(self, weight: float, field_name: str = None, pred_val: Any = None) -> dict:
         """Create a false alarm result.
-
+        
         Args:
             weight: Field weight for scoring
-
+            field_name: Name of the field (for hierarchical field detection)
+            pred_val: Predicted value (for counting nested fields)
+            
         Returns:
             False alarm result dictionary
         """
+        fa_count = 1
+        fp_count = 1
+        
+        # CRITICAL FIX: For hierarchical fields, count nested field contributions
+        if field_name and pred_val is not None:
+            field_info = self.__class__.model_fields.get(field_name)
+            if field_info and self._is_structured_field_type(field_info):
+                # This is a hierarchical field - count nested fields
+                from typing import get_origin, get_args
+                field_type = field_info.annotation if hasattr(field_info, 'annotation') else None
+                if field_type and get_origin(field_type) is list:
+                    args = get_args(field_type)
+                    if args and hasattr(args[0], 'model_fields'):
+                        nested_model_class = args[0]
+                        nested_field_count = len([f for f in nested_model_class.model_fields.keys() if f != 'extra_fields'])
+                        
+                        # Count the list items and their nested fields
+                        if isinstance(pred_val, list):
+                            list_length = len(pred_val)
+                            fa_count += list_length * nested_field_count
+                            fp_count += list_length * nested_field_count
+        
         return {
-            "overall": {"tp": 0, "fa": 1, "fd": 0, "fp": 1, "tn": 0, "fn": 0},
+            "overall": {"tp": 0, "fa": fa_count, "fd": 0, "fp": fp_count, "tn": 0, "fn": 0},
             "fields": {},
             "raw_similarity_score": 0.0,
             "similarity_score": 0.0,
@@ -537,17 +571,39 @@ class StructuredModel(BaseModel):
             "weight": weight,
         }
 
-    def _create_false_negative_result(self, weight: float) -> dict:
+    def _create_false_negative_result(self, weight: float, field_name: str = None, gt_val: Any = None) -> dict:
         """Create a false negative result.
-
+        
         Args:
             weight: Field weight for scoring
-
+            field_name: Name of the field (for hierarchical field detection)
+            gt_val: Ground truth value (for counting nested fields)
+            
         Returns:
             False negative result dictionary
         """
+        fn_count = 1
+        
+        # CRITICAL FIX: For hierarchical fields, count nested field contributions
+        if field_name and gt_val is not None:
+            field_info = self.__class__.model_fields.get(field_name)
+            if field_info and self._is_structured_field_type(field_info):
+                # This is a hierarchical field - count nested fields
+                from typing import get_origin, get_args
+                field_type = field_info.annotation if hasattr(field_info, 'annotation') else None
+                if field_type and get_origin(field_type) is list:
+                    args = get_args(field_type)
+                    if args and hasattr(args[0], 'model_fields'):
+                        nested_model_class = args[0]
+                        nested_field_count = len([f for f in nested_model_class.model_fields.keys() if f != 'extra_fields'])
+                        
+                        # Count the list items and their nested fields
+                        if isinstance(gt_val, list):
+                            list_length = len(gt_val)
+                            fn_count += list_length * nested_field_count
+        
         return {
-            "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 1},
+            "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": fn_count},
             "fields": {},
             "raw_similarity_score": 0.0,
             "similarity_score": 0.0,
@@ -562,19 +618,19 @@ class StructuredModel(BaseModel):
         weight: float,
     ) -> dict:
         """Handle empty list cases with beautiful match statements.
-
+        
         Args:
             gt_list: Ground truth list (may be None)
-            pred_list: Predicted list (may be None)
+            pred_list: Predicted list (may be None) 
             weight: Field weight for scoring
-
+            
         Returns:
             Result dictionary if early exit needed, None if should continue processing
         """
         # Normalize None to empty lists for consistent handling
         gt_len = len(gt_list or [])
         pred_len = len(pred_list or [])
-
+        
         match (gt_len, pred_len):
             case (0, 0):
                 # Both empty lists → True Negative
@@ -631,12 +687,12 @@ class StructuredModel(BaseModel):
         match_threshold: float,
     ) -> tuple:
         """Calculate object-level metrics using Hungarian matching.
-
+        
         Args:
             gt_list: Ground truth list
             pred_list: Predicted list
             match_threshold: Threshold for considering objects as matches
-
+            
         Returns:
             Tuple of (object_metrics_dict, matched_pairs, matched_gt_indices, matched_pred_indices)
         """
@@ -644,7 +700,7 @@ class StructuredModel(BaseModel):
         hungarian_helper = HungarianHelper()
         hungarian_info = hungarian_helper.get_complete_matching_info(gt_list, pred_list)
         matched_pairs = hungarian_info["matched_pairs"]
-
+        
         # Count OBJECTS, not individual fields
         tp_objects = 0  # Objects with similarity >= match_threshold
         fd_objects = 0  # Objects with similarity < match_threshold
@@ -653,7 +709,7 @@ class StructuredModel(BaseModel):
                 tp_objects += 1
             else:
                 fd_objects += 1
-
+        
         # Count unmatched objects
         matched_gt_indices = {idx for idx, _, _ in matched_pairs}
         matched_pred_indices = {idx for _, idx, _ in matched_pairs}
@@ -661,17 +717,17 @@ class StructuredModel(BaseModel):
         fa_objects = len(pred_list) - len(
             matched_pred_indices
         )  # Unmatched pred objects
-
+        
         # Build list-level metrics counting OBJECTS (not fields)
         object_level_metrics = {
             "tp": tp_objects,
-            "fa": fa_objects,
+            "fa": fa_objects,  
             "fd": fd_objects,
             "fp": fa_objects + fd_objects,  # Total false positives
             "tn": 0,  # No true negatives at object level for non-empty lists
             "fn": fn_objects,
         }
-
+        
         return (
             object_level_metrics,
             matched_pairs,
@@ -686,12 +742,12 @@ class StructuredModel(BaseModel):
         info: "ComparableField",
     ) -> float:
         """Calculate raw similarity score for structured list.
-
+        
         Args:
             gt_list: Ground truth list
             pred_list: Predicted list
             info: Field comparison info
-
+            
         Returns:
             Raw similarity score between 0.0 and 1.0
         """
@@ -704,7 +760,7 @@ class StructuredModel(BaseModel):
             return 0.0
 
     # Necessary/sufficient field methods removed - no longer used
-
+    
     def _compare_unordered_lists(
         self,
         list1: List[Any],
@@ -713,13 +769,13 @@ class StructuredModel(BaseModel):
         threshold: float,
     ) -> Dict[str, Any]:
         """Compare two lists as unordered collections using Hungarian matching.
-
+        
         Args:
             list1: First list
             list2: Second list
             comparator: Comparator to use for item comparison
             threshold: Minimum score to consider a match
-
+            
         Returns:
             Dictionary with confusion matrix metrics including:
             - tp: True positives (matches >= threshold)
@@ -735,17 +791,17 @@ class StructuredModel(BaseModel):
 
     def compare_field(self, field_name: str, other_value: Any) -> float:
         """Compare a single field with a value using the configured comparator.
-
+        
         Args:
             field_name: Name of the field to compare
             other_value: Value to compare with
-
+            
         Returns:
             Similarity score between 0.0 and 1.0
         """
         # Get our field value
         my_value = getattr(self, field_name)
-
+        
         # If both values are StructuredModel instances, use recursive compare_with
         if isinstance(my_value, StructuredModel) and isinstance(
             other_value, StructuredModel
@@ -753,9 +809,9 @@ class StructuredModel(BaseModel):
             # Use compare_with for rich comparison
             comparison_result = my_value.compare_with(
                 other_value,
-                include_confusion_matrix=False,
-                document_non_matches=False,
-                evaluator_format=False,
+                                                    include_confusion_matrix=False,
+                                                    document_non_matches=False,
+                                                    evaluator_format=False,
                 recall_with_fd=False,
             )
             # Apply field-level threshold if configured
@@ -766,40 +822,40 @@ class StructuredModel(BaseModel):
                 if raw_score >= info.threshold or not info.clip_under_threshold
                 else 0.0
             )
-
+        
         # CRITICAL FIX: For lists, don't clip under threshold for partial matches
         if isinstance(my_value, list) and isinstance(other_value, list):
             # Get field info
             info = self._get_comparison_info(field_name)
-
+            
             # Use the raw comparison result without threshold clipping for lists
             result = ComparisonHelper.compare_unordered_lists(
                 my_value, other_value, info.comparator, info.threshold
             )
-
+            
             # Return the overall score directly (don't clip based on threshold for lists)
             return result["overall_score"]
-
+        
         # For other fields, use existing logic
         return ComparisonHelper.compare_field_with_threshold(
             self, field_name, other_value
         )
-
+    
     def compare_field_raw(self, field_name: str, other_value: Any) -> float:
         """Compare a single field with a value WITHOUT applying thresholds.
-
+        
         This version is used by the compare method to get raw similarity scores.
-
+        
         Args:
             field_name: Name of the field to compare
             other_value: Value to compare with
-
+            
         Returns:
             Raw similarity score between 0.0 and 1.0 without threshold filtering
         """
         # Get our field value
         my_value = getattr(self, field_name)
-
+        
         # If both values are StructuredModel instances, use recursive compare_with
         if isinstance(my_value, StructuredModel) and isinstance(
             other_value, StructuredModel
@@ -807,25 +863,25 @@ class StructuredModel(BaseModel):
             # Use compare_with for rich comparison, but extract the raw score
             comparison_result = my_value.compare_with(
                 other_value,
-                include_confusion_matrix=False,
-                document_non_matches=False,
-                evaluator_format=False,
+                                                    include_confusion_matrix=False,
+                                                    document_non_matches=False,
+                                                    evaluator_format=False,
                 recall_with_fd=False,
             )
             return comparison_result["overall_score"]
-
+        
         # For non-StructuredModel fields, use existing logic
         return ComparisonHelper.compare_field_raw(self, field_name, other_value)
-
+    
     def compare_recursive(self, other: "StructuredModel") -> dict:
         """The ONE clean recursive function that handles everything.
-
+        
         Enhanced to capture BOTH confusion matrix metrics AND similarity scores
         in a single traversal to eliminate double traversal inefficiency.
-
+        
         Args:
             other: Another instance of the same model to compare with
-
+            
         Returns:
             Dictionary with clean hierarchical structure:
             - overall: TP, FP, TN, FN, FD, FA counts + similarity_score + all_fields_matched
@@ -846,48 +902,48 @@ class StructuredModel(BaseModel):
             "fields": {},
             "non_matches": [],
         }
-
+        
         # Score percolation variables
         total_score = 0.0
         total_weight = 0.0
         threshold_matched_fields = set()
-
+        
         for field_name in self.__class__.model_fields:
             if field_name == "extra_fields":
                 continue
-
+                
             gt_val = getattr(self, field_name)
             pred_val = getattr(other, field_name, None)
-
+            
             # Enhanced dispatch returns both metrics AND scores
             field_result = self._dispatch_field_comparison(field_name, gt_val, pred_val)
-
+            
             result["fields"][field_name] = field_result
-
+            
             # Simple aggregation to overall metrics
             self._aggregate_to_overall(field_result, result["overall"])
-
+            
             # Score percolation - aggregate scores upward
             if "similarity_score" in field_result and "weight" in field_result:
                 weight = field_result["weight"]
                 threshold_applied_score = field_result["threshold_applied_score"]
                 total_score += threshold_applied_score * weight
                 total_weight += weight
-
+                
                 # Track threshold-matched fields
                 info = self._get_comparison_info(field_name)
                 if field_result["raw_similarity_score"] >= info.threshold:
                     threshold_matched_fields.add(field_name)
-
+        
         # CRITICAL FIX: Handle hallucinated fields (extra fields) as False Alarms
         extra_fields_fa = self._count_extra_fields_as_false_alarms(other)
         result["overall"]["fa"] += extra_fields_fa
         result["overall"]["fp"] += extra_fields_fa
-
+        
         # Calculate overall similarity score from percolated scores
         if total_weight > 0:
             result["overall"]["similarity_score"] = total_score / total_weight
-
+        
         # Determine all_fields_matched
         model_fields_for_comparison = set(self.__class__.model_fields.keys()) - {
             "extra_fields"
@@ -895,22 +951,22 @@ class StructuredModel(BaseModel):
         result["overall"]["all_fields_matched"] = len(threshold_matched_fields) == len(
             model_fields_for_comparison
         )
-
+        
         return result
-
+    
     def _dispatch_field_comparison(
         self, field_name: str, gt_val: Any, pred_val: Any
     ) -> dict:
         """Enhanced case-based dispatch using match statements for clean logic flow."""
-
+        
         # Get field configuration for scoring
         info = self._get_comparison_info(field_name)
         weight = info.weight
         threshold = info.threshold
-
+        
         # Check if this field is ANY list type (including Optional[List[str]], Optional[List[StructuredModel]], etc.)
         is_list_field = self._is_list_field(field_name)
-
+        
         # Get null states and hierarchical needs
         gt_is_null = self._is_truly_null(gt_val)
         pred_is_null = self._is_truly_null(pred_val)
@@ -918,32 +974,32 @@ class StructuredModel(BaseModel):
         pred_needs_hierarchy = self._should_use_hierarchical_structure(
             pred_val, field_name
         )
-
+        
         # Handle list fields with match statements
         if is_list_field:
             list_result = self._handle_list_field_dispatch(gt_val, pred_val, weight)
             if list_result is not None:
                 return list_result
             # If None returned, continue to regular type-based dispatch
-
+        
         # Handle non-hierarchical primitive null cases with match statements
         if not (gt_needs_hierarchy or pred_needs_hierarchy):
             gt_effectively_null_prim = self._is_effectively_null_for_primitives(gt_val)
             pred_effectively_null_prim = self._is_effectively_null_for_primitives(
                 pred_val
             )
-
+            
             match (gt_effectively_null_prim, pred_effectively_null_prim):
                 case (True, True):
-                    return self._create_true_negative_result(weight)
+                    return self._create_true_negative_result(weight, field_name)
                 case (True, False):
-                    return self._create_false_alarm_result(weight)
+                    return self._create_false_alarm_result(weight, field_name, pred_val)
                 case (False, True):
-                    return self._create_false_negative_result(weight)
+                    return self._create_false_negative_result(weight, field_name, gt_val)
                 case _:
                     # Both non-null, continue to type-based dispatch
                     pass
-
+        
         # Type-based dispatch
         if isinstance(gt_val, (str, int, float)) and isinstance(
             pred_val, (str, int, float)
@@ -972,7 +1028,7 @@ class StructuredModel(BaseModel):
                     gt_val, pred_val, field_name
                 )
         elif isinstance(pred_val, list) and len(pred_val) == 0:
-            # Handle empty pred list - check if it should be structured
+            # Handle empty pred list - check if it should be structured  
             field_info = self.__class__.model_fields.get(field_name)
             if field_info and self._is_structured_field_type(field_info):
                 # Empty structured list - should still return hierarchical structure
@@ -986,27 +1042,27 @@ class StructuredModel(BaseModel):
         elif isinstance(gt_val, StructuredModel) and isinstance(
             pred_val, StructuredModel
         ):
-            # CRITICAL FIX: For StructuredModel fields, object-level metrics should be based on
+            # CRITICAL FIX: For StructuredModel fields, object-level metrics should be based on 
             # object similarity, not rollup of nested field metrics
-
+            
             # Get object-level similarity score
             raw_score = gt_val.compare(pred_val)  # Overall object similarity
-
+            
             # Apply object-level binary classification based on threshold
             if raw_score >= threshold:
                 # Object matches threshold -> True Positive
                 object_metrics = {"tp": 1, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
                 threshold_applied_score = raw_score
             else:
-                # Object below threshold -> False Discovery
+                # Object below threshold -> False Discovery  
                 object_metrics = {"tp": 0, "fa": 0, "fd": 1, "fp": 1, "tn": 0, "fn": 0}
                 threshold_applied_score = (
                     0.0 if info.clip_under_threshold else raw_score
                 )
-
+            
             # Still generate nested field details for debugging, but don't roll them up
             nested_details = gt_val.compare_recursive(pred_val)["fields"]
-
+            
             # Return structure with object-level metrics and nested field details kept separate
             return {
                 "overall": {
@@ -1016,7 +1072,7 @@ class StructuredModel(BaseModel):
                 },
                 "fields": nested_details,  # Nested details available for debugging
                 "raw_similarity_score": raw_score,
-                "similarity_score": raw_score,
+                "similarity_score": raw_score, 
                 "threshold_applied_score": threshold_applied_score,
                 "weight": weight,
                 "non_matches": [],  # Add empty non_matches for consistency
@@ -1031,7 +1087,7 @@ class StructuredModel(BaseModel):
                 "threshold_applied_score": 0.0,
                 "weight": weight,
             }
-
+    
     def _compare_primitive_with_scores(
         self, gt_val: Any, pred_val: Any, field_name: str
     ) -> dict:
@@ -1040,7 +1096,7 @@ class StructuredModel(BaseModel):
         raw_similarity = info.comparator.compare(gt_val, pred_val)
         weight = info.weight
         threshold = info.threshold
-
+        
         # For binary classification metrics, always use threshold
         if raw_similarity >= threshold:
             metrics = {"tp": 1, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
@@ -1051,7 +1107,7 @@ class StructuredModel(BaseModel):
             threshold_applied_score = (
                 0.0 if info.clip_under_threshold else raw_similarity
             )
-
+        
         # UNIFIED STRUCTURE: Always use 'overall' for metrics
         # 'fields' key omitted for primitive leaf nodes (semantic meaning: not a parent container)
         return {
@@ -1061,32 +1117,32 @@ class StructuredModel(BaseModel):
             "threshold_applied_score": threshold_applied_score,
             "weight": weight,
         }
-
+    
     def _compare_primitive_list_with_scores(
         self, gt_list: List[Any], pred_list: List[Any], field_name: str
     ) -> dict:
         """Enhanced primitive list comparison that returns both metrics AND scores with hierarchical structure.
-
+        
         DESIGN DECISION: Universal Hierarchical Structure
         ===============================================
-        This method returns a hierarchical structure {"overall": {...}, "fields": {...}} even for
+        This method returns a hierarchical structure {"overall": {...}, "fields": {...}} even for 
         primitive lists (List[str], List[int], etc.) to maintain API consistency across all field types.
-
+        
         Why this approach:
         - CONSISTENCY: All list fields use the same access pattern: cm["fields"][name]["overall"]
         - TEST COMPATIBILITY: Multiple test files expect this pattern for both primitive and structured lists
         - PREDICTABLE API: Consumers don't need to check field type before accessing metrics
-
+        
         Trade-offs:
         - Creates vestigial "fields": {} objects for primitive lists that will never be populated
         - Slightly more verbose structure than necessary for leaf nodes
         - Architecturally less pure than type-based structure (primitives flat, structured hierarchical)
-
+        
         Alternative considered but rejected:
         - Type-based structure where List[primitive] → flat, List[StructuredModel] → hierarchical
         - Would require updating multiple test files and consumer code to handle mixed access patterns
         - More architecturally pure but breaks backward compatibility
-
+        
         Future consideration: If we ever refactor the entire confusion matrix API, we could move to
         type-based structure where the presence of "fields" key indicates structured vs primitive.
         """
@@ -1094,14 +1150,14 @@ class StructuredModel(BaseModel):
         info = self.__class__._get_comparison_info(field_name)
         weight = info.weight
         threshold = info.threshold
-
+        
         # CRITICAL FIX: Handle None values before checking length
         # Convert None to empty list for consistent handling
         if gt_list is None:
             gt_list = []
         if pred_list is None:
             pred_list = []
-
+        
         # Handle empty/null list cases first - FIXED: Empty lists should be TN=1
         if len(gt_list) == 0 and len(pred_list) == 0:
             # Both empty lists should be TN=1
@@ -1131,7 +1187,7 @@ class StructuredModel(BaseModel):
                 "weight": weight,
             }
         elif len(pred_list) == 0:
-            # GT has items, pred empty → False Negatives
+            # GT has items, pred empty → False Negatives  
             return {
                 "overall": {
                     "tp": 0,
@@ -1147,26 +1203,26 @@ class StructuredModel(BaseModel):
                 "threshold_applied_score": 0.0,
                 "weight": weight,
             }
-
+        
         # For primitive lists, use the comparison logic from _compare_unordered_lists
         # which properly handles the threshold-based matching
         comparator = info.comparator
         match_result = self._compare_unordered_lists(
             gt_list, pred_list, comparator, threshold
         )
-
+        
         # Extract the counts from the match result
         tp = match_result.get("tp", 0)
-        fd = match_result.get("fd", 0)
+        fd = match_result.get("fd", 0) 
         fa = match_result.get("fa", 0)
         fn = match_result.get("fn", 0)
-
+        
         # Use the overall_score from the match result for raw similarity
         raw_similarity = match_result.get("overall_score", 0.0)
-
+        
         # CRITICAL FIX: For lists, we NEVER clip under threshold - partial matches are important
         threshold_applied_score = raw_similarity  # Always use raw score for lists
-
+        
         # Return hierarchical structure expected by tests
         return {
             "overall": {"tp": tp, "fa": fa, "fd": fd, "fp": fa + fd, "tn": 0, "fn": fn},
@@ -1176,7 +1232,7 @@ class StructuredModel(BaseModel):
             "threshold_applied_score": threshold_applied_score,
             "weight": weight,
         }
-
+    
     def _compare_struct_list_with_scores(
         self,
         gt_list: List["StructuredModel"],
@@ -1184,48 +1240,48 @@ class StructuredModel(BaseModel):
         field_name: str,
     ) -> dict:
         """Enhanced structural list comparison that returns both metrics AND scores.
-
+        
         PHASE 2: Delegates to StructuredListComparator while maintaining identical behavior.
         """
         # Import here to avoid circular imports
         from .structured_list_comparator import StructuredListComparator
-
+        
         # Create comparator and delegate
         comparator = StructuredListComparator(self)
         return comparator.compare_struct_list_with_scores(
             gt_list, pred_list, field_name
         )
-
+    
     def _count_extra_fields_as_false_alarms(self, other: "StructuredModel") -> int:
         """Count hallucinated fields (extra fields) in the prediction as False Alarms.
-
+        
         Args:
             other: The predicted StructuredModel instance to check for extra fields
-
+            
         Returns:
             Number of hallucinated fields that should count as False Alarms
         """
         fa_count = 0
-
+        
         # Check if the other model has extra fields (hallucinated content)
         if hasattr(other, "__pydantic_extra__"):
             # Count each extra field as one False Alarm
             fa_count += len(other.__pydantic_extra__)
-
+        
         # Also recursively check nested StructuredModel objects for extra fields
         for field_name in self.__class__.model_fields:
             if field_name == "extra_fields":
                 continue
-
+                
             gt_val = getattr(self, field_name, None)
             pred_val = getattr(other, field_name, None)
-
+            
             # Check nested StructuredModel objects
             if isinstance(gt_val, StructuredModel) and isinstance(
                 pred_val, StructuredModel
             ):
                 fa_count += gt_val._count_extra_fields_as_false_alarms(pred_val)
-
+            
             # Check lists of StructuredModel objects
             elif (
                 isinstance(gt_val, list)
@@ -1236,14 +1292,14 @@ class StructuredModel(BaseModel):
                 and isinstance(pred_val[0], StructuredModel)
             ):
                 # For lists, we need to match them up properly using Hungarian matching - OPTIMIZED: Single call gets all info
-                # to avoid double-counting in cases where the list comparison already
+                # to avoid double-counting in cases where the list comparison already 
                 # handles unmatched items as FA. For now, let's recursively check each item.
                 hungarian_helper = HungarianHelper()
                 hungarian_info = hungarian_helper.get_complete_matching_info(
                     gt_val, pred_val
                 )
                 matched_pairs = hungarian_info["matched_pairs"]
-
+                
                 # Count extra fields in matched pairs
                 for gt_idx, pred_idx, similarity in matched_pairs:
                     if gt_idx < len(gt_val) and pred_idx < len(pred_val):
@@ -1252,7 +1308,7 @@ class StructuredModel(BaseModel):
                         fa_count += gt_item._count_extra_fields_as_false_alarms(
                             pred_item
                         )
-
+                
                 # For unmatched prediction items, count their extra fields too
                 matched_pred_indices = {pred_idx for _, pred_idx, _ in matched_pairs}
                 for pred_idx, pred_item in enumerate(pred_val):
@@ -1269,9 +1325,9 @@ class StructuredModel(BaseModel):
                             # If no GT items, count all extra fields in this pred item
                             if hasattr(pred_item, "__pydantic_extra__"):
                                 fa_count += len(pred_item.__pydantic_extra__)
-
+        
         return fa_count
-
+    
     def _aggregate_to_overall(self, field_result: dict, overall: dict) -> None:
         """Simple aggregation to overall metrics."""
         for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
@@ -1280,29 +1336,93 @@ class StructuredModel(BaseModel):
                     overall[metric] += field_result[metric]
                 elif "overall" in field_result and metric in field_result["overall"]:
                     overall[metric] += field_result["overall"][metric]
+    
+    def _collect_all_primitive_metrics(self, node: dict, path: str = "") -> dict:
+        """Collect ALL primitive field metrics from entire subtree.
+        
+        This method performs a comprehensive traversal to find all primitive confusion matrix
+        metrics, including those from Hungarian matching results and deeply nested structures.
+        It uses a comprehensive approach to ensure all metrics are collected.
+        
+        CRITICAL FIX: Now properly handles both 'nested_fields' from Hungarian matching results
+        and regular 'fields' structures to ensure all primitive metrics are included in aggregates.
+        
+        Args:
+            node: Dictionary node to traverse
+            path: Current path for debugging/logging
+            
+        Returns:
+            Dictionary with aggregated primitive counts: {tp, fa, fd, fp, tn, fn}
+        """
+        total_counts = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
+        
+        if not isinstance(node, dict):
+            return total_counts
+        
+        # Check if this node has subfields
+        has_subfields = ("fields" in node and 
+                        isinstance(node["fields"], dict) and 
+                        len(node["fields"]) > 0)
+        
+        # Check for nested_fields from Hungarian matching (legacy structure)
+        has_nested_fields = ("nested_fields" in node and 
+                           isinstance(node["nested_fields"], dict) and 
+                           len(node["nested_fields"]) > 0)
+        
+        # CRITICAL FIX: For nodes with subfields, we need to recursively collect from all children
+        if has_subfields:
+            # This is a parent node - collect from children to avoid double counting
+            for field_name, field_data in node["fields"].items():
+                if isinstance(field_data, dict):
+                    child_counts = self._collect_all_primitive_metrics(field_data, f"{path}.{field_name}" if path else field_name)
+                    for metric in total_counts:
+                        total_counts[metric] += child_counts[metric]
+        
+        # CRITICAL FIX: For nodes with nested_fields (Hungarian matching results), 
+        # we should use nested_fields instead of fields for more accurate metrics
+        if has_nested_fields:
+            # This is a Hungarian matching result node - collect from nested_fields
+            # These contain the individual field metrics from matched pairs and include TN counts
+            for nested_field_name, nested_field_data in node["nested_fields"].items():
+                if isinstance(nested_field_data, dict) and self._has_basic_metrics(nested_field_data):
+                    # These are primitive metrics from individual fields within matched objects
+                    for metric in total_counts:
+                        total_counts[metric] += nested_field_data.get(metric, 0)
+            # If we have nested_fields, don't also collect from fields to avoid double counting
+            return total_counts
+        
+        # If this is a leaf node (no subfields and no nested_fields), collect its metrics
+        if not has_subfields and not has_nested_fields:
+            if "overall" in node and isinstance(node["overall"], dict) and self._has_basic_metrics(node["overall"]):
+                # Hierarchical leaf node: collect from overall
+                overall = node["overall"]
+                for metric in total_counts:
+                    total_counts[metric] += overall.get(metric, 0)
+            elif self._has_basic_metrics(node):
+                # Flat leaf node: collect directly
+                for metric in total_counts:
+                    total_counts[metric] += node.get(metric, 0)
+        
+        return total_counts
 
     def _calculate_aggregate_metrics(self, result: dict) -> dict:
         """Calculate aggregate metrics for all nodes in the result tree.
-
-        CRITICAL FIX: Enhanced deep nesting traversal to handle arbitrary nesting depth.
-        The aggregate field contains the sum of all primitive field confusion matrices
-        below that node in the tree. This provides universal field-level granularity.
-
+        
+        CRITICAL FIX: Now uses comprehensive primitive metric collection to ensure
+        all leaf-level metrics are included in aggregates, including Hungarian matching results.
+        
         Args:
             result: Result from compare_recursive with hierarchical structure
-
+            
         Returns:
             Modified result with 'aggregate' fields added at each level
         """
         if not isinstance(result, dict):
             return result
-
+        
         # Make a copy to avoid modifying the original
         result_copy = result.copy()
-
-        # Calculate aggregate for this node
-        aggregate_metrics = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
-
+        
         # Recursively process 'fields' first to get child aggregates
         if "fields" in result_copy and isinstance(result_copy["fields"], dict):
             fields_copy = {}
@@ -1311,112 +1431,48 @@ class StructuredModel(BaseModel):
                     # Recursively calculate aggregate for child field
                     processed_field = self._calculate_aggregate_metrics(field_result)
                     fields_copy[field_name] = processed_field
-
-                    # CRITICAL FIX: Sum child's aggregate metrics to parent
-                    if "aggregate" in processed_field and self._has_basic_metrics(
-                        processed_field["aggregate"]
-                    ):
-                        child_aggregate = processed_field["aggregate"]
-                        for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                            aggregate_metrics[metric] += child_aggregate.get(metric, 0)
                 else:
                     # Non-dict field - keep as is
                     fields_copy[field_name] = field_result
             result_copy["fields"] = fields_copy
-
-        # CRITICAL FIX: Enhanced leaf node detection for deep nesting
-        # Handle both empty fields dict and missing fields key as leaf indicators
-        is_leaf_node = (
-            "fields" not in result_copy
-            or not result_copy["fields"]
-            or (
-                isinstance(result_copy["fields"], dict)
-                and len(result_copy["fields"]) == 0
-            )
-        )
-
-        if is_leaf_node:
-            # Check if this is a leaf node with basic metrics (either in "overall" or directly)
-            if "overall" in result_copy and self._has_basic_metrics(
-                result_copy["overall"]
-            ):
-                # Hierarchical leaf node: aggregate = overall metrics
-                overall = result_copy["overall"]
-                for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                    aggregate_metrics[metric] = overall.get(metric, 0)
-            elif self._has_basic_metrics(result_copy):
-                # CRITICAL FIX: Legacy primitive leaf node - wrap in "overall" structure
-                # This preserves Universal Aggregate Field structure compliance
-                legacy_metrics = {}
-                for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                    legacy_metrics[metric] = result_copy.get(metric, 0)
-                    aggregate_metrics[metric] = result_copy.get(metric, 0)
-
-                # Wrap legacy structure in "overall" key to maintain consistency
-                if not "overall" in result_copy:
-                    # Move all basic metrics to "overall" key
-                    result_copy["overall"] = legacy_metrics
-                    # Remove basic metrics from top level to avoid duplication
-                    for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                        if metric in result_copy:
-                            del result_copy[metric]
-                    # Preserve other keys like derived, raw_similarity_score, etc.
-
-        # CRITICAL FIX: Always sum child field metrics if no child aggregates were found
-        # This handles the deep nesting case where leaf nodes have overall metrics but empty fields
-        if (
-            aggregate_metrics["tp"] == 0
-            and aggregate_metrics["fa"] == 0
-            and aggregate_metrics["fd"] == 0
-            and aggregate_metrics["fp"] == 0
-            and aggregate_metrics["tn"] == 0
-            and aggregate_metrics["fn"] == 0
-        ):
-            # Check if we have fields with overall metrics that we can sum
-            if "fields" in result_copy and isinstance(result_copy["fields"], dict):
-                for field_name, field_result in result_copy["fields"].items():
-                    if isinstance(field_result, dict):
-                        # ENHANCED: Check for both direct metrics and overall metrics
-                        if "overall" in field_result and self._has_basic_metrics(
-                            field_result["overall"]
-                        ):
-                            field_overall = field_result["overall"]
-                            for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                                aggregate_metrics[metric] += field_overall.get(
-                                    metric, 0
-                                )
-                        elif self._has_basic_metrics(field_result):
-                            # Direct metrics (legacy format)
-                            for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                                aggregate_metrics[metric] += field_result.get(metric, 0)
-
-        # Add aggregate as a sibling of 'overall' and 'fields'
-        result_copy["aggregate"] = aggregate_metrics
-
+        
+        # CRITICAL FIX: Use comprehensive primitive metric collection
+        # This ensures ALL primitive metrics are included, including Hungarian matching results
+        aggregate_metrics = self._collect_all_primitive_metrics(result_copy)
+        
+        # Only add aggregate if this node has subfields (non-leaf nodes)
+        has_subfields = ("fields" in result_copy and 
+                        isinstance(result_copy["fields"], dict) and 
+                        len(result_copy["fields"]) > 0)
+        
+        if has_subfields or any(aggregate_metrics.values()):
+            # Add aggregate as a sibling of 'overall' and 'fields'
+            result_copy["aggregate"] = aggregate_metrics
+        
         return result_copy
-
+    
     def _add_derived_metrics_to_result(self, result: dict) -> dict:
         """Walk through result and add 'derived' fields with F1, precision, recall, accuracy.
-
+        
         Args:
             result: Result from compare_recursive with basic TP, FP, FN, etc. metrics
-
+            
         Returns:
             Modified result with 'derived' fields added at each level
         """
         if not isinstance(result, dict):
             return result
-
+        
         # Make a copy to avoid modifying the original
         result_copy = result.copy()
-
+        
         # Add derived metrics to 'overall' if it exists and has basic metrics
         if "overall" in result_copy and isinstance(result_copy["overall"], dict):
             overall = result_copy["overall"]
             if self._has_basic_metrics(overall):
                 metrics_helper = MetricsHelper()
                 overall["derived"] = metrics_helper.calculate_derived_metrics(overall)
-
+                
                 # Also add derived metrics to aggregate if it exists
                 if "aggregate" in overall and self._has_basic_metrics(
                     overall["aggregate"]
@@ -1424,7 +1480,7 @@ class StructuredModel(BaseModel):
                     overall["aggregate"]["derived"] = (
                         metrics_helper.calculate_derived_metrics(overall["aggregate"])
                     )
-
+        
         # Add derived metrics to top-level aggregate if it exists
         if "aggregate" in result_copy and self._has_basic_metrics(
             result_copy["aggregate"]
@@ -1433,7 +1489,7 @@ class StructuredModel(BaseModel):
             result_copy["aggregate"]["derived"] = (
                 metrics_helper.calculate_derived_metrics(result_copy["aggregate"])
             )
-
+        
         # Recursively process 'fields' if it exists
         if "fields" in result_copy and isinstance(result_copy["fields"], dict):
             fields_copy = {}
@@ -1456,7 +1512,7 @@ class StructuredModel(BaseModel):
                                 field_result["overall"]
                             )
                         )
-
+                        
                         # Also add derived metrics to aggregate if it exists
                         if "aggregate" in field_copy and self._has_basic_metrics(
                             field_copy["aggregate"]
@@ -1466,28 +1522,28 @@ class StructuredModel(BaseModel):
                                     field_copy["aggregate"]
                                 )
                             )
-
+                        
                         fields_copy[field_name] = field_copy
                     elif self._has_basic_metrics(field_result):
                         # CRITICAL FIX: Legacy leaf field with basic metrics - wrap in "overall" structure
                         field_copy = field_result.copy()
                         metrics_helper = MetricsHelper()
-
+                        
                         # Extract basic metrics and wrap in "overall" structure
                         legacy_metrics = {}
                         for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
                             if metric in field_copy:
                                 legacy_metrics[metric] = field_copy[metric]
                                 del field_copy[metric]  # Remove from top level
-
+                        
                         # Add derived metrics to the legacy metrics
                         legacy_metrics["derived"] = (
                             metrics_helper.calculate_derived_metrics(legacy_metrics)
                         )
-
+                        
                         # Wrap in "overall" structure
                         field_copy["overall"] = legacy_metrics
-
+                        
                         fields_copy[field_name] = field_copy
                     else:
                         # Other structure - keep as is
@@ -1496,48 +1552,48 @@ class StructuredModel(BaseModel):
                     # Non-dict field - keep as is
                     fields_copy[field_name] = field_result
             result_copy["fields"] = fields_copy
-
+        
         return result_copy
-
+    
     def _has_basic_metrics(self, metrics_dict: dict) -> bool:
         """Check if a dictionary has basic confusion matrix metrics.
-
+        
         Args:
             metrics_dict: Dictionary to check
-
+            
         Returns:
             True if it has the basic metrics (tp, fp, fn, etc.)
         """
         basic_metrics = ["tp", "fp", "fn", "tn", "fa", "fd"]
         return all(metric in metrics_dict for metric in basic_metrics)
-
+    
     def _classify_field_for_confusion_matrix(
         self, field_name: str, other_value: Any, threshold: float = None
     ) -> Dict[str, Any]:
         """Classify a field comparison according to the confusion matrix rules.
-
+        
         Args:
             field_name: Name of the field being compared
             other_value: Value to compare with
             threshold: Threshold for matching (uses field's threshold if None)
-
+            
         Returns:
             Dictionary with TP, FP, TN, FN, FD counts and derived metrics
         """
         # Get field values
         gt_value = getattr(self, field_name)
         pred_value = other_value
-
-        # Get field configuration
+        
+        # Get field configuration 
         info = self.__class__._get_comparison_info(field_name)
         if threshold is None:
             threshold = info.threshold
         comparator = info.comparator
-
+        
         # Determine if values are null
         gt_is_null = FieldHelper.is_null_value(gt_value)
         pred_is_null = FieldHelper.is_null_value(pred_value)
-
+        
         # Calculate similarity if both aren't null
         similarity = None
         if not gt_is_null and not pred_is_null:
@@ -1552,40 +1608,109 @@ class StructuredModel(BaseModel):
             values_match = similarity >= threshold
         else:
             values_match = False
-
+        
         # Apply confusion matrix classification
         if gt_is_null and pred_is_null:
             # TN: Both null
-            result = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 1, "fn": 0}
+            tn_count = 1
+            # CRITICAL FIX: For hierarchical fields, count nested field contributions
+            field_info = self.__class__.model_fields.get(field_name)
+            if field_info and self._is_structured_field_type(field_info):
+                from typing import get_origin, get_args, Union
+                field_type = field_info.annotation if hasattr(field_info, 'annotation') else None
+                if field_type:
+                    # Handle Union types (e.g., Union[List[CodeDescription], None, Any])
+                    if get_origin(field_type) is Union:
+                        # Find the List type in the Union
+                        for arg in get_args(field_type):
+                            if get_origin(arg) is list:
+                                field_type = arg
+                                break
+                    
+                    if get_origin(field_type) is list:
+                        args = get_args(field_type)
+                        if args and hasattr(args[0], 'model_fields'):
+                            nested_model_class = args[0]
+                            nested_field_count = len([f for f in nested_model_class.model_fields.keys() if f != 'extra_fields'])
+                            tn_count += nested_field_count
+            result = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": tn_count, "fn": 0}
         elif gt_is_null and not pred_is_null:
             # FA: GT null, prediction non-null (False Alarm)
-            result = {"tp": 0, "fa": 1, "fd": 0, "fp": 1, "tn": 0, "fn": 0}
+            fa_count = 1
+            fp_count = 1
+            # CRITICAL FIX: For hierarchical fields, count nested field contributions
+            field_info = self.__class__.model_fields.get(field_name)
+            if field_info and self._is_structured_field_type(field_info):
+                from typing import get_origin, get_args, Union
+                field_type = field_info.annotation if hasattr(field_info, 'annotation') else None
+                if field_type:
+                    # Handle Union types (e.g., Union[List[CodeDescription], None, Any])
+                    if get_origin(field_type) is Union:
+                        # Find the List type in the Union
+                        for arg in get_args(field_type):
+                            if get_origin(arg) is list:
+                                field_type = arg
+                                break
+                    
+                    if get_origin(field_type) is list:
+                        args = get_args(field_type)
+                        if args and hasattr(args[0], 'model_fields'):
+                            nested_model_class = args[0]
+                            nested_field_count = len([f for f in nested_model_class.model_fields.keys() if f != 'extra_fields'])
+                            if isinstance(pred_value, list):
+                                list_length = len(pred_value)
+                                fa_count += list_length * nested_field_count
+                                fp_count += list_length * nested_field_count
+            result = {"tp": 0, "fa": fa_count, "fd": 0, "fp": fp_count, "tn": 0, "fn": 0}
         elif not gt_is_null and pred_is_null:
             # FN: GT non-null, prediction null
-            result = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 1}
+            fn_count = 1
+            # CRITICAL FIX: For hierarchical fields, count nested field contributions
+            field_info = self.__class__.model_fields.get(field_name)
+            if field_info and self._is_structured_field_type(field_info):
+                from typing import get_origin, get_args, Union
+                field_type = field_info.annotation if hasattr(field_info, 'annotation') else None
+                if field_type:
+                    # Handle Union types (e.g., Union[List[CodeDescription], None, Any])
+                    if get_origin(field_type) is Union:
+                        # Find the List type in the Union
+                        for arg in get_args(field_type):
+                            if get_origin(arg) is list:
+                                field_type = arg
+                                break
+                    
+                    if get_origin(field_type) is list:
+                        args = get_args(field_type)
+                        if args and hasattr(args[0], 'model_fields'):
+                            nested_model_class = args[0]
+                            nested_field_count = len([f for f in nested_model_class.model_fields.keys() if f != 'extra_fields'])
+                            if isinstance(gt_value, list):
+                                list_length = len(gt_value)
+                                fn_count += list_length * nested_field_count
+            result = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": fn_count}
         elif values_match:
             # TP: Both non-null and match
             result = {"tp": 1, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
         else:
             # FD: Both non-null but don't match (False Discovery)
             result = {"tp": 0, "fa": 0, "fd": 1, "fp": 1, "tn": 0, "fn": 0}
-
+        
         # Add derived metrics
         metrics_helper = MetricsHelper()
         result["derived"] = metrics_helper.calculate_derived_metrics(result)
         # Don't include similarity_score in the result as tests don't expect it
-
+        
         return result
-
+    
     def _calculate_list_confusion_matrix(
         self, field_name: str, other_list: List[Any]
     ) -> Dict[str, Any]:
         """Calculate confusion matrix for a list field, including nested field metrics.
-
+        
         Args:
             field_name: Name of the list field being compared
             other_list: Predicted list to compare with
-
+            
         Returns:
             Dictionary with:
             - Top-level TP, FP, TN, FN, FD, FA counts and derived metrics for the list field
@@ -1594,7 +1719,7 @@ class StructuredModel(BaseModel):
         """
         gt_list = getattr(self, field_name)
         pred_list = other_list
-
+        
         # Initialize result structure
         result = {
             "tp": 0,
@@ -1606,7 +1731,7 @@ class StructuredModel(BaseModel):
             "nested_fields": {},  # Store nested field metrics here
             "non_matches": [],  # Store individual object-level non-matches here
         }
-
+        
         # Handle null cases first
         if FieldHelper.is_null_value(gt_list) and FieldHelper.is_null_value(pred_list):
             result.update({"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 1, "fn": 0})
@@ -1640,28 +1765,28 @@ class StructuredModel(BaseModel):
             info = self.__class__._get_comparison_info(field_name)
             comparator = info.comparator
             threshold = info.threshold
-
+            
             # Reuse existing Hungarian matching logic
             match_result = self._compare_unordered_lists(
                 gt_list, pred_list, comparator, threshold
             )
-
+            
             # Use the detailed confusion matrix results directly from Hungarian matcher
             result.update(
                 {
-                    "tp": match_result["tp"],
+                "tp": match_result["tp"],
                     "fa": match_result[
                         "fa"
                     ],  # False alarms (unmatched prediction items)
                     "fd": match_result[
                         "fd"
                     ],  # False discoveries (matches below threshold)
-                    "fp": match_result["fp"],  # Total false positives (fa + fd)
-                    "tn": 0,
+                "fp": match_result["fp"],  # Total false positives (fa + fd)
+                "tn": 0,
                     "fn": match_result["fn"],  # False negatives (unmatched GT items)
                 }
             )
-
+            
             # Collect individual object-level non-matches using NonMatchesHelper
             if gt_list and isinstance(gt_list[0], StructuredModel):
                 non_matches_helper = NonMatchesHelper()
@@ -1669,7 +1794,7 @@ class StructuredModel(BaseModel):
                     field_name, gt_list, pred_list
                 )
                 result["non_matches"] = non_matches
-
+            
             # If list contains StructuredModel objects, calculate nested field metrics
             if gt_list and isinstance(gt_list[0], StructuredModel):
                 nested_metrics = self._calculate_nested_field_metrics(
@@ -1681,32 +1806,15 @@ class StructuredModel(BaseModel):
         # List level metrics represent object-level matches from Hungarian algorithm
         # Nested field metrics represent field-level matches within those objects
         # They are separate concerns and should not be aggregated
+        
 
-        # Only aggregate if this is explicitly marked as an aggregate field AND it's not a list
-        is_aggregate = self.__class__._is_aggregate_field(field_name)
-        if is_aggregate and not isinstance(gt_list, list):
-            # Initialize top-level confusion matrix values to 0
-            result["tp"] = 0
-            result["fa"] = 0
-            result["fd"] = 0
-            result["fp"] = 0
-            result["tn"] = 0
-            result["fn"] = 0
-            # Sum up the confusion matrix values from nested fields
-            for field, field_metrics in result["nested_fields"].items():
-                result["tp"] += field_metrics["tp"]
-                result["fa"] += field_metrics["fa"]
-                result["fd"] += field_metrics["fd"]
-                result["fp"] += field_metrics["fp"]
-                result["tn"] += field_metrics["tn"]
-                result["fn"] += field_metrics["fn"]
-
-        # Add derived metrics
+        
+        # Add derived metrics  
         metrics_helper = MetricsHelper()
         result["derived"] = metrics_helper.calculate_derived_metrics(result)
-
+        
         return result
-
+    
     def _calculate_nested_field_metrics(
         self,
         list_field_name: str,
@@ -1715,47 +1823,47 @@ class StructuredModel(BaseModel):
         threshold: float,
     ) -> Dict[str, Dict[str, Any]]:
         """Calculate confusion matrix metrics for individual fields within list items.
-
+        
         THRESHOLD-GATED RECURSION: Only perform recursive field analysis for object pairs
-        with similarity >= StructuredModel.match_threshold. Poor matches and unmatched
+        with similarity >= StructuredModel.match_threshold. Poor matches and unmatched 
         items are treated as atomic units.
-
+        
         Args:
             list_field_name: Name of the parent list field (e.g., "transactions")
             gt_list: Ground truth list of StructuredModel objects
             pred_list: Predicted list of StructuredModel objects
             threshold: Matching threshold (not used for threshold-gating)
-
+            
         Returns:
             Dictionary mapping nested field paths to their confusion matrix metrics
             E.g., {"transactions.date": {...}, "transactions.description": {...}}
         """
         nested_metrics = {}
-
+        
         if not gt_list or not isinstance(gt_list[0], StructuredModel):
             return nested_metrics
-
+        
         # Get the model class from the first item
         model_class = gt_list[0].__class__
-
+        
         # CRITICAL FIX: Use field's threshold, not class's match_threshold
         # Get the field info from the parent object to use the correct threshold
         parent_field_info = self.__class__._get_comparison_info(list_field_name)
         match_threshold = parent_field_info.threshold
-
+        
         # For each field in the nested model
         for field_name in model_class.model_fields:
             if field_name == "extra_fields":
                 continue
-
+                
             nested_field_path = f"{list_field_name}.{field_name}"
-
+            
             # Initialize aggregated counts for this nested field
             total_tp = total_fa = total_fd = total_fp = total_tn = total_fn = 0
-
+            
             # Use HungarianHelper for Hungarian matching operations - OPTIMIZED: Single call gets all info
             hungarian_helper = HungarianHelper()
-
+            
             # Use HungarianHelper to get optimal assignments with similarity scores
             assignments = []
             matched_pairs_with_scores = []
@@ -1766,25 +1874,25 @@ class StructuredModel(BaseModel):
                 matched_pairs_with_scores = hungarian_info["matched_pairs"]
                 # Extract (gt_idx, pred_idx) pairs from the matched_pairs
                 assignments = [(i, j) for i, j, score in matched_pairs_with_scores]
-
+            
             # THRESHOLD-GATED RECURSION: Only process pairs that meet the match_threshold
             for gt_idx, pred_idx, similarity_score in matched_pairs_with_scores:
                 if gt_idx < len(gt_list) and pred_idx < len(pred_list):
                     gt_item = gt_list[gt_idx]
                     pred_item = pred_list[pred_idx]
-
+                    
                     # Handle floating point precision issues
                     is_above_threshold = (
                         similarity_score >= match_threshold
                         or abs(similarity_score - match_threshold) < 1e-10
                     )
-
+                    
                     # Only perform recursive field analysis if similarity meets threshold
                     if is_above_threshold:
                         # Get field values
                         gt_value = getattr(gt_item, field_name, None)
                         pred_value = getattr(pred_item, field_name, None)
-
+                        
                         # Check if this field is a List[StructuredModel] that needs recursive processing
                         if (
                             isinstance(gt_value, list)
@@ -1798,7 +1906,7 @@ class StructuredModel(BaseModel):
                                     field_name, pred_value
                                 )
                             )
-
+                            
                             # Aggregate the list-level counts
                             total_tp += list_classification["tp"]
                             total_fa += list_classification["fa"]
@@ -1806,7 +1914,7 @@ class StructuredModel(BaseModel):
                             total_fp += list_classification["fp"]
                             total_tn += list_classification["tn"]
                             total_fn += list_classification["fn"]
-
+                            
                             # IMPORTANT: Also collect the deeper nested field metrics
                             if "nested_fields" in list_classification:
                                 for (
@@ -1817,7 +1925,7 @@ class StructuredModel(BaseModel):
                                     full_deeper_path = (
                                         f"{list_field_name}.{deeper_field_path}"
                                     )
-
+                                    
                                     # Initialize or aggregate into the deeper nested metrics
                                     if full_deeper_path not in nested_metrics:
                                         nested_metrics[full_deeper_path] = {
@@ -1828,7 +1936,7 @@ class StructuredModel(BaseModel):
                                             "tn": 0,
                                             "fn": 0,
                                         }
-
+                                    
                                     nested_metrics[full_deeper_path]["tp"] += (
                                         deeper_metrics["tp"]
                                     )
@@ -1856,7 +1964,7 @@ class StructuredModel(BaseModel):
                                     None,  # Use field's own threshold
                                 )
                             )
-
+                            
                             # Aggregate counts
                             total_tp += field_classification["tp"]
                             total_fa += field_classification["fa"]
@@ -1868,7 +1976,7 @@ class StructuredModel(BaseModel):
                         # Skip recursive analysis for pairs below threshold
                         # These will be handled as FD at the object level
                         pass
-
+            
             # Handle unmatched ground truth items (false negatives)
             matched_gt_indices = set(idx for idx, _ in assignments)
             for gt_idx, gt_item in enumerate(gt_list):
@@ -1884,7 +1992,7 @@ class StructuredModel(BaseModel):
                             # For List[StructuredModel], count each item in the list as a separate FN
                             # and handle deeper nested fields
                             total_fn += len(gt_value)  # Each list item is a separate FN
-
+                            
                             # Also handle deeper nested fields for unmatched items
                             dummy_empty_list = []  # Empty list for comparison
                             list_classification = (
@@ -1915,7 +2023,7 @@ class StructuredModel(BaseModel):
                         else:
                             # Handle primitive fields or single StructuredModel fields
                             total_fn += 1
-
+            
             # Handle unmatched prediction items (false alarms)
             matched_pred_indices = set(idx for _, idx in assignments)
             for pred_idx, pred_item in enumerate(pred_list):
@@ -1936,7 +2044,7 @@ class StructuredModel(BaseModel):
                             total_fp += len(
                                 pred_value
                             )  # Each list item is also a separate FP
-
+                            
                             # Also handle deeper nested fields for unmatched items
                             dummy_empty_list = []  # Empty list for comparison
                             # We need to create a dummy GT item for comparison to get the structure
@@ -1974,7 +2082,7 @@ class StructuredModel(BaseModel):
                             # Handle primitive fields or single StructuredModel fields
                             total_fa += 1
                             total_fp += 1
-
+            
             # Store the aggregated metrics for this nested field
             nested_metrics[nested_field_path] = {
                 "tp": total_tp,
@@ -1994,7 +2102,7 @@ class StructuredModel(BaseModel):
                     }
                 ),
             }
-
+        
         # Add derived metrics for all deeper nested fields that were collected
         for deeper_path, deeper_metrics in nested_metrics.items():
             if deeper_path != nested_field_path and "derived" not in deeper_metrics:
@@ -2008,30 +2116,24 @@ class StructuredModel(BaseModel):
                         "fn": deeper_metrics["fn"],
                     }
                 )
-
+        
         return nested_metrics
-
-    def _calculate_single_nested_field_metrics(
-        self,
-        parent_field_name: str,
-        gt_nested: "StructuredModel",
-        pred_nested: "StructuredModel",
-        parent_is_aggregate: bool = False,
-    ) -> Dict[str, Dict[str, Any]]:
+    
+    def _calculate_single_nested_field_metrics(self, parent_field_name: str, gt_nested: 'StructuredModel', 
+                        pred_nested: 'StructuredModel') -> Dict[str, Dict[str, Any]]:
         """Calculate confusion matrix metrics for fields within a single nested StructuredModel.
-
+        
         Args:
             parent_field_name: Name of the parent field (e.g., "address")
             gt_nested: Ground truth nested StructuredModel
             pred_nested: Predicted nested StructuredModel
-            parent_is_aggregate: Whether the parent field should aggregate child metrics
-
+            
         Returns:
             Dictionary mapping nested field paths to their confusion matrix metrics
             E.g., {"address.street": {...}, "address.city": {...}}
         """
         nested_metrics = {}
-
+        
         if not isinstance(gt_nested, StructuredModel) or not isinstance(
             pred_nested, StructuredModel
         ):
@@ -2043,35 +2145,22 @@ class StructuredModel(BaseModel):
             ):
                 return nested_metrics
             return nested_metrics
+        
 
-        # Initialize aggregation metrics for parent field if it's an aggregated field
-        parent_metrics = (
-            {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
-            if parent_is_aggregate
-            else None
-        )
-
-        # Track which fields are aggregate fields themselves to avoid double counting
-        child_aggregate_fields = set()
 
         # For each field in the nested model
         for field_name in gt_nested.__class__.model_fields:
             if field_name == "extra_fields":
                 continue
-
+                
             nested_field_path = f"{parent_field_name}.{field_name}"
+            
 
-            # Check if this nested field is itself an aggregate field
-            is_child_aggregate = False
-            if hasattr(gt_nested.__class__, "_is_aggregate_field"):
-                is_child_aggregate = gt_nested.__class__._is_aggregate_field(field_name)
-                if is_child_aggregate:
-                    child_aggregate_fields.add(field_name)
-
+            
             # Get the field value from the prediction
             pred_value = getattr(pred_nested, field_name, None)
             gt_value = getattr(gt_nested, field_name)
-
+            
             # Handle lists of StructuredModel objects
             if (
                 isinstance(gt_value, list)
@@ -2083,14 +2172,14 @@ class StructuredModel(BaseModel):
                 list_metrics = gt_nested._calculate_list_confusion_matrix(
                     field_name, pred_value
                 )
-
+                
                 # Store the metrics for this nested field
                 nested_metrics[nested_field_path] = {
                     key: value
                     for key, value in list_metrics.items()
                     if key != "nested_fields"
                 }
-
+                
                 # Add nested field metrics if available
                 if "nested_fields" in list_metrics:
                     for sub_field, sub_metrics in list_metrics["nested_fields"].items():
@@ -2101,79 +2190,39 @@ class StructuredModel(BaseModel):
                 field_classification = gt_nested._classify_field_for_confusion_matrix(
                     field_name, pred_value
                 )
-
+                
                 # Store the metrics for this nested field
                 nested_metrics[nested_field_path] = field_classification
 
                 # Recursively calculate metrics for deeper nesting
                 deeper_metrics = self._calculate_single_nested_field_metrics(
-                    nested_field_path, gt_value, pred_value, is_child_aggregate
-                )
+                    nested_field_path, gt_value, pred_value)
                 nested_metrics.update(deeper_metrics)
 
-                # If this is an aggregate child field, we need to use its aggregated metrics
-                # instead of the direct field comparison metrics
-                if is_child_aggregate and nested_field_path in deeper_metrics:
-                    # For an aggregate child field, we replace its direct metrics with
-                    # the aggregation of its children's metrics
-                    nested_metrics[nested_field_path] = deeper_metrics[
-                        nested_field_path
-                    ]
 
-            # For parent aggregation, we need to be careful not to double count metrics
-            if parent_is_aggregate:
-                if is_child_aggregate:
-                    # If child is an aggregate, use its aggregated metrics for parent
-                    if nested_field_path in deeper_metrics:
-                        child_agg_metrics = deeper_metrics[nested_field_path]
-                        for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                            parent_metrics[metric] += child_agg_metrics.get(metric, 0)
-                else:
-                    # If child is not an aggregate, use its direct field metrics
-                    field_metrics = nested_metrics[nested_field_path]
-                    for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                        parent_metrics[metric] += field_metrics.get(metric, 0)
-
-        # If parent is an aggregated field, add the aggregated metrics to the result
-        if parent_is_aggregate:
-            # Don't include metrics from child aggregate fields in the parent's metrics
-            # as they've already been counted through their own aggregation
-            for field_name in child_aggregate_fields:
-                nested_field_path = f"{parent_field_name}.{field_name}"
-                if nested_field_path in nested_metrics:
-                    # Don't double count these metrics in the parent
-                    field_metrics = nested_metrics[nested_field_path]
-                    # Subtract these metrics from parent_metrics to avoid double counting
-                    for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                        parent_metrics[metric] -= field_metrics.get(metric, 0)
-
-            nested_metrics[parent_field_name] = parent_metrics
-            # Add derived metrics
-            nested_metrics[parent_field_name]["derived"] = (
-                MetricsHelper().calculate_derived_metrics(parent_metrics)
-            )
 
         return nested_metrics
+    
+    
 
-    def _collect_enhanced_non_matches(
-        self, recursive_result: dict, other: "StructuredModel"
-    ) -> List[Dict[str, Any]]:
+    
+    def _collect_enhanced_non_matches(self, recursive_result: dict, other: 'StructuredModel') -> List[Dict[str, Any]]:
         """Collect enhanced non-matches with object-level granularity.
-
+        
         Args:
             recursive_result: Result from compare_recursive containing field comparison details
             other: The predicted StructuredModel instance
-
+            
         Returns:
             List of non-match dictionaries with enhanced object-level information
         """
         all_non_matches = []
-
+        
         # Walk through the recursive result and collect non-matches
         for field_name, field_result in recursive_result.get("fields", {}).items():
             gt_val = getattr(self, field_name)
             pred_val = getattr(other, field_name, None)
-
+            
             # Check if this is a list field that should use object-level collection
             if (
                 isinstance(gt_val, list)
@@ -2187,8 +2236,43 @@ class StructuredModel(BaseModel):
                     field_name, gt_val, pred_val
                 )
                 all_non_matches.extend(object_non_matches)
-
-            # Handle null list cases
+                
+                # NEW: Also collect field-level non-matches from within matched objects
+                # Get the Hungarian matching information to find matched pairs
+                hungarian_helper = HungarianHelper()
+                if gt_val and pred_val:
+                    hungarian_info = hungarian_helper.get_complete_matching_info(gt_val, pred_val)
+                    matched_pairs = hungarian_info["matched_pairs"]
+                    
+                    # For each matched pair, collect field-level non-matches from the individual comparison
+                    for gt_idx, pred_idx, similarity_score in matched_pairs:
+                        if gt_idx < len(gt_val) and pred_idx < len(pred_val):
+                            gt_item = gt_val[gt_idx]
+                            pred_item = pred_val[pred_idx]
+                            
+                            # Get the match threshold for this object type
+                            match_threshold = getattr(gt_item.__class__, 'match_threshold', 0.7)
+                            
+                            # Only collect field-level non-matches if this pair is above threshold (TP)
+                            # or if it's below threshold but we want to see why it failed (FD)
+                            if similarity_score >= match_threshold or similarity_score > 0.0:
+                                # Perform individual comparison to get field-level details
+                                individual_result = gt_item.compare_with(
+                                    pred_item, 
+                                    include_confusion_matrix=True, 
+                                    document_non_matches=True
+                                )
+                                
+                                # Collect field-level non-matches from the individual comparison
+                                if "non_matches" in individual_result:
+                                    for field_nm in individual_result["non_matches"]:
+                                        # Prefix the field path with the list index
+                                        indexed_field_path = f"{field_name}[{gt_idx}].{field_nm['field_path']}"
+                                        field_nm_copy = field_nm.copy()
+                                        field_nm_copy["field_path"] = indexed_field_path
+                                        all_non_matches.append(field_nm_copy)
+            
+            # Handle null list cases  
             elif (
                 (gt_val is None or (isinstance(gt_val, list) and len(gt_val) == 0))
                 and isinstance(pred_val, list)
@@ -2200,7 +2284,7 @@ class StructuredModel(BaseModel):
                     field_name, gt_val, pred_val
                 )
                 all_non_matches.extend(null_non_matches)
-
+                
             elif (
                 isinstance(gt_val, list)
                 and len(gt_val) > 0
@@ -2215,7 +2299,7 @@ class StructuredModel(BaseModel):
                     field_name, gt_val, pred_val
                 )
                 all_non_matches.extend(null_non_matches)
-
+                
             else:
                 # Use existing field-level logic for non-list fields
                 # Extract metrics from field result to determine non-match type
@@ -2225,43 +2309,66 @@ class StructuredModel(BaseModel):
                     metrics = field_result
                 else:
                     continue  # Skip if we can't extract metrics
-
-                # Create field-level non-match entries based on metrics (legacy format for backward compatibility)
-                if metrics.get("fa", 0) > 0:  # False Alarm
-                    entry = {
-                        "field_path": field_name,
-                        "non_match_type": NonMatchType.FALSE_ALARM,  # Use enum value
-                        "ground_truth_value": gt_val,
-                        "prediction_value": pred_val,
+                
+                # NEW: Collect leaf-level non_matches for primitive fields
+                helper = NonMatchesHelper()
+                
+                # Check if this is a primitive field (not a StructuredModel or list)
+                if not isinstance(gt_val, (StructuredModel, list)) and not isinstance(pred_val, (StructuredModel, list)):
+                    # This is a primitive field - collect leaf-level non_matches ONLY
+                    leaf_non_matches = helper.collect_primitive_field_non_matches(
+                        field_name, gt_val, pred_val, field_result
+                    )
+                    all_non_matches.extend(leaf_non_matches)
+                    # Skip object-level entries for primitive fields to avoid duplication
+                
+                # Check if this is a primitive list field
+                elif (isinstance(gt_val, list) and isinstance(pred_val, list) and 
+                      (not gt_val or not isinstance(gt_val[0], StructuredModel))):
+                    # This is a primitive list - collect leaf-level non_matches ONLY
+                    leaf_non_matches = helper.collect_primitive_list_non_matches(
+                        field_name, gt_val, pred_val, field_result
+                    )
+                    all_non_matches.extend(leaf_non_matches)
+                    # Skip object-level entries for primitive lists to avoid duplication
+                
+                else:
+                    # For non-primitive fields, create object-level non-match entries (legacy format for backward compatibility)
+                    if metrics.get("fa", 0) > 0:  # False Alarm
+                        entry = {
+                            "field_path": field_name,
+                            "non_match_type": NonMatchType.FALSE_ALARM,  # Use enum value
+                            "ground_truth_value": gt_val,
+                            "prediction_value": pred_val,
                         "details": {"reason": "unmatched prediction"},
-                    }
-                    all_non_matches.append(entry)
-                elif metrics.get("fn", 0) > 0:  # False Negative
-                    entry = {
-                        "field_path": field_name,
-                        "non_match_type": NonMatchType.FALSE_NEGATIVE,  # Use enum value
-                        "ground_truth_value": gt_val,
-                        "prediction_value": pred_val,
+                        }
+                        all_non_matches.append(entry)
+                    elif metrics.get("fn", 0) > 0:  # False Negative
+                        entry = {
+                            "field_path": field_name,
+                            "non_match_type": NonMatchType.FALSE_NEGATIVE,  # Use enum value
+                            "ground_truth_value": gt_val,
+                            "prediction_value": pred_val,
                         "details": {"reason": "unmatched ground truth"},
-                    }
-                    all_non_matches.append(entry)
-                elif metrics.get("fd", 0) > 0:  # False Discovery
-                    similarity = field_result.get("raw_similarity_score")
-                    entry = {
-                        "field_path": field_name,
-                        "non_match_type": NonMatchType.FALSE_DISCOVERY,  # Use enum value
-                        "ground_truth_value": gt_val,
-                        "prediction_value": pred_val,
-                        "similarity_score": similarity,
+                        }
+                        all_non_matches.append(entry)
+                    elif metrics.get("fd", 0) > 0:  # False Discovery
+                        similarity = field_result.get("raw_similarity_score")
+                        entry = {
+                            "field_path": field_name,
+                            "non_match_type": NonMatchType.FALSE_DISCOVERY,  # Use enum value
+                            "ground_truth_value": gt_val,
+                            "prediction_value": pred_val,
+                            "similarity_score": similarity,
                         "details": {"reason": "below threshold"},
-                    }
-                    if similarity is not None:
-                        info = self._get_comparison_info(field_name)
+                        }
+                        if similarity is not None:
+                            info = self._get_comparison_info(field_name)
                         entry["details"]["reason"] = (
                             f"below threshold ({similarity:.3f} < {info.threshold})"
                         )
-                    all_non_matches.append(entry)
-
+                        all_non_matches.append(entry)
+                
                 # ADDITIONAL: Handle nested StructuredModel objects for detailed non-match collection
                 if (
                     isinstance(gt_val, StructuredModel)
@@ -2278,44 +2385,68 @@ class StructuredModel(BaseModel):
                             f"{field_name}.{nested_nm['field_path']}"
                         )
                         all_non_matches.append(nested_nm)
-
+        
+        # NEW: Add hierarchical debugging support
+        if all_non_matches:
+            helper = NonMatchesHelper()
+            
+            # Add aggregate contribution tracing if we have aggregate metrics
+            if "aggregate" in recursive_result:
+                all_non_matches = helper.add_aggregate_contribution_tracing(
+                    all_non_matches, recursive_result["aggregate"]
+                )
+            
+            # Add hierarchical organization metadata
+            hierarchical_info = helper.organize_non_matches_hierarchically(all_non_matches)
+            
+            # Add debugging metadata to the first non_match entry for easy access
+            if all_non_matches:
+                all_non_matches[0]["_debugging_metadata"] = {
+                    "hierarchical_summary": hierarchical_info["summary"],
+                    "field_paths_affected": list(hierarchical_info["by_field_path"].keys()),
+                    "leaf_vs_object_breakdown": {
+                        "leaf_level": hierarchical_info["summary"]["leaf_level_count"],
+                        "object_level": hierarchical_info["summary"]["object_level_count"]
+                    }
+                }
+        
         return all_non_matches
-
+    
     def _collect_non_matches(
         self, other: "StructuredModel", base_path: str = ""
     ) -> List[NonMatchField]:
         """Collect non-matches for detailed analysis.
-
+        
         Args:
             other: Other model to compare with
             base_path: Base path for field naming (e.g., "address")
-
+            
         Returns:
             List of NonMatchField objects documenting non-matches
         """
         non_matches = []
-
+        
         # Handle null cases
         if other is None:
             non_matches.append(
                 NonMatchField(
-                    field_path=base_path or "root",
-                    non_match_type=NonMatchType.FALSE_NEGATIVE,
-                    ground_truth_value=self,
+                field_path=base_path or "root",
+                non_match_type=NonMatchType.FALSE_NEGATIVE,
+                ground_truth_value=self,
                     prediction_value=None,
                 )
             )
             return non_matches
-
+        
         # Compare each field
         for field_name in self.__class__.model_fields:
             if field_name == "extra_fields":
                 continue
-
+                
             field_path = f"{base_path}.{field_name}" if base_path else field_name
             gt_value = getattr(self, field_name)
             pred_value = getattr(other, field_name, None)
-
+            
             # Use existing field classification logic
             if type(pred_value) == list:
                 classification = self._calculate_list_confusion_matrix(
@@ -2325,38 +2456,38 @@ class StructuredModel(BaseModel):
                 classification = self._classify_field_for_confusion_matrix(
                     field_name, pred_value
                 )
-
+            
             # Document non-matches based on classification
             if classification["fa"] > 0:  # False Alarm
                 non_matches.append(
                     NonMatchField(
-                        field_path=field_path,
-                        non_match_type=NonMatchType.FALSE_ALARM,
-                        ground_truth_value=gt_value,
-                        prediction_value=pred_value,
+                    field_path=field_path,
+                    non_match_type=NonMatchType.FALSE_ALARM,
+                    ground_truth_value=gt_value,
+                    prediction_value=pred_value,
                         similarity_score=classification.get("similarity_score"),
                     )
                 )
             elif classification["fn"] > 0:  # False Negative
                 non_matches.append(
                     NonMatchField(
-                        field_path=field_path,
-                        non_match_type=NonMatchType.FALSE_NEGATIVE,
-                        ground_truth_value=gt_value,
+                    field_path=field_path,
+                    non_match_type=NonMatchType.FALSE_NEGATIVE,
+                    ground_truth_value=gt_value,
                         prediction_value=pred_value,
                     )
                 )
             elif classification["fd"] > 0:  # False Discovery
                 non_matches.append(
                     NonMatchField(
-                        field_path=field_path,
-                        non_match_type=NonMatchType.FALSE_DISCOVERY,
-                        ground_truth_value=gt_value,
-                        prediction_value=pred_value,
+                    field_path=field_path,
+                    non_match_type=NonMatchType.FALSE_DISCOVERY,
+                    ground_truth_value=gt_value,
+                    prediction_value=pred_value,
                         similarity_score=classification.get("similarity_score"),
                     )
                 )
-
+            
             # Handle nested models recursively
             if isinstance(gt_value, StructuredModel) and isinstance(
                 pred_value, StructuredModel
@@ -2365,28 +2496,28 @@ class StructuredModel(BaseModel):
                     pred_value, field_path
                 )
                 non_matches.extend(nested_non_matches)
-
+        
         return non_matches
-
+    
     def compare(self, other: "StructuredModel") -> float:
         """Compare this model with another and return a scalar similarity score.
-
+        
         Returns the overall weighted average score regardless of sufficient/necessary field matching.
         This provides a more nuanced score for use in comparators.
-
+        
         Args:
             other: Another instance of the same model to compare with
-
+            
         Returns:
             Similarity score between 0.0 and 1.0
         """
         # We'll calculate the overall weighted score directly instead of using compare_with
         # This ensures that sufficient/necessary field rules don't cause a zero score
         # when at least some fields match
-
+        
         total_score = 0.0
         total_weight = 0.0
-
+        
         for field_name in self.__class__.model_fields:
             # Skip the extra_fields attribute in comparison
             if field_name == "extra_fields":
@@ -2396,22 +2527,22 @@ class StructuredModel(BaseModel):
                 info = self.__class__._get_comparison_info(field_name)
                 # Use weight from ComparableField object
                 weight = info.weight
-
+                
                 # Compare field values WITHOUT applying thresholds
                 field_score = self.compare_field_raw(
                     field_name, getattr(other, field_name)
                 )
-
+                
                 # Update total score
                 total_score += field_score * weight
                 total_weight += weight
-
+        
         # Calculate overall score
         if total_weight > 0:
             return total_score / total_weight
         else:
             return 0.0
-
+    
     def compare_with(
         self,
         other: "StructuredModel",
@@ -2422,7 +2553,7 @@ class StructuredModel(BaseModel):
         add_derived_metrics: bool = True,
     ) -> Dict[str, Any]:
         """Compare this model with another instance using SINGLE TRAVERSAL optimization.
-
+        
         Args:
             other: Another instance of the same model to compare with
             include_confusion_matrix: Whether to include confusion matrix calculations
@@ -2431,7 +2562,7 @@ class StructuredModel(BaseModel):
             recall_with_fd: If True, include FD in recall denominator (TP/(TP+FN+FD))
                             If False, use traditional recall (TP/(TP+FN))
             add_derived_metrics: Whether to add derived metrics to confusion matrix
-
+            
         Returns:
             Dictionary with comparison results including:
             - field_scores: Scores for each field
@@ -2442,7 +2573,7 @@ class StructuredModel(BaseModel):
         """
         # SINGLE TRAVERSAL: Get everything in one pass
         recursive_result = self.compare_recursive(other)
-
+        
         # Extract scoring information from recursive result
         field_scores = {}
         for field_name, field_result in recursive_result["fields"].items():
@@ -2453,59 +2584,59 @@ class StructuredModel(BaseModel):
                 # Fallback to raw_similarity_score if threshold_applied_score not available
                 elif "raw_similarity_score" in field_result:
                     field_scores[field_name] = field_result["raw_similarity_score"]
-
+        
         # Extract overall metrics
         overall_result = recursive_result["overall"]
         overall_score = overall_result.get("similarity_score", 0.0)
         all_fields_matched = overall_result.get("all_fields_matched", False)
-
+        
         # Build basic result structure
         result = {
             "field_scores": field_scores,
             "overall_score": overall_score,
             "all_fields_matched": all_fields_matched,
         }
-
+        
         # Add optional features using already-computed recursive result
         if include_confusion_matrix:
             confusion_matrix = recursive_result
-
+            
             # Add universal aggregate metrics to all nodes
             confusion_matrix = self._calculate_aggregate_metrics(confusion_matrix)
-
+            
             # Add derived metrics if requested
             if add_derived_metrics:
                 confusion_matrix = self._add_derived_metrics_to_result(confusion_matrix)
-
+            
             result["confusion_matrix"] = confusion_matrix
-
+        
         # Add optional non-match documentation
         if document_non_matches:
             # NEW: Collect enhanced object-level non-matches
             non_matches = self._collect_enhanced_non_matches(recursive_result, other)
             result["non_matches"] = non_matches
-
+        
         # If evaluator_format is requested, transform the result
         if evaluator_format:
             return self._format_for_evaluator(result, other, recall_with_fd)
-
+            
         return result
-
+    
     def _convert_score_to_binary_metrics(
         self, score: float, threshold: float = 0.5
     ) -> Dict[str, float]:
         """Convert similarity score to binary classification metrics using MetricsHelper.
-
+        
         Args:
             score: Similarity score [0-1]
             threshold: Threshold for considering a match
-
+            
         Returns:
             Dictionary with TP, FP, FN, TN counts converted to metrics
         """
         metrics_helper = MetricsHelper()
         return metrics_helper.convert_score_to_binary_metrics(score, threshold)
-
+    
     def _format_for_evaluator(
         self,
         result: Dict[str, Any],
@@ -2513,19 +2644,19 @@ class StructuredModel(BaseModel):
         recall_with_fd: bool = False,
     ) -> Dict[str, Any]:
         """Format comparison results for evaluator compatibility.
-
+        
         Args:
             result: Standard comparison result from compare_with
             other: The other model being compared
             recall_with_fd: Whether to include FD in recall denominator
-
+            
         Returns:
             Dictionary in evaluator format with overall, fields, confusion_matrix
         """
         return EvaluatorFormatHelper.format_for_evaluator(
             self, result, other, recall_with_fd
         )
-
+    
     def _calculate_list_item_metrics(
         self,
         field_name: str,
@@ -2534,46 +2665,46 @@ class StructuredModel(BaseModel):
         recall_with_fd: bool = False,
     ) -> List[Dict[str, Any]]:
         """Calculate metrics for individual items in a list field.
-
+        
         Args:
             field_name: Name of the list field
             gt_list: Ground truth list
             pred_list: Prediction list
             recall_with_fd: Whether to include FD in recall denominator
-
+            
         Returns:
             List of metrics dictionaries for each matched item pair
         """
         return EvaluatorFormatHelper.calculate_list_item_metrics(
             field_name, gt_list, pred_list, recall_with_fd
         )
-
+    
     @classmethod
     def model_json_schema(cls, **kwargs):
         """Override to add model-level comparison metadata.
-
+        
         Extends the standard Pydantic JSON schema with comparison metadata
         at the field level.
-
+        
         Args:
             **kwargs: Arguments to pass to the parent method
-
+            
         Returns:
             JSON schema with added comparison metadata
         """
         schema = super().model_json_schema(**kwargs)
-
+        
         # Add comparison metadata to each field in the schema
         for field_name, field_info in cls.model_fields.items():
             if field_name == "extra_fields":
                 continue
-
+                
             # Get the schema property for this field
             if field_name not in schema.get("properties", {}):
                 continue
-
+                
             field_props = schema["properties"][field_name]
-
+            
             # Since ComparableField is now always a function, check for json_schema_extra
             if hasattr(field_info, "json_schema_extra") and callable(
                 field_info.json_schema_extra
@@ -2581,9 +2712,9 @@ class StructuredModel(BaseModel):
                 # Fallback: Check for json_schema_extra function
                 temp_schema = {}
                 field_info.json_schema_extra(temp_schema)
-
+                
                 if "x-comparison" in temp_schema:
                     # Copy the comparison metadata from the temp schema to the real schema
                     field_props["x-comparison"] = temp_schema["x-comparison"]
-
+        
         return schema

--- a/tests/structured_object_evaluator/test_bulk_structured_model_evaluator.py
+++ b/tests/structured_object_evaluator/test_bulk_structured_model_evaluator.py
@@ -574,7 +574,7 @@ class TestCompatibility:
         )
 
         evaluator = BulkStructuredModelEvaluator(BankStatement)
-        result = evaluator.evaluate_dataframe(df)
+        result, error_count = evaluator.evaluate_dataframe(df)
 
         assert isinstance(result, ProcessEvaluation)
         assert result.metrics["cm_accuracy"] == 1.0  # Perfect matches

--- a/tests/structured_object_evaluator/test_ecommerce_orders_aggregate_comprehensive.py
+++ b/tests/structured_object_evaluator/test_ecommerce_orders_aggregate_comprehensive.py
@@ -94,6 +94,7 @@ class Product(StructuredModel):
 
 class Discount(StructuredModel):
     match_threshold = 1.0
+    Customer_Id: Union[Optional[str], Any] = exact_number
     Discount_Code: Union[Optional[List[CategoryDescription]], Any] = category_description_field
 
 class Order(StructuredModel):
@@ -187,7 +188,7 @@ class TestEcommerceOrdersAggregateComprehensive:
         
         # Print the result for debugging
         print("\n=== FULL COMPARISON RESULT ===")
-        print(json.dumps(result, indent=2))
+        print(json.dumps(result, indent=2, default=str))
         
         # Verify that confusion matrix is included
         assert "confusion_matrix" in result
@@ -197,23 +198,11 @@ class TestEcommerceOrdersAggregateComprehensive:
         assert "aggregate" in cm
         aggregate = cm["aggregate"]
         
-        # Updated expected results based on correct Hungarian matching and aggregation:
-        # The Hungarian algorithm correctly matches GT[1]->Pred[0] and GT[3]->Pred[1] 
-        # based on optimal similarity scores, not the originally assumed GT[0]->Pred[0]
-        
-        print(f"\n=== AGGREGATE COUNTS ===")
-        print(f"TP: {aggregate.get('tp', 'MISSING')}, Expected: 19")
-        print(f"FA: {aggregate.get('fa', 'MISSING')}, Expected: 3")
-        print(f"FD: {aggregate.get('fd', 'MISSING')}, Expected: 3")
-        print(f"TN: {aggregate.get('tn', 'MISSING')}, Expected: 4")
-        print(f"FN: {aggregate.get('fn', 'MISSING')}, Expected: 11")
-        
-        # Verify the corrected aggregate counts (updated after implementing threshold-gated overall vs aggregate)
-        assert aggregate["tp"] == 19, f"Expected TP=19, got {aggregate['tp']}"
-        assert aggregate["fa"] == 3, f"Expected FA=3, got {aggregate['fa']}"
-        assert aggregate["fd"] == 3, f"Expected FD=3, got {aggregate['fd']}"  # Updated: was 4, now 3 after threshold fix
-        assert aggregate["tn"] == 4, f"Expected TN=4, got {aggregate['tn']}"  # Updated: was 5, now 4 after threshold fix
-        assert aggregate["fn"] == 11, f"Expected FN=11, got {aggregate['fn']}"
+        assert aggregate["tp"] == 17, f'Expected TP=17, got {aggregate["tp"]}'
+        assert aggregate["fa"] == 5, f'Expected FA=5, got {aggregate["fa"]}'
+        assert aggregate["fd"] == 5, f'Expected FD=5, got {aggregate["fd"]}'
+        assert aggregate["tn"] == 8, f'Expected TN=8, got {aggregate["tn"]}'
+        assert aggregate["fn"] == 13, f'Expected FN=11, got {aggregate["fn"]}'
 
     def test_order_info_field_aggregate_counts(self):
         """Test the Order_Info field aggregate counts specifically."""
@@ -225,85 +214,85 @@ class TestEcommerceOrdersAggregateComprehensive:
         cm = result["confusion_matrix"]
         
         # Order_Status at object level 1 tp
-        assert cm["fields"]["Order_Info"]['fields']['Order_Status']['overall']['tp'] == 1, f"Expected Order_Status overall TP=1, got {cm["fields"]["Order_Info"]['fields']['Order_Status']['overall']['tp']}"
-        assert cm["fields"]["Order_Info"]['fields']['Order_Status']['overall']['fa'] == 0, f"Expected Order_Status overall FA=0, got {cm["fields"]["Order_Info"]['fields']['Order_Status']['overall']['fa']}"
-        assert cm["fields"]["Order_Info"]['fields']['Order_Status']['overall']['fd'] == 0, f"Expected Order_Status overall FD=0, got {cm["fields"]["Order_Info"]['fields']['Order_Status']['overall']['fd']}"
-        assert cm["fields"]["Order_Info"]['fields']['Order_Status']['overall']['tn'] == 0, f"Expected Order_Status overall TN=0, got {cm["fields"]["Order_Info"]['fields']['Order_Status']['overall']['tn']}"
-        assert cm["fields"]["Order_Info"]['fields']['Order_Status']['overall']['fn'] == 0, f"Expected Order_Status overall FN=0, got {cm["fields"]["Order_Info"]['fields']['Order_Status']['overall']['fn']}"
+        assert cm["fields"]["Order_Info"]["fields"]["Order_Status"]["overall"]["tp"] == 1, f'Expected Order_Status overall TP=1, got {cm["fields"]["Order_Info"]["fields"]["Order_Status"]["overall"]["tp"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Order_Status"]["overall"]["fa"] == 0, f'Expected Order_Status overall FA=0, got {cm["fields"]["Order_Info"]["fields"]["Order_Status"]["overall"]["fa"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Order_Status"]["overall"]["fd"] == 0, f'Expected Order_Status overall FD=0, got {cm["fields"]["Order_Info"]["fields"]["Order_Status"]["overall"]["fd"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Order_Status"]["overall"]["tn"] == 0, f'Expected Order_Status overall TN=0, got {cm["fields"]["Order_Info"]["fields"]["Order_Status"]["overall"]["tn"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Order_Status"]["overall"]["fn"] == 0, f'Expected Order_Status overall FN=0, got {cm["fields"]["Order_Info"]["fields"]["Order_Status"]["overall"]["fn"]}'
 
-        # Order_Status at field level 2 tp: Category_Code, Category_Name
-        assert cm["fields"]["Order_Info"]['fields']['Order_Status']['aggregate']['tp'] == 2, f"Expected Order_Status aggregate TP=2, got {cm["fields"]["Order_Info"]['fields']['Order_Status']['aggregate']['tp']}"
-        assert cm["fields"]["Order_Info"]['fields']['Order_Status']['aggregate']['fa'] == 0, f"Expected Order_Status aggregate FA=0, got {cm["fields"]["Order_Info"]['fields']['Order_Status']['aggregate']['fa']}"
-        assert cm["fields"]["Order_Info"]['fields']['Order_Status']['aggregate']['fd'] == 0, f"Expected Order_Status aggregate FD=0, got {cm["fields"]["Order_Info"]['fields']['Order_Status']['aggregate']['fd']}"
-        assert cm["fields"]["Order_Info"]['fields']['Order_Status']['aggregate']['tn'] == 0, f"Expected Order_Status aggregate TN=0, got {cm["fields"]["Order_Info"]['fields']['Order_Status']['aggregate']['tn']}"
-        assert cm["fields"]["Order_Info"]['fields']['Order_Status']['aggregate']['fn'] == 0, f"Expected Order_Status aggregate FN=0, got {cm["fields"]["Order_Info"]['fields']['Order_Status']['aggregate']['fn']}"
+        # Order_Status at field level 1 true negative (Category_Code), 1 true positive (Category_Name)
+        assert cm["fields"]["Order_Info"]["fields"]["Order_Status"]["aggregate"]["tp"] == 1, f'Expected Order_Status aggregate TP=1, got {cm["fields"]["Order_Info"]["fields"]["Order_Status"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Order_Status"]["aggregate"]["fa"] == 0, f'Expected Order_Status aggregate FA=0, got {cm["fields"]["Order_Info"]["fields"]["Order_Status"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Order_Status"]["aggregate"]["fd"] == 0, f'Expected Order_Status aggregate FD=0, got {cm["fields"]["Order_Info"]["fields"]["Order_Status"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Order_Status"]["aggregate"]["tn"] == 1, f'Expected Order_Status aggregate TN=1, got {cm["fields"]["Order_Info"]["fields"]["Order_Status"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Order_Status"]["aggregate"]["fn"] == 0, f'Expected Order_Status aggregate FN=0, got {cm["fields"]["Order_Info"]["fields"]["Order_Status"]["aggregate"]["fn"]}'
 
         # Total_Amount has no nested fields, so overall (object level) metrics == aggregate (field level) metrics
-        assert cm["fields"]["Order_Info"]['fields']['Total_Amount']['overall']['tp'] == 1, f"Expected Total_Amount overall TP=1, got {cm["fields"]["Order_Info"]['fields']['Total_Amount']['overall']['tp']}"
-        assert cm["fields"]["Order_Info"]['fields']['Total_Amount']['overall']['fa'] == 0, f"Expected Total_Amount overall FA=0, got {cm["fields"]["Order_Info"]['fields']['Total_Amount']['overall']['fa']}"
-        assert cm["fields"]["Order_Info"]['fields']['Total_Amount']['overall']['fd'] == 0, f"Expected Total_Amount overall FD=0, got {cm["fields"]["Order_Info"]['fields']['Total_Amount']['overall']['fd']}"
-        assert cm["fields"]["Order_Info"]['fields']['Total_Amount']['overall']['tn'] == 0, f"Expected Total_Amount overall TN=0, got {cm["fields"]["Order_Info"]['fields']['Total_Amount']['overall']['tn']}"
-        assert cm["fields"]["Order_Info"]['fields']['Total_Amount']['overall']['fn'] == 0, f"Expected Total_Amount overall FN=0, got {cm["fields"]["Order_Info"]['fields']['Total_Amount']['overall']['fn']}"
+        assert cm["fields"]["Order_Info"]["fields"]["Total_Amount"]["overall"]["tp"] == 1, f'Expected Total_Amount overall TP=1, got {cm["fields"]["Order_Info"]["fields"]["Total_Amount"]["overall"]["tp"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Total_Amount"]["overall"]["fa"] == 0, f'Expected Total_Amount overall FA=0, got {cm["fields"]["Order_Info"]["fields"]["Total_Amount"]["overall"]["fa"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Total_Amount"]["overall"]["fd"] == 0, f'Expected Total_Amount overall FD=0, got {cm["fields"]["Order_Info"]["fields"]["Total_Amount"]["overall"]["fd"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Total_Amount"]["overall"]["tn"] == 0, f'Expected Total_Amount overall TN=0, got {cm["fields"]["Order_Info"]["fields"]["Total_Amount"]["overall"]["tn"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Total_Amount"]["overall"]["fn"] == 0, f'Expected Total_Amount overall FN=0, got {cm["fields"]["Order_Info"]["fields"]["Total_Amount"]["overall"]["fn"]}'
 
-        assert cm["fields"]["Order_Info"]['fields']['Total_Amount']['aggregate']['tp'] == 1, f"Expected Total_Amount aggregate TP=1, got {cm["fields"]["Order_Info"]['fields']['Total_Amount']['aggregate']['tp']}"
-        assert cm["fields"]["Order_Info"]['fields']['Total_Amount']['aggregate']['fa'] == 0, f"Expected Total_Amount aggregate FA=0, got {cm["fields"]["Order_Info"]['fields']['Total_Amount']['aggregate']['fa']}"
-        assert cm["fields"]["Order_Info"]['fields']['Total_Amount']['aggregate']['fd'] == 0, f"Expected Total_Amount aggregate FD=0, got {cm["fields"]["Order_Info"]['fields']['Total_Amount']['aggregate']['fd']}"
-        assert cm["fields"]["Order_Info"]['fields']['Total_Amount']['aggregate']['tn'] == 0, f"Expected Total_Amount aggregate TN=0, got {cm["fields"]["Order_Info"]['fields']['Total_Amount']['aggregate']['tn']}"
-        assert cm["fields"]["Order_Info"]['fields']['Total_Amount']['aggregate']['fn'] == 0, f"Expected Total_Amount aggregate FN=0, got {cm["fields"]["Order_Info"]['fields']['Total_Amount']['aggregate']['fn']}"
+        assert cm["fields"]["Order_Info"]["fields"]["Total_Amount"]["aggregate"]["tp"] == 1, f'Expected Total_Amount aggregate TP=1, got {cm["fields"]["Order_Info"]["fields"]["Total_Amount"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Total_Amount"]["aggregate"]["fa"] == 0, f'Expected Total_Amount aggregate FA=0, got {cm["fields"]["Order_Info"]["fields"]["Total_Amount"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Total_Amount"]["aggregate"]["fd"] == 0, f'Expected Total_Amount aggregate FD=0, got {cm["fields"]["Order_Info"]["fields"]["Total_Amount"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Total_Amount"]["aggregate"]["tn"] == 0, f'Expected Total_Amount aggregate TN=0, got {cm["fields"]["Order_Info"]["fields"]["Total_Amount"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Total_Amount"]["aggregate"]["fn"] == 0, f'Expected Total_Amount aggregate FN=0, got {cm["fields"]["Order_Info"]["fields"]["Total_Amount"]["aggregate"]["fn"]}'
 
         # Store_Location has no nested fields, so overall (object level) metrics == aggregate (field level) metrics
-        assert cm["fields"]["Order_Info"]['fields']['Store_Location']['overall']['tp'] == 0, f"Expected Store_Location overall TP=0, got {cm["fields"]["Order_Info"]['fields']['Store_Location']['overall']['tp']}"
-        assert cm["fields"]["Order_Info"]['fields']['Store_Location']['overall']['fa'] == 0, f"Expected Store_Location overall FA=0, got {cm["fields"]["Order_Info"]['fields']['Store_Location']['overall']['fa']}"
-        assert cm["fields"]["Order_Info"]['fields']['Store_Location']['overall']['fd'] == 0, f"Expected Store_Location overall FD=0, got {cm["fields"]["Order_Info"]['fields']['Store_Location']['overall']['fd']}"
-        assert cm["fields"]["Order_Info"]['fields']['Store_Location']['overall']['tn'] == 1, f"Expected Store_Location overall TN=1, got {cm["fields"]["Order_Info"]['fields']['Store_Location']['overall']['tn']}"
-        assert cm["fields"]["Order_Info"]['fields']['Store_Location']['overall']['fn'] == 0, f"Expected Store_Location overall FN=0, got {cm["fields"]["Order_Info"]['fields']['Store_Location']['overall']['fn']}"
+        assert cm["fields"]["Order_Info"]["fields"]["Store_Location"]["overall"]["tp"] == 0, f'Expected Store_Location overall TP=0, got {cm["fields"]["Order_Info"]["fields"]["Store_Location"]["overall"]["tp"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Store_Location"]["overall"]["fa"] == 0, f'Expected Store_Location overall FA=0, got {cm["fields"]["Order_Info"]["fields"]["Store_Location"]["overall"]["fa"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Store_Location"]["overall"]["fd"] == 0, f'Expected Store_Location overall FD=0, got {cm["fields"]["Order_Info"]["fields"]["Store_Location"]["overall"]["fd"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Store_Location"]["overall"]["tn"] == 1, f'Expected Store_Location overall TN=1, got {cm["fields"]["Order_Info"]["fields"]["Store_Location"]["overall"]["tn"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Store_Location"]["overall"]["fn"] == 0, f'Expected Store_Location overall FN=0, got {cm["fields"]["Order_Info"]["fields"]["Store_Location"]["overall"]["fn"]}'
 
-        assert cm["fields"]["Order_Info"]['fields']['Store_Location']['aggregate']['tp'] == 0, f"Expected Store_Location aggregate TP=0, got {cm["fields"]["Order_Info"]['fields']['Store_Location']['aggregate']['tp']}"
-        assert cm["fields"]["Order_Info"]['fields']['Store_Location']['aggregate']['fa'] == 0, f"Expected Store_Location aggregate FA=0, got {cm["fields"]["Order_Info"]['fields']['Store_Location']['aggregate']['fa']}"
-        assert cm["fields"]["Order_Info"]['fields']['Store_Location']['aggregate']['fd'] == 0, f"Expected Store_Location aggregate FD=0, got {cm["fields"]["Order_Info"]['fields']['Store_Location']['aggregate']['fd']}"
-        assert cm["fields"]["Order_Info"]['fields']['Store_Location']['aggregate']['tn'] == 1, f"Expected Store_Location aggregate TN=1, got {cm["fields"]["Order_Info"]['fields']['Store_Location']['aggregate']['tn']}"
-        assert cm["fields"]["Order_Info"]['fields']['Store_Location']['aggregate']['fn'] == 0, f"Expected Store_Location aggregate FN=0, got {cm["fields"]["Order_Info"]['fields']['Store_Location']['aggregate']['fn']}"
+        assert cm["fields"]["Order_Info"]["fields"]["Store_Location"]["aggregate"]["tp"] == 0, f'Expected Store_Location aggregate TP=0, got {cm["fields"]["Order_Info"]["fields"]["Store_Location"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Store_Location"]["aggregate"]["fa"] == 0, f'Expected Store_Location aggregate FA=0, got {cm["fields"]["Order_Info"]["fields"]["Store_Location"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Store_Location"]["aggregate"]["fd"] == 0, f'Expected Store_Location aggregate FD=0, got {cm["fields"]["Order_Info"]["fields"]["Store_Location"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Store_Location"]["aggregate"]["tn"] == 1, f'Expected Store_Location aggregate TN=1, got {cm["fields"]["Order_Info"]["fields"]["Store_Location"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Store_Location"]["aggregate"]["fn"] == 0, f'Expected Store_Location aggregate FN=0, got {cm["fields"]["Order_Info"]["fields"]["Store_Location"]["aggregate"]["fn"]}'
 
          # Payment_Method at object level 1 tp, 1 fa
-        assert cm["fields"]["Order_Info"]['fields']['Payment_Method']['overall']['tp'] == 1, f"Expected Payment_Method overall TP=1, got {cm["fields"]["Order_Info"]['fields']['Payment_Method']['overall']['tp']}"
-        assert cm["fields"]["Order_Info"]['fields']['Payment_Method']['overall']['fa'] == 1, f"Expected Payment_Method overall FA=1, got {cm["fields"]["Order_Info"]['fields']['Payment_Method']['overall']['fa']}"
-        assert cm["fields"]["Order_Info"]['fields']['Payment_Method']['overall']['fd'] == 0, f"Expected Payment_Method overall FD=0, got {cm["fields"]["Order_Info"]['fields']['Payment_Method']['overall']['fd']}"
-        assert cm["fields"]["Order_Info"]['fields']['Payment_Method']['overall']['tn'] == 0, f"Expected Payment_Method overall TN=0, got {cm["fields"]["Order_Info"]['fields']['Payment_Method']['overall']['tn']}"
-        assert cm["fields"]["Order_Info"]['fields']['Payment_Method']['overall']['fn'] == 0, f"Expected Payment_Method overall FN=0, got {cm["fields"]["Order_Info"]['fields']['Payment_Method']['overall']['fn']}"
+        assert cm["fields"]["Order_Info"]["fields"]["Payment_Method"]["overall"]["tp"] == 1, f'Expected Payment_Method overall TP=1, got {cm["fields"]["Order_Info"]["fields"]["Payment_Method"]["overall"]["tp"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Payment_Method"]["overall"]["fa"] == 1, f'Expected Payment_Method overall FA=1, got {cm["fields"]["Order_Info"]["fields"]["Payment_Method"]["overall"]["fa"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Payment_Method"]["overall"]["fd"] == 0, f'Expected Payment_Method overall FD=0, got {cm["fields"]["Order_Info"]["fields"]["Payment_Method"]["overall"]["fd"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Payment_Method"]["overall"]["tn"] == 0, f'Expected Payment_Method overall TN=0, got {cm["fields"]["Order_Info"]["fields"]["Payment_Method"]["overall"]["tn"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Payment_Method"]["overall"]["fn"] == 0, f'Expected Payment_Method overall FN=0, got {cm["fields"]["Order_Info"]["fields"]["Payment_Method"]["overall"]["fn"]}'
 
         # Payment_Method at field level 2 tp, 2 fa: Category_Code, Category_Name
-        assert cm["fields"]["Order_Info"]['fields']['Payment_Method']['aggregate']['tp'] == 2, f"Expected Payment_Method aggregate TP=2, got {cm["fields"]["Order_Info"]['fields']['Payment_Method']['aggregate']['tp']}"
-        assert cm["fields"]["Order_Info"]['fields']['Payment_Method']['aggregate']['fa'] == 2, f"Expected Payment_Method aggregate FA=2, got {cm["fields"]["Order_Info"]['fields']['Payment_Method']['aggregate']['fa']}"
-        assert cm["fields"]["Order_Info"]['fields']['Payment_Method']['aggregate']['fd'] == 0, f"Expected Payment_Method aggregate FD=0, got {cm["fields"]["Order_Info"]['fields']['Payment_Method']['aggregate']['fd']}"
-        assert cm["fields"]["Order_Info"]['fields']['Payment_Method']['aggregate']['tn'] == 0, f"Expected Payment_Method aggregate TN=0, got {cm["fields"]["Order_Info"]['fields']['Payment_Method']['aggregate']['tn']}"
-        assert cm["fields"]["Order_Info"]['fields']['Payment_Method']['aggregate']['fn'] == 0, f"Expected Payment_Method aggregate FN=0, got {cm["fields"]["Order_Info"]['fields']['Payment_Method']['aggregate']['fn']}"
+        assert cm["fields"]["Order_Info"]["fields"]["Payment_Method"]["aggregate"]["tp"] == 2, f'Expected Payment_Method aggregate TP=2, got {cm["fields"]["Order_Info"]["fields"]["Payment_Method"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Payment_Method"]["aggregate"]["fa"] == 2, f'Expected Payment_Method aggregate FA=2, got {cm["fields"]["Order_Info"]["fields"]["Payment_Method"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Payment_Method"]["aggregate"]["fd"] == 0, f'Expected Payment_Method aggregate FD=0, got {cm["fields"]["Order_Info"]["fields"]["Payment_Method"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Payment_Method"]["aggregate"]["tn"] == 0, f'Expected Payment_Method aggregate TN=0, got {cm["fields"]["Order_Info"]["fields"]["Payment_Method"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Payment_Method"]["aggregate"]["fn"] == 0, f'Expected Payment_Method aggregate FN=0, got {cm["fields"]["Order_Info"]["fields"]["Payment_Method"]["aggregate"]["fn"]}'
 
         # Order_Notes has no nested fields, so overall (object level) metrics == aggregate (field level) metrics
-        assert cm["fields"]["Order_Info"]['fields']['Order_Notes']['overall']['tp'] == 0, f"Expected Order_Notes overall TP=0, got {cm["fields"]["Order_Info"]['fields']['Order_Notes']['overall']['tp']}"
-        assert cm["fields"]["Order_Info"]['fields']['Order_Notes']['overall']['fa'] == 0, f"Expected Order_Notes overall FA=0, got {cm["fields"]["Order_Info"]['fields']['Order_Notes']['overall']['fa']}"
-        assert cm["fields"]["Order_Info"]['fields']['Order_Notes']['overall']['fd'] == 1, f"Expected Order_Notes overall FD=1, got {cm["fields"]["Order_Info"]['fields']['Order_Notes']['overall']['fd']}"
-        assert cm["fields"]["Order_Info"]['fields']['Order_Notes']['overall']['tn'] == 0, f"Expected Order_Notes overall TN=0, got {cm["fields"]["Order_Info"]['fields']['Order_Notes']['overall']['tn']}"
-        assert cm["fields"]["Order_Info"]['fields']['Order_Notes']['overall']['fn'] == 0, f"Expected Order_Notes overall FN=0, got {cm["fields"]["Order_Info"]['fields']['Order_Notes']['overall']['fn']}"
+        assert cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["overall"]["tp"] == 0, f'Expected Order_Notes overall TP=0, got {cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["overall"]["tp"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["overall"]["fa"] == 0, f'Expected Order_Notes overall FA=0, got {cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["overall"]["fa"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["overall"]["fd"] == 1, f'Expected Order_Notes overall FD=1, got {cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["overall"]["fd"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["overall"]["tn"] == 0, f'Expected Order_Notes overall TN=0, got {cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["overall"]["tn"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["overall"]["fn"] == 0, f'Expected Order_Notes overall FN=0, got {cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["overall"]["fn"]}'
 
-        assert cm["fields"]["Order_Info"]['fields']['Order_Notes']['aggregate']['tp'] == 0, f"Expected Order_Notes aggregate TP=0, got {cm["fields"]["Order_Info"]['fields']['Order_Notes']['aggregate']['tp']}"
-        assert cm["fields"]["Order_Info"]['fields']['Order_Notes']['aggregate']['fa'] == 0, f"Expected Order_Notes aggregate FA=0, got {cm["fields"]["Order_Info"]['fields']['Order_Notes']['aggregate']['fa']}"
-        assert cm["fields"]["Order_Info"]['fields']['Order_Notes']['aggregate']['fd'] == 1, f"Expected Order_Notes aggregate FD=1, got {cm["fields"]["Order_Info"]['fields']['Order_Notes']['aggregate']['fd']}"
-        assert cm["fields"]["Order_Info"]['fields']['Order_Notes']['aggregate']['tn'] == 0, f"Expected Order_Notes aggregate TN=0, got {cm["fields"]["Order_Info"]['fields']['Order_Notes']['aggregate']['tn']}"
-        assert cm["fields"]["Order_Info"]['fields']['Order_Notes']['aggregate']['fn'] == 0, f"Expected Order_Notes aggregate FN=0, got {cm["fields"]["Order_Info"]['fields']['Order_Notes']['aggregate']['fn']}"
+        assert cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["aggregate"]["tp"] == 0, f'Expected Order_Notes aggregate TP=0, got {cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["aggregate"]["fa"] == 0, f'Expected Order_Notes aggregate FA=0, got {cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["aggregate"]["fd"] == 1, f'Expected Order_Notes aggregate FD=1, got {cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["aggregate"]["tn"] == 0, f'Expected Order_Notes aggregate TN=0, got {cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["aggregate"]["fn"] == 0, f'Expected Order_Notes aggregate FN=0, got {cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["aggregate"]["fn"]}'
 
         # at the object level with exact match, 1 false discovery
-        assert cm["fields"]["Order_Info"]["overall"]["tp"] == 0, f"Expected Order_Info overall TP=5, got {cm["fields"]["Order_Info"]["overall"]['tp']}"
-        assert cm["fields"]["Order_Info"]["overall"]["fa"] == 0, f"Expected Order_Info overall FA=2, got {cm["fields"]["Order_Info"]["overall"]['fa']}"
-        assert cm["fields"]["Order_Info"]["overall"]["fd"] == 1, f"Expected Order_Info overall FD=1, got {cm["fields"]["Order_Info"]["overall"]['fd']}"
-        assert cm["fields"]["Order_Info"]["overall"]["tn"] == 0, f"Expected Order_Info overall TN=1, got {cm["fields"]["Order_Info"]["overall"]['tn']}"
-        assert cm["fields"]["Order_Info"]["overall"]["fn"] == 0, f"Expected Order_Info overall FN=0, got {cm["fields"]["Order_Info"]["overall"]['fn']}"
+        assert cm["fields"]["Order_Info"]["overall"]["tp"] == 0, f'Expected Order_Info overall TP=5, got {cm["fields"]["Order_Info"]["overall"]["tp"]}'
+        assert cm["fields"]["Order_Info"]["overall"]["fa"] == 0, f'Expected Order_Info overall FA=2, got {cm["fields"]["Order_Info"]["overall"]["fa"]}'
+        assert cm["fields"]["Order_Info"]["overall"]["fd"] == 1, f'Expected Order_Info overall FD=1, got {cm["fields"]["Order_Info"]["overall"]["fd"]}'
+        assert cm["fields"]["Order_Info"]["overall"]["tn"] == 0, f'Expected Order_Info overall TN=1, got {cm["fields"]["Order_Info"]["overall"]["tn"]}'
+        assert cm["fields"]["Order_Info"]["overall"]["fn"] == 0, f'Expected Order_Info overall FN=0, got {cm["fields"]["Order_Info"]["overall"]["fn"]}'
 
         # at the field level within all nested fields, 5 true positives, 2 false alarms, 1 false discovery and 1 true negative
-        assert cm["fields"]["Order_Info"]["aggregate"]["tp"] == 5, f"Expected Order_Info aggregate TP=5, got {cm["fields"]["Order_Info"]["aggregate"]['tp']}"
-        assert cm["fields"]["Order_Info"]["aggregate"]["fa"] == 2, f"Expected Order_Info aggregate FA=2, got {cm["fields"]["Order_Info"]["aggregate"]['fa']}"
-        assert cm["fields"]["Order_Info"]["aggregate"]["fd"] == 1, f"Expected Order_Info aggregate FD=1, got {cm["fields"]["Order_Info"]["aggregate"]['fd']}"
-        assert cm["fields"]["Order_Info"]["aggregate"]["tn"] == 1, f"Expected Order_Info aggregate TN=1, got {cm["fields"]["Order_Info"]["aggregate"]['tn']}"
-        assert cm["fields"]["Order_Info"]["aggregate"]["fn"] == 0, f"Expected Order_Info aggregate FN=0, got {cm["fields"]["Order_Info"]["aggregate"]['fn']}"
+        assert cm["fields"]["Order_Info"]["aggregate"]["tp"] == 4, f'Expected Order_Info aggregate TP=4, got {cm["fields"]["Order_Info"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Order_Info"]["aggregate"]["fa"] == 2, f'Expected Order_Info aggregate FA=2, got {cm["fields"]["Order_Info"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Order_Info"]["aggregate"]["fd"] == 1, f'Expected Order_Info aggregate FD=1, got {cm["fields"]["Order_Info"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Order_Info"]["aggregate"]["tn"] == 2, f'Expected Order_Info aggregate TN=2, got {cm["fields"]["Order_Info"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Order_Info"]["aggregate"]["fn"] == 0, f'Expected Order_Info aggregate FN=0, got {cm["fields"]["Order_Info"]["aggregate"]["fn"]}'
 
     def test_customers_field_aggregate_counts(self):
         """Test the Customers field aggregate counts with Hungarian matching."""
@@ -316,84 +305,84 @@ class TestEcommerceOrdersAggregateComprehensive:
 
         # Hungarian matches GT[1]->Pred[0] and GT[3]->Pred[1]
 
-        # gt_json['Customers'][0]['Customer_Id'], pred_json['Customers'][0]['Customer_Id']:  1 true positive
-        # gt_json['Customers'][3]['Customer_Id'], pred_json['Customers'][1]['Customer_Id']:  1 false discovery
-        # gt_json['Customers'][1]['Customer_Id'], gt_json['Customers'][2]['Customer_Id']:  2 false neagtive
-        assert cm["fields"]["Customers"]['fields']['Customer_Id']['aggregate']['tp'] == 1, f"Expected Customer_Id aggregate TP=1, got {cm["fields"]["Customers"]['fields']['Customer_Id']['aggregate']['tp']}"
-        assert cm["fields"]["Customers"]['fields']['Customer_Id']['aggregate']['fa'] == 0, f"Expected Customer_Id aggregate FA=0, got {cm["fields"]["Customers"]['fields']['Customer_Id']['aggregate']['fa']}"
-        assert cm["fields"]["Customers"]['fields']['Customer_Id']['aggregate']['fd'] == 1, f"Expected Customer_Id aggregate FD=1, got {cm["fields"]["Customers"]['fields']['Customer_Id']['aggregate']['fd']}"
-        assert cm["fields"]["Customers"]['fields']['Customer_Id']['aggregate']['tn'] == 0, f"Expected Customer_Id aggregate TN=0, got {cm["fields"]["Customers"]['fields']['Customer_Id']['aggregate']['tn']}"
-        assert cm["fields"]["Customers"]['fields']['Customer_Id']['aggregate']['fn'] == 2, f"Expected Customer_Id aggregate FN=2, got {cm["fields"]["Customers"]['fields']['Customer_Id']['aggregate']['fn']}"
+        # gt_json["Customers"][0]["Customer_Id"], pred_json["Customers"][0]["Customer_Id"]:  1 true positive
+        # gt_json["Customers"][3]["Customer_Id"], pred_json["Customers"][1]["Customer_Id"]:  1 false discovery
+        # gt_json["Customers"][1]["Customer_Id"], gt_json["Customers"][2]["Customer_Id"]:  2 false neagtive
+        assert cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["tp"] == 1, f'Expected Customer_Id aggregate TP=1, got {cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["fa"] == 0, f'Expected Customer_Id aggregate FA=0, got {cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["fd"] == 1, f'Expected Customer_Id aggregate FD=1, got {cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["tn"] == 0, f'Expected Customer_Id aggregate TN=0, got {cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["fn"] == 2, f'Expected Customer_Id aggregate FN=2, got {cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["fn"]}'
 
-        # gt_json['Customers'][0]['Customer_Type'], pred_json['Customers'][0]['Customer_Type']:  1 false discovery
-        # gt_json['Customers'][3]['Customer_Type'], pred_json['Customers'][1]['Customer_Type']:  1 true positive
-        # gt_json['Customers'][1]['Customer_Type'], gt_json['Customers'][2]['Customer_Type']:  2 false neagtive
-        assert cm["fields"]["Customers"]['fields']['Customer_Type']['aggregate']['tp'] == 1, f"Expected Customer_Type aggregate TP=1, got {cm["fields"]["Customers"]['fields']['Customer_Type']['aggregate']['tp']}"
-        assert cm["fields"]["Customers"]['fields']['Customer_Type']['aggregate']['fa'] == 0, f"Expected Customer_Type aggregate FA=0, got {cm["fields"]["Customers"]['fields']['Customer_Type']['aggregate']['fa']}"
-        assert cm["fields"]["Customers"]['fields']['Customer_Type']['aggregate']['fd'] == 1, f"Expected Customer_Type aggregate FD=1, got {cm["fields"]["Customers"]['fields']['Customer_Type']['aggregate']['fd']}"
-        assert cm["fields"]["Customers"]['fields']['Customer_Type']['aggregate']['tn'] == 0, f"Expected Customer_Type aggregate TN=0, got {cm["fields"]["Customers"]['fields']['Customer_Type']['aggregate']['tn']}"
-        assert cm["fields"]["Customers"]['fields']['Customer_Type']['aggregate']['fn'] == 2, f"Expected Customer_Type aggregate FN=2, got {cm["fields"]["Customers"]['fields']['Customer_Type']['aggregate']['fn']}"
+        # gt_json["Customers"][0]["Customer_Type"], pred_json["Customers"][0]["Customer_Type"]:  1 false discovery
+        # gt_json["Customers"][3]["Customer_Type"], pred_json["Customers"][1]["Customer_Type"]:  1 true positive
+        # gt_json["Customers"][1]["Customer_Type"], gt_json["Customers"][2]["Customer_Type"]:  2 false neagtive
+        assert cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["tp"] == 1, f'Expected Customer_Type aggregate TP=1, got {cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["fa"] == 0, f'Expected Customer_Type aggregate FA=0, got {cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["fd"] == 1, f'Expected Customer_Type aggregate FD=1, got {cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["tn"] == 0, f'Expected Customer_Type aggregate TN=0, got {cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["fn"] == 2, f'Expected Customer_Type aggregate FN=2, got {cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["fn"]}'
 
-        # gt_json['Customers'][0]['Account_Number'], pred_json['Customers'][0]['Account_Number']:  1 true positive
-        # gt_json['Customers'][3]['Account_Number'], pred_json['Customers'][1]['Account_Number']:  1 true positive
-        # gt_json['Customers'][1]['Account_Number'], gt_json['Customers'][2]['Account_Number']:  2 false neagtive
-        assert cm["fields"]["Customers"]['fields']['Account_Number']['aggregate']['tp'] == 2, f"Expected Account_Number aggregate TP=2, got {cm["fields"]["Customers"]['fields']['Account_Number']['aggregate']['tp']}"
-        assert cm["fields"]["Customers"]['fields']['Account_Number']['aggregate']['fa'] == 0, f"Expected Account_Number aggregate FA=0, got {cm["fields"]["Customers"]['fields']['Account_Number']['aggregate']['fa']}"
-        assert cm["fields"]["Customers"]['fields']['Account_Number']['aggregate']['fd'] == 0, f"Expected Account_Number aggregate FD=0, got {cm["fields"]["Customers"]['fields']['Account_Number']['aggregate']['fd']}"
-        assert cm["fields"]["Customers"]['fields']['Account_Number']['aggregate']['tn'] == 0, f"Expected Account_Number aggregate TN=0, got {cm["fields"]["Customers"]['fields']['Account_Number']['aggregate']['tn']}"
-        assert cm["fields"]["Customers"]['fields']['Account_Number']['aggregate']['fn'] == 2, f"Expected Account_Number aggregate FN=2, got {cm["fields"]["Customers"]['fields']['Account_Number']['aggregate']['fn']}"
+        # gt_json["Customers"][0]["Account_Number"], pred_json["Customers"][0]["Account_Number"]:  1 true positive
+        # gt_json["Customers"][3]["Account_Number"], pred_json["Customers"][1]["Account_Number"]:  1 true positive
+        # gt_json["Customers"][1]["Account_Number"], gt_json["Customers"][2]["Account_Number"]:  2 false neagtive
+        assert cm["fields"]["Customers"]["fields"]["Account_Number"]["aggregate"]["tp"] == 2, f'Expected Account_Number aggregate TP=2, got {cm["fields"]["Customers"]["fields"]["Account_Number"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Customers"]["fields"]["Account_Number"]["aggregate"]["fa"] == 0, f'Expected Account_Number aggregate FA=0, got {cm["fields"]["Customers"]["fields"]["Account_Number"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Customers"]["fields"]["Account_Number"]["aggregate"]["fd"] == 0, f'Expected Account_Number aggregate FD=0, got {cm["fields"]["Customers"]["fields"]["Account_Number"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Customers"]["fields"]["Account_Number"]["aggregate"]["tn"] == 0, f'Expected Account_Number aggregate TN=0, got {cm["fields"]["Customers"]["fields"]["Account_Number"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Customers"]["fields"]["Account_Number"]["aggregate"]["fn"] == 2, f'Expected Account_Number aggregate FN=2, got {cm["fields"]["Customers"]["fields"]["Account_Number"]["aggregate"]["fn"]}'
 
-        # gt_json['Customers'][0]['Is_Premium_Member'], pred_json['Customers'][0]['Is_Premium_Member']:  1 false alarm
-        # gt_json['Customers'][3]['Is_Premium_Member'], pred_json['Customers'][1]['Is_Premium_Member']:  1 true positive
-        # gt_json['Customers'][1]['Is_Premium_Member']:  1 false neagtive
-        # gt_json['Customers'][2]['Is_Premium_Member']: 1 true negative
-        assert cm["fields"]["Customers"]['fields']['Is_Premium_Member']['aggregate']['tp'] == 1, f"Expected Is_Premium_Member aggregate TP=1, got {cm["fields"]["Customers"]['fields']['Is_Premium_Member']['aggregate']['tp']}"
-        assert cm["fields"]["Customers"]['fields']['Is_Premium_Member']['aggregate']['fa'] == 1, f"Expected Is_Premium_Member aggregate FA=1, got {cm["fields"]["Customers"]['fields']['Is_Premium_Member']['aggregate']['fa']}"
-        assert cm["fields"]["Customers"]['fields']['Is_Premium_Member']['aggregate']['fd'] == 0, f"Expected Is_Premium_Member aggregate FD=0, got {cm["fields"]["Customers"]['fields']['Is_Premium_Member']['aggregate']['fd']}"
-        assert cm["fields"]["Customers"]['fields']['Is_Premium_Member']['aggregate']['tn'] == 1, f"Expected Is_Premium_Member aggregate TN=1, got {cm["fields"]["Customers"]['fields']['Is_Premium_Member']['aggregate']['tn']}"
-        assert cm["fields"]["Customers"]['fields']['Is_Premium_Member']['aggregate']['fn'] == 1, f"Expected Is_Premium_Member aggregate FN=1, got {cm["fields"]["Customers"]['fields']['Is_Premium_Member']['aggregate']['fn']}"
+        # gt_json["Customers"][0]["Is_Premium_Member"], pred_json["Customers"][0]["Is_Premium_Member"]:  1 false alarm
+        # gt_json["Customers"][3]["Is_Premium_Member"], pred_json["Customers"][1]["Is_Premium_Member"]:  1 true positive
+        # gt_json["Customers"][1]["Is_Premium_Member"]:  1 false neagtive
+        # gt_json["Customers"][2]["Is_Premium_Member"]: 1 true negative
+        assert cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["tp"] == 1, f'Expected Is_Premium_Member aggregate TP=1, got {cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["fa"] == 1, f'Expected Is_Premium_Member aggregate FA=1, got {cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["fd"] == 0, f'Expected Is_Premium_Member aggregate FD=0, got {cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["tn"] == 1, f'Expected Is_Premium_Member aggregate TN=1, got {cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["fn"] == 1, f'Expected Is_Premium_Member aggregate FN=1, got {cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["fn"]}'
 
-        # gt_json['Customers'][0]['Customer_Name'], pred_json['Customers'][0]['Customer_Name']:  1 true positive
-        # gt_json['Customers'][3]['Customer_Name'], pred_json['Customers'][1]['Customer_Name']:  1 true positive
-        # gt_json['Customers'][1]['Customer_Name'], gt_json['Customers'][2]['Customer_Name']:  2 false neagtive
-        assert cm["fields"]["Customers"]['fields']['Customer_Name']['aggregate']['tp'] == 2, f"Expected Customer_Name aggregate TP=2, got {cm["fields"]["Customers"]['fields']['Customer_Name']['aggregate']['tp']}"
-        assert cm["fields"]["Customers"]['fields']['Customer_Name']['aggregate']['fa'] == 0, f"Expected Customer_Name aggregate FA=0, got {cm["fields"]["Customers"]['fields']['Customer_Name']['aggregate']['fa']}"
-        assert cm["fields"]["Customers"]['fields']['Customer_Name']['aggregate']['fd'] == 0, f"Expected Customer_Name aggregate FD=0, got {cm["fields"]["Customers"]['fields']['Customer_Name']['aggregate']['fd']}"
-        assert cm["fields"]["Customers"]['fields']['Customer_Name']['aggregate']['tn'] == 0, f"Expected Customer_Name aggregate TN=0, got {cm["fields"]["Customers"]['fields']['Customer_Name']['aggregate']['tn']}"
-        assert cm["fields"]["Customers"]['fields']['Customer_Name']['aggregate']['fn'] == 2, f"Expected Customer_Name aggregate FN=2, got {cm["fields"]["Customers"]['fields']['Customer_Name']['aggregate']['fn']}"
+        # gt_json["Customers"][0]["Customer_Name"], pred_json["Customers"][0]["Customer_Name"]:  1 true positive
+        # gt_json["Customers"][3]["Customer_Name"], pred_json["Customers"][1]["Customer_Name"]:  1 true positive
+        # gt_json["Customers"][1]["Customer_Name"], gt_json["Customers"][2]["Customer_Name"]:  2 false neagtive
+        assert cm["fields"]["Customers"]["fields"]["Customer_Name"]["aggregate"]["tp"] == 2, f'Expected Customer_Name aggregate TP=2, got {cm["fields"]["Customers"]["fields"]["Customer_Name"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Customers"]["fields"]["Customer_Name"]["aggregate"]["fa"] == 0, f'Expected Customer_Name aggregate FA=0, got {cm["fields"]["Customers"]["fields"]["Customer_Name"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Customers"]["fields"]["Customer_Name"]["aggregate"]["fd"] == 0, f'Expected Customer_Name aggregate FD=0, got {cm["fields"]["Customers"]["fields"]["Customer_Name"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Customers"]["fields"]["Customer_Name"]["aggregate"]["tn"] == 0, f'Expected Customer_Name aggregate TN=0, got {cm["fields"]["Customers"]["fields"]["Customer_Name"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Customers"]["fields"]["Customer_Name"]["aggregate"]["fn"] == 2, f'Expected Customer_Name aggregate FN=2, got {cm["fields"]["Customers"]["fields"]["Customer_Name"]["aggregate"]["fn"]}'
 
-        # gt_json['Customers'][0]['Shipping_Address'], pred_json['Customers'][0]['Shipping_Address']:  1 true positive
-        # gt_json['Customers'][3]['Shipping_Address'], pred_json['Customers'][1]['Shipping_Address']:  1 true positive
-        # gt_json['Customers'][1]['Shipping_Address'], gt_json['Customers'][2]['Shipping_Address']:  2 false neagtive
-        assert cm["fields"]["Customers"]['fields']['Shipping_Address']['aggregate']['tp'] == 2, f"Expected Shipping_Address aggregate TP=2, got {cm["fields"]["Customers"]['fields']['Shipping_Address']['aggregate']['tp']}"
-        assert cm["fields"]["Customers"]['fields']['Shipping_Address']['aggregate']['fa'] == 0, f"Expected Shipping_Address aggregate FA=0, got {cm["fields"]["Customers"]['fields']['Shipping_Address']['aggregate']['fa']}"
-        assert cm["fields"]["Customers"]['fields']['Shipping_Address']['aggregate']['fd'] == 0, f"Expected Shipping_Address aggregate FD=0, got {cm["fields"]["Customers"]['fields']['Shipping_Address']['aggregate']['fd']}"
-        assert cm["fields"]["Customers"]['fields']['Shipping_Address']['aggregate']['tn'] == 0, f"Expected Shipping_Address aggregate TN=0, got {cm["fields"]["Customers"]['fields']['Shipping_Address']['aggregate']['tn']}"
-        assert cm["fields"]["Customers"]['fields']['Shipping_Address']['aggregate']['fn'] == 2, f"Expected Shipping_Address aggregate FN=2, got {cm["fields"]["Customers"]['fields']['Shipping_Address']['aggregate']['fn']}"
+        # gt_json["Customers"][0]["Shipping_Address"], pred_json["Customers"][0]["Shipping_Address"]:  1 true positive
+        # gt_json["Customers"][3]["Shipping_Address"], pred_json["Customers"][1]["Shipping_Address"]:  1 true positive
+        # gt_json["Customers"][1]["Shipping_Address"], gt_json["Customers"][2]["Shipping_Address"]:  2 false neagtive
+        assert cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["tp"] == 2, f'Expected Shipping_Address aggregate TP=2, got {cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["fa"] == 0, f'Expected Shipping_Address aggregate FA=0, got {cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["fd"] == 0, f'Expected Shipping_Address aggregate FD=0, got {cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["tn"] == 0, f'Expected Shipping_Address aggregate TN=0, got {cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["fn"] == 2, f'Expected Shipping_Address aggregate FN=2, got {cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["fn"]}'
 
-        # gt_json['Customers'][0]['Loyalty_Status'], pred_json['Customers'][0]['Loyalty_Status']:  1 false alarm (object level) or 2 false alarm (aggregate level)
-        # gt_json['Customers'][3]['Loyalty_Status'], pred_json['Customers'][1]['Loyalty_Status']:  1 true negative (object level) or 2 true negative (aggregate level)
-        # gt_json['Customers'][1]['Loyalty_Status']: 1 false negative (object level) or 2 false negative (aggregate level)
-        # gt_json['Customers'][2]['Loyalty_Status']: 1 true negative (object level) or 2 true negative (aggregate level)
-        assert cm["fields"]["Customers"]['fields']['Loyalty_Status']['aggregate']['tp'] == 0, f"Expected Loyalty_Status aggregate TP=0, got {cm["fields"]["Customers"]['fields']['Loyalty_Status']['aggregate']['tp']}"
-        assert cm["fields"]["Customers"]['fields']['Loyalty_Status']['aggregate']['fa'] == 2, f"Expected Loyalty_Status aggregate FA=2, got {cm["fields"]["Customers"]['fields']['Loyalty_Status']['aggregate']['fa']}"
-        assert cm["fields"]["Customers"]['fields']['Loyalty_Status']['aggregate']['fd'] == 0, f"Expected Loyalty_Status aggregate FD=0, got {cm["fields"]["Customers"]['fields']['Loyalty_Status']['aggregate']['fd']}"
-        assert cm["fields"]["Customers"]['fields']['Loyalty_Status']['aggregate']['tn'] == 4, f"Expected Loyalty_Status aggregate TN=4, got {cm["fields"]["Customers"]['fields']['Loyalty_Status']['aggregate']['tn']}"
-        assert cm["fields"]["Customers"]['fields']['Loyalty_Status']['aggregate']['fn'] == 2, f"Expected Loyalty_Status aggregate FN=2, got {cm["fields"]["Customers"]['fields']['Loyalty_Status']['aggregate']['fn']}"
+        # gt_json["Customers"][0]["Loyalty_Status"], pred_json["Customers"][0]["Loyalty_Status"]:  1 false alarm (object level) or 2 false alarm (aggregate level)
+        # gt_json["Customers"][3]["Loyalty_Status"], pred_json["Customers"][1]["Loyalty_Status"]:  1 true negative (object level) or 2 true negative (aggregate level)
+        # gt_json["Customers"][1]["Loyalty_Status"]: 1 false negative (object level) or 2 false negative (aggregate level)
+        # gt_json["Customers"][2]["Loyalty_Status"]: 1 true negative (object level) or 2 true negative (aggregate level)
+        assert cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["tp"] == 0, f'Expected Loyalty_Status aggregate TP=0, got {cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fa"] == 2, f'Expected Loyalty_Status aggregate FA=2, got {cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fd"] == 0, f'Expected Loyalty_Status aggregate FD=0, got {cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["tn"] == 4, f'Expected Loyalty_Status aggregate TN=4, got {cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fn"] == 2, f'Expected Loyalty_Status aggregate FN=2, got {cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fn"]}'
 
         # at the object level with match_threshold = 1.0, 2 false discoveries and 2 false negatives (2 entries are matched, but below threshold, 2 entries are missing in prediction)
-        assert cm["fields"]["Customers"]["overall"]["tp"] == 0, f"Expected Customers overall TP=0, got {cm["fields"]["Customers"]["overall"]["tp"]}"
-        assert cm["fields"]["Customers"]["overall"]["fa"] == 0, f"Expected Customers overall FA=0, got {cm["fields"]["Customers"]["overall"]['fa']}"
-        assert cm["fields"]["Customers"]["overall"]["fd"] == 2, f"Expected Customers overall FD=2, got {cm["fields"]["Customers"]["overall"]['fd']}"
-        assert cm["fields"]["Customers"]["overall"]["tn"] == 0, f"Expected Customers overall TN=0, got {cm["fields"]["Customers"]["overall"]['tn']}"
-        assert cm["fields"]["Customers"]["overall"]["fn"] == 2, f"Expected Customers overall FN=2, got {cm["fields"]["Customers"]["overall"]['fn']}"
+        assert cm["fields"]["Customers"]["overall"]["tp"] == 0, f'Expected Customers overall TP=0, got {cm["fields"]["Customers"]["overall"]["tp"]}'
+        assert cm["fields"]["Customers"]["overall"]["fa"] == 0, f'Expected Customers overall FA=0, got {cm["fields"]["Customers"]["overall"]["fa"]}'
+        assert cm["fields"]["Customers"]["overall"]["fd"] == 2, f'Expected Customers overall FD=2, got {cm["fields"]["Customers"]["overall"]["fd"]}'
+        assert cm["fields"]["Customers"]["overall"]["tn"] == 0, f'Expected Customers overall TN=0, got {cm["fields"]["Customers"]["overall"]["tn"]}'
+        assert cm["fields"]["Customers"]["overall"]["fn"] == 2, f'Expected Customers overall FN=2, got {cm["fields"]["Customers"]["overall"]["fn"]}'
 
         # at the field level within all matched entries (2 matched entries are considered for the sub field comparison, 2 unmatched entries are contributing to the fn)     
-        assert cm["fields"]["Customers"]["aggregate"]["tp"] == 9, f"Expected Customers aggregate TP=9, got {cm["fields"]["Customers"]["aggregate"]['tp']}"
-        assert cm["fields"]["Customers"]["aggregate"]["fa"] == 3, f"Expected Customers aggregate FA=3, got {cm["fields"]["Customers"]["aggregate"]['fa']}"
-        assert cm["fields"]["Customers"]["aggregate"]["fd"] == 2, f"Expected Customers aggregate FD=2, got {cm["fields"]["Customers"]["aggregate"]['fd']}"
-        assert cm["fields"]["Customers"]["aggregate"]["tn"] == 5, f"Expected Customers aggregate TN=5, got {cm["fields"]["Customers"]["aggregate"]['tn']}"
-        assert cm["fields"]["Customers"]["aggregate"]["fn"] == 13, f"Expected Customers aggregate FN=13, got {cm["fields"]["Customers"]["aggregate"]['fn']}"
+        assert cm["fields"]["Customers"]["aggregate"]["tp"] == 9, f'Expected Customers aggregate TP=9, got {cm["fields"]["Customers"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Customers"]["aggregate"]["fa"] == 3, f'Expected Customers aggregate FA=3, got {cm["fields"]["Customers"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Customers"]["aggregate"]["fd"] == 2, f'Expected Customers aggregate FD=2, got {cm["fields"]["Customers"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Customers"]["aggregate"]["tn"] == 5, f'Expected Customers aggregate TN=5, got {cm["fields"]["Customers"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Customers"]["aggregate"]["fn"] == 13, f'Expected Customers aggregate FN=13, got {cm["fields"]["Customers"]["aggregate"]["fn"]}'
 
     def test_products_field_aggregate_counts(self):
         """Test the Products field aggregate counts."""
@@ -404,36 +393,36 @@ class TestEcommerceOrdersAggregateComprehensive:
         
         cm = result["confusion_matrix"]
         
-        # gt_json['Products'][0]['Product_Id'], pred_json['Products'][0]['Product_Id']:  1 true positive
-        # gt_json['Products'][1]['Product_Id'], pred_json['Products'][1]['Product_Id']:  1 true positive
-        assert cm["fields"]["Products"]['fields']['Product_Id']['aggregate']['tp'] == 2, f"Expected Product_Id aggregate TP=2, got {cm["fields"]["Products"]['fields']['Product_Id']['aggregate']['tp']}"
-        assert cm["fields"]["Products"]['fields']['Product_Id']['aggregate']['fa'] == 0, f"Expected Product_Id aggregate FA=0, got {cm["fields"]["Products"]['fields']['Product_Id']['aggregate']['fa']}"
-        assert cm["fields"]["Products"]['fields']['Product_Id']['aggregate']['fd'] == 0, f"Expected Product_Id aggregate FD=0, got {cm["fields"]["Products"]['fields']['Product_Id']['aggregate']['fd']}"
-        assert cm["fields"]["Products"]['fields']['Product_Id']['aggregate']['tn'] == 0, f"Expected Product_Id aggregate TN=0, got {cm["fields"]["Products"]['fields']['Product_Id']['aggregate']['tn']}"
-        assert cm["fields"]["Products"]['fields']['Product_Id']['aggregate']['fn'] == 0, f"Expected Product_Id aggregate FN=0, got {cm["fields"]["Products"]['fields']['Product_Id']['aggregate']['fn']}"
+        # gt_json["Products"][0]["Product_Id"], pred_json["Products"][0]["Product_Id"]:  1 true positive
+        # gt_json["Products"][1]["Product_Id"], pred_json["Products"][1]["Product_Id"]:  1 true positive
+        assert cm["fields"]["Products"]["fields"]["Product_Id"]["aggregate"]["tp"] == 2, f'Expected Product_Id aggregate TP=2, got {cm["fields"]["Products"]["fields"]["Product_Id"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Products"]["fields"]["Product_Id"]["aggregate"]["fa"] == 0, f'Expected Product_Id aggregate FA=0, got {cm["fields"]["Products"]["fields"]["Product_Id"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Products"]["fields"]["Product_Id"]["aggregate"]["fd"] == 0, f'Expected Product_Id aggregate FD=0, got {cm["fields"]["Products"]["fields"]["Product_Id"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Products"]["fields"]["Product_Id"]["aggregate"]["tn"] == 0, f'Expected Product_Id aggregate TN=0, got {cm["fields"]["Products"]["fields"]["Product_Id"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Products"]["fields"]["Product_Id"]["aggregate"]["fn"] == 0, f'Expected Product_Id aggregate FN=0, got {cm["fields"]["Products"]["fields"]["Product_Id"]["aggregate"]["fn"]}'
 
-        # gt_json['Products'][0]['Product_Category'], pred_json['Products'][0]['Product_Category']:  1 true positive
-        # gt_json['Products'][1]['Product_Category'], pred_json['Products'][1]['Product_Category']:  1 false discovery
+        # gt_json["Products"][0]["Product_Category"], pred_json["Products"][0]["Product_Category"]:  1 true positive
+        # gt_json["Products"][1]["Product_Category"], pred_json["Products"][1]["Product_Category"]:  1 false discovery
         # Category_Name fields should be ignored since CategoryOnly model only defines Category_Code field, not Category_Name field
-        assert cm["fields"]["Products"]['fields']['Product_Category']['aggregate']['tp'] == 1, f"Expected Product_Category aggregate TP=1, got {cm["fields"]["Products"]['fields']['Product_Category']['aggregate']['tp']}"
-        assert cm["fields"]["Products"]['fields']['Product_Category']['aggregate']['fa'] == 0, f"Expected Product_Category aggregate FA=0, got {cm["fields"]["Products"]['fields']['Product_Category']['aggregate']['fa']}"
-        assert cm["fields"]["Products"]['fields']['Product_Category']['aggregate']['fd'] == 1, f"Expected Product_Category aggregate FD=1, got {cm["fields"]["Products"]['fields']['Product_Category']['aggregate']['fd']}"
-        assert cm["fields"]["Products"]['fields']['Product_Category']['aggregate']['tn'] == 0, f"Expected Product_Category aggregate TN=0, got {cm["fields"]["Products"]['fields']['Product_Category']['aggregate']['tn']}"
-        assert cm["fields"]["Products"]['fields']['Product_Category']['aggregate']['fn'] == 0, f"Expected Product_Category aggregate FN=0, got {cm["fields"]["Products"]['fields']['Product_Category']['aggregate']['fn']}"
+        assert cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["tp"] == 1, f'Expected Product_Category aggregate TP=1, got {cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["fa"] == 0, f'Expected Product_Category aggregate FA=0, got {cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["fd"] == 1, f'Expected Product_Category aggregate FD=1, got {cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["tn"] == 0, f'Expected Product_Category aggregate TN=0, got {cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["fn"] == 0, f'Expected Product_Category aggregate FN=0, got {cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["fn"]}'
 
         # at the object level with match_threshold = 1.0, 1 true positve, 1 false discovery (2 entries are matched, but only one match is above threshold)
-        assert cm["fields"]["Products"]["overall"]["tp"] == 1, f"Expected Products overall TP=1, got {cm["fields"]["Products"]["overall"]["tp"]}"
-        assert cm["fields"]["Products"]["overall"]["fa"] == 0, f"Expected Products overall FA=0, got {cm["fields"]["Products"]["overall"]['fa']}"
-        assert cm["fields"]["Products"]["overall"]["fd"] == 1, f"Expected Products overall FD=1, got {cm["fields"]["Products"]["overall"]['fd']}"
-        assert cm["fields"]["Products"]["overall"]["tn"] == 0, f"Expected Products overall TN=0, got {cm["fields"]["Products"]["overall"]['tn']}"
-        assert cm["fields"]["Products"]["overall"]["fn"] == 0, f"Expected Products overall FN=0, got {cm["fields"]["Products"]["overall"]['fn']}"
+        assert cm["fields"]["Products"]["overall"]["tp"] == 1, f'Expected Products overall TP=1, got {cm["fields"]["Products"]["overall"]["tp"]}'
+        assert cm["fields"]["Products"]["overall"]["fa"] == 0, f'Expected Products overall FA=0, got {cm["fields"]["Products"]["overall"]["fa"]}'
+        assert cm["fields"]["Products"]["overall"]["fd"] == 1, f'Expected Products overall FD=1, got {cm["fields"]["Products"]["overall"]["fd"]}'
+        assert cm["fields"]["Products"]["overall"]["tn"] == 0, f'Expected Products overall TN=0, got {cm["fields"]["Products"]["overall"]["tn"]}'
+        assert cm["fields"]["Products"]["overall"]["fn"] == 0, f'Expected Products overall FN=0, got {cm["fields"]["Products"]["overall"]["fn"]}'
 
         # at the field level within all matched entries (2 matched entries are considered for the sub field comparison)     
-        assert cm["fields"]["Products"]["aggregate"]["tp"] == 3, f"Expected Products aggregate TP=3, got {cm["fields"]["Products"]["aggregate"]['tp']}"
-        assert cm["fields"]["Products"]["aggregate"]["fa"] == 0, f"Expected Products aggregate FA=0, got {cm["fields"]["Products"]["aggregate"]['fa']}"
-        assert cm["fields"]["Products"]["aggregate"]["fd"] == 1, f"Expected Products aggregate FD=1, got {cm["fields"]["Products"]["aggregate"]['fd']}"
-        assert cm["fields"]["Products"]["aggregate"]["tn"] == 0, f"Expected Products aggregate TN=0, got {cm["fields"]["Products"]["aggregate"]['tn']}"
-        assert cm["fields"]["Products"]["aggregate"]["fn"] == 0, f"Expected Products aggregate FN=0, got {cm["fields"]["Products"]["aggregate"]['fn']}"
+        assert cm["fields"]["Products"]["aggregate"]["tp"] == 3, f'Expected Products aggregate TP=3, got {cm["fields"]["Products"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Products"]["aggregate"]["fa"] == 0, f'Expected Products aggregate FA=0, got {cm["fields"]["Products"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Products"]["aggregate"]["fd"] == 1, f'Expected Products aggregate FD=1, got {cm["fields"]["Products"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Products"]["aggregate"]["tn"] == 0, f'Expected Products aggregate TN=0, got {cm["fields"]["Products"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Products"]["aggregate"]["fn"] == 0, f'Expected Products aggregate FN=0, got {cm["fields"]["Products"]["aggregate"]["fn"]}'
 
     def test_discounts_field_aggregate_counts(self):
         """Test the Discounts field aggregate counts."""
@@ -444,27 +433,27 @@ class TestEcommerceOrdersAggregateComprehensive:
         
         cm = result["confusion_matrix"]
 
-        # gt_json['Customers'][0]['Customer_Id'], pred_json['Customers'][0]['Customer_Id']: 1 true positive
-        # gt_json['Customers'][3]['Customer_Id'], pred_json['Customers'][1]['Customer_Id']: 1 false discovery
-        assert cm["fields"]["Discounts"]['fields']['Customer_Id']['aggregate']['tp'] == 1, f"Expected Customer_Id aggregate TP=1, got {cm["fields"]["Discounts"]['fields']['Customer_Id']['aggregate']['tp']}"
-        assert cm["fields"]["Discounts"]['fields']['Customer_Id']['aggregate']['fa'] == 0, f"Expected Customer_Id aggregate FA=0, got {cm["fields"]["Discounts"]['fields']['Customer_Id']['aggregate']['fa']}"
-        assert cm["fields"]["Discounts"]['fields']['Customer_Id']['aggregate']['fd'] == 1, f"Expected Customer_Id aggregate FD=1, got {cm["fields"]["Discounts"]['fields']['Customer_Id']['aggregate']['fd']}"
-        assert cm["fields"]["Discounts"]['fields']['Customer_Id']['aggregate']['tn'] == 0, f"Expected Customer_Id aggregate TN=0, got {cm["fields"]["Discounts"]['fields']['Customer_Id']['aggregate']['tn']}"
-        assert cm["fields"]["Discounts"]['fields']['Customer_Id']['aggregate']['fn'] == 2, f"Expected Customer_Id aggregate FN=2, got {cm["fields"]["Discounts"]['fields']['Customer_Id']['aggregate']['fn']}"
+        # gt_json["Customers"][0]["Customer_Id"], pred_json["Customers"][0]["Customer_Id"]: 1 true positive
+        # gt_json["Customers"][3]["Customer_Id"], pred_json["Customers"][1]["Customer_Id"]: 1 false discovery
+        assert cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["tp"] == 1, f'Expected Customer_Id aggregate TP=1, got {cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["fa"] == 0, f'Expected Customer_Id aggregate FA=0, got {cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["fd"] == 1, f'Expected Customer_Id aggregate FD=1, got {cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["tn"] == 0, f'Expected Customer_Id aggregate TN=0, got {cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["fn"] == 2, f'Expected Customer_Id aggregate FN=2, got {cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["fn"]}'
 
         # at the object level with match_threshold = 1.0, 1 false discovery (no matches are made)
-        assert cm["fields"]["Discounts"]["overall"]["tp"] == 0, f"Expected Discounts overall TP=0, got {cm["fields"]["Discounts"]["overall"]["tp"]}"
-        assert cm["fields"]["Discounts"]["overall"]["fa"] == 0, f"Expected Discounts overall FA=0, got {cm["fields"]["Discounts"]["overall"]['fa']}"
-        assert cm["fields"]["Discounts"]["overall"]["fd"] == 1, f"Expected Discounts overall FD=1, got {cm["fields"]["Discounts"]["overall"]['fd']}"
-        assert cm["fields"]["Discounts"]["overall"]["tn"] == 0, f"Expected Discounts overall TN=0, got {cm["fields"]["Discounts"]["overall"]['tn']}"
-        assert cm["fields"]["Discounts"]["overall"]["fn"] == 0, f"Expected Discounts overall FN=0, got {cm["fields"]["Discounts"]["overall"]['fn']}"
+        assert cm["fields"]["Discounts"]["overall"]["tp"] == 0, f'Expected Discounts overall TP=0, got {cm["fields"]["Discounts"]["overall"]["tp"]}'
+        assert cm["fields"]["Discounts"]["overall"]["fa"] == 0, f'Expected Discounts overall FA=0, got {cm["fields"]["Discounts"]["overall"]["fa"]}'
+        assert cm["fields"]["Discounts"]["overall"]["fd"] == 1, f'Expected Discounts overall FD=1, got {cm["fields"]["Discounts"]["overall"]["fd"]}'
+        assert cm["fields"]["Discounts"]["overall"]["tn"] == 0, f'Expected Discounts overall TN=0, got {cm["fields"]["Discounts"]["overall"]["tn"]}'
+        assert cm["fields"]["Discounts"]["overall"]["fn"] == 0, f'Expected Discounts overall FN=0, got {cm["fields"]["Discounts"]["overall"]["fn"]}'
 
         # at the field level within all matched entries (no matches, but same length, so the two entries are compared)  
-        assert cm["fields"]["Discounts"]["aggregate"]["tp"] == 1, f"Expected Discounts aggregate TP=1, got {cm["fields"]["Discounts"]["aggregate"]['tp']}"
-        assert cm["fields"]["Discounts"]["aggregate"]["fa"] == 0, f"Expected Discounts aggregate FA=0, got {cm["fields"]["Discounts"]["aggregate"]['fa']}"
-        assert cm["fields"]["Discounts"]["aggregate"]["fd"] == 1, f"Expected Discounts aggregate FD=1, got {cm["fields"]["Discounts"]["aggregate"]['fd']}"
-        assert cm["fields"]["Discounts"]["aggregate"]["tn"] == 1, f"Expected Discounts aggregate TN=1, got {cm["fields"]["Discounts"]["aggregate"]['tn']}"
-        assert cm["fields"]["Discounts"]["aggregate"]["fn"] == 0, f"Expected Discounts aggregate FN=0, got {cm["fields"]["Discounts"]["aggregate"]['fn']}"
+        assert cm["fields"]["Discounts"]["aggregate"]["tp"] == 1, f'Expected Discounts aggregate TP=1, got {cm["fields"]["Discounts"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Discounts"]["aggregate"]["fa"] == 0, f'Expected Discounts aggregate FA=0, got {cm["fields"]["Discounts"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Discounts"]["aggregate"]["fd"] == 1, f'Expected Discounts aggregate FD=1, got {cm["fields"]["Discounts"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Discounts"]["aggregate"]["tn"] == 1, f'Expected Discounts aggregate TN=1, got {cm["fields"]["Discounts"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Discounts"]["aggregate"]["fn"] == 0, f'Expected Discounts aggregate FN=0, got {cm["fields"]["Discounts"]["aggregate"]["fn"]}'
 
     def test_hungarian_matching_verification(self):
         """Test that Hungarian matching works correctly for the Customers list."""
@@ -472,8 +461,8 @@ class TestEcommerceOrdersAggregateComprehensive:
         
         hungarian_helper = HungarianHelper()
         hungarian_info = hungarian_helper.get_complete_matching_info(
-            self.gt_json['Customers'], 
-            self.pred_json['Customers']
+            self.gt_json["Customers"], 
+            self.pred_json["Customers"]
         )
         matched_pairs = hungarian_info["matched_pairs"]
         
@@ -502,8 +491,8 @@ class TestEcommerceOrdersAggregateComprehensive:
         
         hungarian_helper = HungarianHelper()
         hungarian_info = hungarian_helper.get_complete_matching_info(
-            self.gt_json['Products'], 
-            self.pred_json['Products']
+            self.gt_json["Products"], 
+            self.pred_json["Products"]
         )
         matched_pairs = hungarian_info["matched_pairs"]
         
@@ -529,8 +518,8 @@ class TestEcommerceOrdersAggregateComprehensive:
         
         hungarian_helper = HungarianHelper()
         hungarian_info = hungarian_helper.get_complete_matching_info(
-            self.gt_json['Discounts'], 
-            self.pred_json['Discounts']
+            self.gt_json["Discounts"], 
+            self.pred_json["Discounts"]
         )
         matched_pairs = hungarian_info["matched_pairs"]
         
@@ -576,17 +565,17 @@ class TestEcommerceOrdersAggregateComprehensive:
         root_aggregate = cm["aggregate"]
         
         print(f"\n=== AGGREGATE CONSISTENCY CHECK ===")
-        print(f"Root TP: {root_aggregate['tp']}, Sum: {total_tp}")
-        print(f"Root FA: {root_aggregate['fa']}, Sum: {total_fa}")
-        print(f"Root FD: {root_aggregate['fd']}, Sum: {total_fd}")
-        print(f"Root TN: {root_aggregate['tn']}, Sum: {total_tn}")
-        print(f"Root FN: {root_aggregate['fn']}, Sum: {total_fn}")
+        print(f'Root TP: {root_aggregate["tp"]}, Sum: {total_tp}')
+        print(f'Root FA: {root_aggregate["fa"]}, Sum: {total_fa}')
+        print(f'Root FD: {root_aggregate["fd"]}, Sum: {total_fd}')
+        print(f'Root TN: {root_aggregate["tn"]}, Sum: {total_tn}')
+        print(f'Root FN: {root_aggregate["fn"]}, Sum: {total_fn}')
         
-        assert root_aggregate["tp"] == total_tp, f"Root TP {root_aggregate['tp']} != sum {total_tp}"
-        assert root_aggregate["fa"] == total_fa, f"Root FA {root_aggregate['fa']} != sum {total_fa}"
-        assert root_aggregate["fd"] == total_fd, f"Root FD {root_aggregate['fd']} != sum {total_fd}"
-        assert root_aggregate["tn"] == total_tn, f"Root TN {root_aggregate['tn']} != sum {total_tn}"
-        assert root_aggregate["fn"] == total_fn, f"Root FN {root_aggregate['fn']} != sum {total_fn}"
+        assert root_aggregate["tp"] == total_tp, f'Root TP {root_aggregate["tp"]} != sum {total_tp}'
+        assert root_aggregate["fa"] == total_fa, f'Root FA {root_aggregate["fa"]} != sum {total_fa}'
+        assert root_aggregate["fd"] == total_fd, f'Root FD {root_aggregate["fd"]} != sum {total_fd}'
+        assert root_aggregate["tn"] == total_tn, f'Root TN {root_aggregate["tn"]} != sum {total_tn}'
+        assert root_aggregate["fn"] == total_fn, f'Root FN {root_aggregate["fn"]} != sum {total_fn}'
 
     def test_empty_lists_aggregate_handling(self):
         """Test aggregate handling when lists are empty."""
@@ -630,9 +619,9 @@ class TestEcommerceOrdersAggregateComprehensive:
         products_agg = cm["fields"]["Products"]["aggregate"]
         discounts_agg = cm["fields"]["Discounts"]["aggregate"]
         
-        assert customers_agg["tn"] == 1, f"Expected Customers TN=1 for empty lists, got {customers_agg['tn']}"
-        assert products_agg["tn"] == 1, f"Expected Products TN=1 for empty lists, got {products_agg['tn']}"
-        assert discounts_agg["tn"] == 1, f"Expected Discounts TN=1 for empty lists, got {discounts_agg['tn']}"
+        assert customers_agg["tn"] == 1, f'Expected Customers TN=1 for empty lists, got {customers_agg["tn"]}'
+        assert products_agg["tn"] == 1, f'Expected Products TN=1 for empty lists, got {products_agg["tn"]}'
+        assert discounts_agg["tn"] == 1, f'Expected Discounts TN=1 for empty lists, got {discounts_agg["tn"]}'
 
     def test_nested_category_description_aggregation(self):
         """Test that nested CategoryDescription objects contribute correctly to aggregates."""
@@ -650,7 +639,7 @@ class TestEcommerceOrdersAggregateComprehensive:
         print(f"\n=== ORDER_INFO NESTED FIELDS ===")
         for field_name, field_data in order_info_fields.items():
             if isinstance(field_data, dict) and "aggregate" in field_data:
-                print(f"{field_name} aggregate: {field_data['aggregate']}")
+                print(f'{field_name} aggregate: {field_data["aggregate"]}')
 
     def test_threshold_based_classification(self):
         """Test that threshold-based classification works correctly in aggregates."""
@@ -689,7 +678,7 @@ class TestEcommerceOrdersAggregateComprehensive:
         cm = result["confusion_matrix"]
         
         print(f"\n=== THRESHOLD TEST RESULT ===")
-        print(json.dumps(cm["fields"]["Order_Info"]["aggregate"], indent=2))
+        print(json.dumps(cm["fields"]["Order_Info"]["aggregate"], indent=2, default=str))
         
         # Verify that threshold-based classification affects aggregates correctly
         order_info_agg = cm["fields"]["Order_Info"]["aggregate"]

--- a/tests/structured_object_evaluator/test_ecommerce_orders_aggregate_comprehensive.py
+++ b/tests/structured_object_evaluator/test_ecommerce_orders_aggregate_comprehensive.py
@@ -1,0 +1,613 @@
+"""
+Comprehensive test suite for aggregate counts functionality in structured_model.py
+Based on an e-commerce orders domain (transformed from police reports)
+
+This test file verifies that the aggregate confusion matrix counts work correctly
+for complex hierarchical structures with nested objects and lists.
+"""
+
+import json
+import pytest
+from typing import Optional, List, Any, Dict, Union
+
+from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+from stickler.structured_object_evaluator.models.comparable_field import ComparableField
+from stickler.comparators.levenshtein import LevenshteinComparator
+from stickler.comparators.numeric import NumericComparator
+from stickler.comparators.exact import ExactComparator
+from stickler.comparators.fuzzy import FuzzyComparator
+
+# Import the models from the e-commerce orders file
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+# Define the same field configurations as in the original model
+aggregate_field = ComparableField(
+    weight=1.0
+) 
+
+exact_field = ComparableField(
+    comparator=ExactComparator(),  
+    threshold=1.0,
+    weight=1.0
+) 
+
+exact_number = ComparableField(
+    comparator=NumericComparator(),  
+    threshold=1.0,
+    weight=1.0
+) 
+
+loose_field = ComparableField(
+    comparator=LevenshteinComparator(),  
+    threshold=0.75,
+    weight=1.0
+)
+
+fuzzy_field = ComparableField(
+    comparator=LevenshteinComparator(),  
+    threshold=0.80,
+    weight=1.0
+)
+
+category_description_field = ComparableField(
+    comparator=LevenshteinComparator(),  
+    weight=1.0
+)
+
+# Define the model classes for e-commerce orders
+class CategoryDescription(StructuredModel):
+    Category_Code: Union[Optional[str], Any] = exact_field
+    Category_Name: Union[Optional[str], Any] = ComparableField(
+        comparator=LevenshteinComparator(),  
+        threshold=0.85,
+        weight=1.0
+    )
+    match_threshold = 1.0
+
+class CategoryOnly(StructuredModel):
+    Category_Code: Union[Optional[str], Any] = exact_number
+    match_threshold = 1.0
+
+class OrderDetails(StructuredModel):
+    match_threshold = 1.0
+    Order_Status: Union[Optional[List[CategoryDescription]], Any] = category_description_field
+    Total_Amount: Union[Optional[str], Any] = exact_number
+    Store_Location: Union[Optional[str], Any] = exact_field
+    Payment_Method: Union[Optional[List[CategoryDescription]], Any] = category_description_field
+    Order_Notes: Union[Optional[str], Any] = loose_field
+
+class Customer(StructuredModel):
+    match_threshold = 1.0
+    Customer_Id: Union[Optional[str], Any] = exact_number
+    Customer_Type: Union[Optional[str], Any] = exact_field
+    Account_Number: Union[Optional[str], Any] = exact_number
+    Is_Premium_Member: Union[Optional[str], Any] = exact_field
+    Customer_Name: Union[Optional[str], Any] = exact_field
+    Shipping_Address: Union[Optional[str], Any] = loose_field
+    Loyalty_Status: Union[Optional[List[CategoryDescription]], Any] = category_description_field
+
+class Product(StructuredModel):
+    match_threshold = 1.0
+    Product_Id: Union[Optional[str], Any] = exact_number
+    Product_Category: Union[Optional[List[CategoryOnly]], Any] = aggregate_field
+
+class Discount(StructuredModel):
+    match_threshold = 1.0
+    Discount_Code: Union[Optional[List[CategoryDescription]], Any] = category_description_field
+
+class Order(StructuredModel):
+    Order_Info: OrderDetails = aggregate_field
+    Customers: List[Customer] = aggregate_field
+    Products: List[Product] = aggregate_field
+    Discounts: List[Discount] = aggregate_field
+
+
+class TestEcommerceOrdersAggregateComprehensive:
+    """Comprehensive test suite for aggregate counts functionality."""
+    
+    def setup_method(self):
+        """Set up test data from the e-commerce orders model."""
+        # Ground truth data
+        self.gt_str = """{"Order_Info": {"Order_Status": [{"Category_Code": "", "Category_Name": "PROCESSING"}],
+  "Total_Amount": "0",
+  "Store_Location": "",
+  "Payment_Method": [{"Category_Code": "A", "Category_Name": "Credit Card"}],
+  "Order_Notes": "express delivery"},
+ "Customers": [{"Customer_Id": "1",
+   "Customer_Type": "BUSINESS",
+   "Account_Number": "1",
+   "Customer_Name": "JOHN",
+   "Shipping_Address": "123 MAIN ST SUITE 100"},
+  {"Customer_Id": "2",
+   "Customer_Type": "INDIVIDUAL",
+   "Account_Number": "1",
+   "Is_Premium_Member": "Y",
+   "Customer_Name": "JOHN",
+   "Shipping_Address": "123 MAIN ST SUITE 100",
+   "Loyalty_Status": [{"Category_Code": "A",
+     "Category_Name": "Gold Member"}]},
+  {"Customer_Id": "3",
+   "Customer_Type": "BUSINESS",
+   "Account_Number": "2",
+   "Customer_Name": "SARAH",
+   "Shipping_Address": "123 MAIN ST SUITE 100"},
+  {"Customer_Id": "4",
+   "Customer_Type": "INDIVIDUAL",
+   "Account_Number": "2",
+   "Is_Premium_Member": "Y",
+   "Customer_Name": "SARAH",
+   "Shipping_Address": "123 MAIN ST SUITE 100"}],
+ "Discounts": [{"Discount_Code": [{"Category_Code": "", "Category_Name": "SAVE10"}]}],
+ "Products": [{"Product_Id": "1",
+   "Product_Category": [{"Category_Code": "04", "Category_Name": "Electronics"}]}, 
+  {"Product_Id": "2",
+   "Product_Category": [{"Category_Code": "01",
+     "Category_Name": "Home and Garden Supplies"}]}]}""" # Product_Category.Category_Name is not part of the structured model, should be ignored
+    
+        # Prediction data
+        self.pred_str = """{"Order_Info": {"Order_Status": [{"Category_Code": "", "Category_Name": "Processing"}],
+  "Total_Amount": "0",
+  "Store_Location": "",
+  "Payment_Method": [{"Category_Code": "A", "Category_Name": "CREDIT CARD"}, {"Category_Code": "C", "Category_Name": "PAYPAL"}],
+  "Order_Notes": "standard delivery"},
+ "Customers": [{"Customer_Id": "01",
+   "Customer_Type": "INDIVIDUAL",
+   "Account_Number": "01",
+   "Is_Premium_Member": "Y",
+   "Customer_Name": "JOHN",
+   "Shipping_Address": "123 MAIN ST SUITE 504",
+   "Loyalty_Status": [{"Category_Code": "A",
+     "Category_Name": "Gold Member"}]},
+  {"Customer_Id": "02",
+   "Customer_Type": "INDIVIDUAL",
+   "Account_Number": "02",
+   "Is_Premium_Member": "Y",
+   "Customer_Name": "SARAH",
+   "Shipping_Address": "123 MAIN ST SUITE 3203"}],
+ "Discounts": [{"Discount_Code": [{"Category_Code": "", "Category_Name": "SAVE20"}]}],
+ "Products": [{"Product_Id": "01",
+   "Product_Category": [{"Category_Code": "04"}]},
+  {"Product_Id": "02",
+   "Product_Category": [{"Category_Code": "02"}]}]}"""
+
+        self.gt_json = json.loads(self.gt_str)
+        self.pred_json = json.loads(self.pred_str)
+        
+        self.gt_order = Order.from_json(self.gt_json)
+        self.pred_order = Order.from_json(self.pred_json)
+
+    def test_full_comparison_with_expected_aggregate_counts(self):
+        """Test the full comparison with expected aggregate counts."""
+        result = self.gt_order.compare_with(
+            self.pred_order, 
+            include_confusion_matrix=True, 
+            document_non_matches=True
+        )
+        
+        # Print the result for debugging
+        print("\n=== FULL COMPARISON RESULT ===")
+        print(json.dumps(result, indent=2))
+        
+        # Verify that confusion matrix is included
+        assert "confusion_matrix" in result
+        cm = result["confusion_matrix"]
+        
+        # Verify that aggregate metrics are calculated
+        assert "aggregate" in cm
+        aggregate = cm["aggregate"]
+        
+        # Updated expected results based on correct Hungarian matching and aggregation:
+        # The Hungarian algorithm correctly matches GT[1]->Pred[0] and GT[3]->Pred[1] 
+        # based on optimal similarity scores, not the originally assumed GT[0]->Pred[0]
+        
+        print(f"\n=== AGGREGATE COUNTS ===")
+        print(f"TP: {aggregate.get('tp', 'MISSING')}, Expected: 19")
+        print(f"FA: {aggregate.get('fa', 'MISSING')}, Expected: 3")
+        print(f"FD: {aggregate.get('fd', 'MISSING')}, Expected: 4")
+        print(f"TN: {aggregate.get('tn', 'MISSING')}, Expected: 5")
+        print(f"FN: {aggregate.get('fn', 'MISSING')}, Expected: 11")
+        
+        # Verify the corrected aggregate counts
+        assert aggregate["tp"] == 19, f"Expected TP=19, got {aggregate['tp']}"
+        assert aggregate["fa"] == 3, f"Expected FA=3, got {aggregate['fa']}"
+        assert aggregate["fd"] == 4, f"Expected FD=4, got {aggregate['fd']}"
+        assert aggregate["tn"] == 5, f"Expected TN=5, got {aggregate['tn']}"
+        assert aggregate["fn"] == 11, f"Expected FN=11, got {aggregate['fn']}"
+
+    def test_order_info_field_aggregate_counts(self):
+        """Test the Order_Info field aggregate counts specifically."""
+        result = self.gt_order.compare_with(
+            self.pred_order, 
+            include_confusion_matrix=True
+        )
+        
+        cm = result["confusion_matrix"]
+        order_info_metrics = cm["fields"]["Order_Info"]["aggregate"]
+        
+        # Expected results from comments:
+        # result['confusion_matrix']['fields']['Order_Info']['aggregate']['tp']: 5
+        # result['confusion_matrix']['fields']['Order_Info']['aggregate']['fa']: 2
+        # result['confusion_matrix']['fields']['Order_Info']['aggregate']['fd']: 0
+        # result['confusion_matrix']['fields']['Order_Info']['aggregate']['tn']: 2
+        # result['confusion_matrix']['fields']['Order_Info']['aggregate']['fn']: 0
+        
+        print(f"\n=== ORDER_INFO AGGREGATE COUNTS ===")
+        print(f"TP: {order_info_metrics.get('tp', 'MISSING')}, Expected: 4")
+        print(f"FA: {order_info_metrics.get('fa', 'MISSING')}, Expected: 2")
+        print(f"FD: {order_info_metrics.get('fd', 'MISSING')}, Expected: 1")
+        print(f"TN: {order_info_metrics.get('tn', 'MISSING')}, Expected: 2")
+        print(f"FN: {order_info_metrics.get('fn', 'MISSING')}, Expected: 0")
+        
+        assert order_info_metrics["tp"] == 4, f"Expected Order_Info TP=4, got {order_info_metrics['tp']}"
+        assert order_info_metrics["fa"] == 2, f"Expected Order_Info FA=2, got {order_info_metrics['fa']}"
+        assert order_info_metrics["fd"] == 1, f"Expected Order_Info FD=1, got {order_info_metrics['fd']}"
+        assert order_info_metrics["tn"] == 2, f"Expected Order_Info TN=2, got {order_info_metrics['tn']}"
+        assert order_info_metrics["fn"] == 0, f"Expected Order_Info FN=0, got {order_info_metrics['fn']}"
+
+    def test_customers_field_aggregate_counts(self):
+        """Test the Customers field aggregate counts with Hungarian matching."""
+        result = self.gt_order.compare_with(
+            self.pred_order, 
+            include_confusion_matrix=True
+        )
+        
+        cm = result["confusion_matrix"]
+        customers_metrics = cm["fields"]["Customers"]["aggregate"]
+        
+        # Updated expected results based on correct Hungarian matching:
+        # Hungarian matches GT[1]->Pred[0] and GT[3]->Pred[1], not GT[0]->Pred[0] as originally assumed
+        
+        print(f"\n=== CUSTOMERS AGGREGATE COUNTS ===")
+        print(f"TP: {customers_metrics.get('tp', 'MISSING')}, Expected: 12")
+        print(f"FA: {customers_metrics.get('fa', 'MISSING')}, Expected: 0")
+        print(f"FD: {customers_metrics.get('fd', 'MISSING')}, Expected: 2")
+        print(f"TN: {customers_metrics.get('tn', 'MISSING')}, Expected: 2")
+        print(f"FN: {customers_metrics.get('fn', 'MISSING')}, Expected: 10")
+        
+        assert customers_metrics["tp"] == 12, f"Expected Customers TP=12, got {customers_metrics['tp']}"
+        assert customers_metrics["fa"] == 0, f"Expected Customers FA=0, got {customers_metrics['fa']}"
+        assert customers_metrics["fd"] == 2, f"Expected Customers FD=2, got {customers_metrics['fd']}"
+        assert customers_metrics["tn"] == 2, f"Expected Customers TN=2, got {customers_metrics['tn']}"
+        assert customers_metrics["fn"] == 10, f"Expected Customers FN=10, got {customers_metrics['fn']}"
+
+    def test_products_field_aggregate_counts(self):
+        """Test the Products field aggregate counts."""
+        result = self.gt_order.compare_with(
+            self.pred_order, 
+            include_confusion_matrix=True
+        )
+        
+        cm = result["confusion_matrix"]
+        products_metrics = cm["fields"]["Products"]["aggregate"]
+        
+        # Expected results from original comments - Category_Name fields should be ignored
+        # since CategoryOnly model only defines Category_Code field, not Category_Name field
+        
+        print(f"\n=== PRODUCTS AGGREGATE COUNTS ===")
+        print(f"TP: {products_metrics.get('tp', 'MISSING')}, Expected: 3")
+        print(f"FA: {products_metrics.get('fa', 'MISSING')}, Expected: 1") # Current implementation: Hungarian matching fails for Product_Category, treats as unmatched
+        print(f"FD: {products_metrics.get('fd', 'MISSING')}, Expected: 0") # Current implementation: Hungarian matching fails for Product_Category, treats as unmatched
+        print(f"TN: {products_metrics.get('tn', 'MISSING')}, Expected: 0")
+        print(f"FN: {products_metrics.get('fn', 'MISSING')}, Expected: 1")
+        
+        assert products_metrics["tp"] == 3, f"Expected Products TP=3, got {products_metrics['tp']}"
+        assert products_metrics["fa"] == 1, f"Expected Products FA=1, got {products_metrics['fa']}"
+        assert products_metrics["fd"] == 0, f"Expected Products FD=0, got {products_metrics['fd']}"
+        assert products_metrics["tn"] == 0, f"Expected Products TN=0, got {products_metrics['tn']}"
+        assert products_metrics["fn"] == 1, f"Expected Products FN=1, got {products_metrics['fn']}"
+
+    def test_discounts_field_aggregate_counts(self):
+        """Test the Discounts field aggregate counts."""
+        result = self.gt_order.compare_with(
+            self.pred_order, 
+            include_confusion_matrix=True
+        )
+        
+        cm = result["confusion_matrix"]
+        discounts_metrics = cm["fields"]["Discounts"]["aggregate"]
+        
+        # Expected results from comments:
+        # result['confusion_matrix']['fields']['Discounts']['aggregate']['tp']: 0
+        # result['confusion_matrix']['fields']['Discounts']['aggregate']['fa']: 0
+        # result['confusion_matrix']['fields']['Discounts']['aggregate']['fd']: 1
+        # result['confusion_matrix']['fields']['Discounts']['aggregate']['tn']: 1
+        # result['confusion_matrix']['fields']['Discounts']['aggregate']['fn']: 0
+        
+        print(f"\n=== DISCOUNTS AGGREGATE COUNTS ===")
+        print(f"TP: {discounts_metrics.get('tp', 'MISSING')}, Expected: 0")
+        print(f"FA: {discounts_metrics.get('fa', 'MISSING')}, Expected: 0")
+        print(f"FD: {discounts_metrics.get('fd', 'MISSING')}, Expected: 1")
+        print(f"TN: {discounts_metrics.get('tn', 'MISSING')}, Expected: 1")
+        print(f"FN: {discounts_metrics.get('fn', 'MISSING')}, Expected: 0")
+        
+        assert discounts_metrics["tp"] == 0, f"Expected Discounts TP=0, got {discounts_metrics['tp']}"
+        assert discounts_metrics["fa"] == 0, f"Expected Discounts FA=0, got {discounts_metrics['fa']}"
+        assert discounts_metrics["fd"] == 1, f"Expected Discounts FD=1, got {discounts_metrics['fd']}"
+        assert discounts_metrics["tn"] == 1, f"Expected Discounts TN=1, got {discounts_metrics['tn']}"
+        assert discounts_metrics["fn"] == 0, f"Expected Discounts FN=0, got {discounts_metrics['fn']}"
+
+    def test_hungarian_matching_verification(self):
+        """Test that Hungarian matching works correctly for the Customers list."""
+        from stickler.structured_object_evaluator.models.hungarian_helper import HungarianHelper
+        
+        hungarian_helper = HungarianHelper()
+        hungarian_info = hungarian_helper.get_complete_matching_info(
+            self.gt_json['Customers'], 
+            self.pred_json['Customers']
+        )
+        matched_pairs = hungarian_info["matched_pairs"]
+        
+        print(f"\n=== HUNGARIAN MATCHING RESULTS ===")
+        print(f"Matched pairs: {matched_pairs}")
+        
+        # Expected from comments:
+        # matched_pairs[0] should be (0, 0, some_number)
+        # matched_pairs[1] should be (3, 1, some_number)
+        
+        assert len(matched_pairs) == 2, f"Expected 2 matched pairs, got {len(matched_pairs)}"
+        
+        # Check the first match (GT index 0 should match with Pred index 0)
+        gt_idx_0, pred_idx_0, similarity_0 = matched_pairs[0]
+        assert gt_idx_0 == 0, f"Expected GT index 0, got {gt_idx_0}"
+        assert pred_idx_0 == 0, f"Expected Pred index 0, got {pred_idx_0}"
+        
+        # Check the second match (GT index 3 should match with Pred index 1)
+        gt_idx_1, pred_idx_1, similarity_1 = matched_pairs[1]
+        assert gt_idx_1 == 3, f"Expected GT index 3, got {gt_idx_1}"
+        assert pred_idx_1 == 1, f"Expected Pred index 1, got {pred_idx_1}"
+
+    def test_products_hungarian_matching(self):
+        """Test Hungarian matching for Products list."""
+        from stickler.structured_object_evaluator.models.hungarian_helper import HungarianHelper
+        
+        hungarian_helper = HungarianHelper()
+        hungarian_info = hungarian_helper.get_complete_matching_info(
+            self.gt_json['Products'], 
+            self.pred_json['Products']
+        )
+        matched_pairs = hungarian_info["matched_pairs"]
+        
+        print(f"\n=== PRODUCTS HUNGARIAN MATCHING ===")
+        print(f"Matched pairs: {matched_pairs}")
+        
+        # Expected from comments:
+        # matched_pairs[0] should be (0, 0, some_number)
+        # matched_pairs[1] should be (1, 1, some_number)
+        
+        assert len(matched_pairs) == 2, f"Expected 2 matched pairs, got {len(matched_pairs)}"
+        
+        # Verify the matches
+        gt_indices = [pair[0] for pair in matched_pairs]
+        pred_indices = [pair[1] for pair in matched_pairs]
+        
+        assert 0 in gt_indices and 0 in pred_indices, "Expected (0,0) match"
+        assert 1 in gt_indices and 1 in pred_indices, "Expected (1,1) match"
+
+    def test_discounts_hungarian_matching(self):
+        """Test Hungarian matching for Discounts list."""
+        from stickler.structured_object_evaluator.models.hungarian_helper import HungarianHelper
+        
+        hungarian_helper = HungarianHelper()
+        hungarian_info = hungarian_helper.get_complete_matching_info(
+            self.gt_json['Discounts'], 
+            self.pred_json['Discounts']
+        )
+        matched_pairs = hungarian_info["matched_pairs"]
+        
+        print(f"\n=== DISCOUNTS HUNGARIAN MATCHING ===")
+        print(f"Matched pairs: {matched_pairs}")
+        
+        # Discounts matching may result in 0 or 1 pairs depending on similarity threshold
+        # The current implementation correctly handles this case
+        
+        if len(matched_pairs) == 1:
+            gt_idx, pred_idx, similarity = matched_pairs[0]
+            assert gt_idx == 0, f"Expected GT index 0, got {gt_idx}"
+            assert pred_idx == 0, f"Expected Pred index 0, got {pred_idx}"
+        else:
+            # No matches found due to low similarity - this is acceptable
+            assert len(matched_pairs) == 0, f"Expected 0 or 1 matched pairs, got {len(matched_pairs)}"
+
+    def test_aggregate_consistency(self):
+        """Test that aggregate counts are consistent with sum of individual field counts."""
+        result = self.gt_order.compare_with(
+            self.pred_order, 
+            include_confusion_matrix=True
+        )
+        
+        cm = result["confusion_matrix"]
+        
+        # Calculate sum of all field aggregates
+        total_tp = 0
+        total_fa = 0
+        total_fd = 0
+        total_tn = 0
+        total_fn = 0
+        
+        for field_name in ["Order_Info", "Customers", "Products", "Discounts"]:
+            field_aggregate = cm["fields"][field_name]["aggregate"]
+            total_tp += field_aggregate["tp"]
+            total_fa += field_aggregate["fa"]
+            total_fd += field_aggregate["fd"]
+            total_tn += field_aggregate["tn"]
+            total_fn += field_aggregate["fn"]
+        
+        # Verify that root aggregate equals sum of field aggregates
+        root_aggregate = cm["aggregate"]
+        
+        print(f"\n=== AGGREGATE CONSISTENCY CHECK ===")
+        print(f"Root TP: {root_aggregate['tp']}, Sum: {total_tp}")
+        print(f"Root FA: {root_aggregate['fa']}, Sum: {total_fa}")
+        print(f"Root FD: {root_aggregate['fd']}, Sum: {total_fd}")
+        print(f"Root TN: {root_aggregate['tn']}, Sum: {total_tn}")
+        print(f"Root FN: {root_aggregate['fn']}, Sum: {total_fn}")
+        
+        assert root_aggregate["tp"] == total_tp, f"Root TP {root_aggregate['tp']} != sum {total_tp}"
+        assert root_aggregate["fa"] == total_fa, f"Root FA {root_aggregate['fa']} != sum {total_fa}"
+        assert root_aggregate["fd"] == total_fd, f"Root FD {root_aggregate['fd']} != sum {total_fd}"
+        assert root_aggregate["tn"] == total_tn, f"Root TN {root_aggregate['tn']} != sum {total_tn}"
+        assert root_aggregate["fn"] == total_fn, f"Root FN {root_aggregate['fn']} != sum {total_fn}"
+
+    def test_empty_lists_aggregate_handling(self):
+        """Test aggregate handling when lists are empty."""
+        # Create a minimal order with empty lists
+        empty_gt = {
+            "Order_Info": {
+                "Order_Status": [],
+                "Total_Amount": "0",
+                "Store_Location": "",
+                "Payment_Method": [],
+                "Order_Notes": "test"
+            },
+            "Customers": [],
+            "Products": [],
+            "Discounts": []
+        }
+        
+        empty_pred = {
+            "Order_Info": {
+                "Order_Status": [],
+                "Total_Amount": "0",
+                "Store_Location": "",
+                "Payment_Method": [],
+                "Order_Notes": "test"
+            },
+            "Customers": [],
+            "Products": [],
+            "Discounts": []
+        }
+        
+        gt_order = Order.from_json(empty_gt)
+        pred_order = Order.from_json(empty_pred)
+        
+        result = gt_order.compare_with(pred_order, include_confusion_matrix=True)
+        
+        # Verify that empty lists are handled correctly in aggregates
+        cm = result["confusion_matrix"]
+        
+        # Empty lists should contribute TN=1 each
+        customers_agg = cm["fields"]["Customers"]["aggregate"]
+        products_agg = cm["fields"]["Products"]["aggregate"]
+        discounts_agg = cm["fields"]["Discounts"]["aggregate"]
+        
+        assert customers_agg["tn"] == 1, f"Expected Customers TN=1 for empty lists, got {customers_agg['tn']}"
+        assert products_agg["tn"] == 1, f"Expected Products TN=1 for empty lists, got {products_agg['tn']}"
+        assert discounts_agg["tn"] == 1, f"Expected Discounts TN=1 for empty lists, got {discounts_agg['tn']}"
+
+    def test_nested_category_description_aggregation(self):
+        """Test that nested CategoryDescription objects contribute correctly to aggregates."""
+        result = self.gt_order.compare_with(
+            self.pred_order, 
+            include_confusion_matrix=True
+        )
+        
+        cm = result["confusion_matrix"]
+        
+        # Check that nested CategoryDescription fields are included in aggregates
+        # The Order_Info.Order_Status and Order_Info.Payment_Method should contribute
+        order_info_fields = cm["fields"]["Order_Info"]["fields"]
+        
+        print(f"\n=== ORDER_INFO NESTED FIELDS ===")
+        for field_name, field_data in order_info_fields.items():
+            if isinstance(field_data, dict) and "aggregate" in field_data:
+                print(f"{field_name} aggregate: {field_data['aggregate']}")
+
+    def test_threshold_based_classification(self):
+        """Test that threshold-based classification works correctly in aggregates."""
+        # Test with a simple case where we know the threshold behavior
+        simple_gt = {
+            "Order_Info": {
+                "Order_Status": [{"Category_Code": "A", "Category_Name": "EXACT MATCH"}],
+                "Total_Amount": "5",
+                "Store_Location": "TEST",
+                "Payment_Method": [],
+                "Order_Notes": "exact notes"
+            },
+            "Customers": [],
+            "Products": [],
+            "Discounts": []
+        }
+        
+        # Prediction with slight differences to test thresholds
+        simple_pred = {
+            "Order_Info": {
+                "Order_Status": [{"Category_Code": "A", "Category_Name": "EXACT MATCH"}],  # Should be TP
+                "Total_Amount": "5",  # Should be TP
+                "Store_Location": "TEST",  # Should be TP
+                "Payment_Method": [],  # Should be TN
+                "Order_Notes": "different notes"  # Should be FD (below threshold)
+            },
+            "Customers": [],
+            "Products": [],
+            "Discounts": []
+        }
+        
+        gt_order = Order.from_json(simple_gt)
+        pred_order = Order.from_json(simple_pred)
+        
+        result = gt_order.compare_with(pred_order, include_confusion_matrix=True)
+        cm = result["confusion_matrix"]
+        
+        print(f"\n=== THRESHOLD TEST RESULT ===")
+        print(json.dumps(cm["fields"]["Order_Info"]["aggregate"], indent=2))
+        
+        # Verify that threshold-based classification affects aggregates correctly
+        order_info_agg = cm["fields"]["Order_Info"]["aggregate"]
+        
+        # We should have some TPs and potentially some FDs based on thresholds
+        assert order_info_agg["tp"] > 0, "Should have some true positives"
+        assert order_info_agg["tp"] + order_info_agg["fd"] + order_info_agg["tn"] > 0, "Should have some classifications"
+
+
+if __name__ == "__main__":
+    # Run the tests
+    test_instance = TestEcommerceOrdersAggregateComprehensive()
+    test_instance.setup_method()
+    
+    print("Running comprehensive aggregate tests...")
+    
+    try:
+        test_instance.test_full_comparison_with_expected_aggregate_counts()
+        print("✓ Full comparison aggregate counts test passed")
+        
+        test_instance.test_order_info_field_aggregate_counts()
+        print("✓ Order info field aggregate counts test passed")
+        
+        test_instance.test_customers_field_aggregate_counts()
+        print("✓ Customers field aggregate counts test passed")
+        
+        test_instance.test_products_field_aggregate_counts()
+        print("✓ Products field aggregate counts test passed")
+        
+        test_instance.test_discounts_field_aggregate_counts()
+        print("✓ Discounts field aggregate counts test passed")
+        
+        test_instance.test_hungarian_matching_verification()
+        print("✓ Hungarian matching verification test passed")
+        
+        test_instance.test_products_hungarian_matching()
+        print("✓ Products Hungarian matching test passed")
+        
+        test_instance.test_discounts_hungarian_matching()
+        print("✓ Discounts Hungarian matching test passed")
+        
+        test_instance.test_aggregate_consistency()
+        print("✓ Aggregate consistency test passed")
+        
+        test_instance.test_empty_lists_aggregate_handling()
+        print("✓ Empty lists aggregate handling test passed")
+        
+        test_instance.test_nested_category_description_aggregation()
+        print("✓ Nested category description aggregation test passed")
+        
+        test_instance.test_threshold_based_classification()
+        print("✓ Threshold-based classification test passed")
+        
+        print("\n🎉 All aggregate tests passed successfully!")
+        
+    except Exception as e:
+        print(f"\n❌ Test failed with error: {e}")
+        import traceback
+        traceback.print_exc()

--- a/tests/structured_object_evaluator/test_ecommerce_orders_aggregate_comprehensive.py
+++ b/tests/structured_object_evaluator/test_ecommerce_orders_aggregate_comprehensive.py
@@ -1,6 +1,6 @@
 """
 Comprehensive test suite for aggregate counts functionality in structured_model.py
-Based on an e-commerce orders domain (transformed from police reports)
+Based on an e-commerce orders domain
 
 This test file verifies that the aggregate confusion matrix counts work correctly
 for complex hierarchical structures with nested objects and lists.

--- a/tests/structured_object_evaluator/test_ecommerce_orders_aggregate_comprehensive.py
+++ b/tests/structured_object_evaluator/test_ecommerce_orders_aggregate_comprehensive.py
@@ -416,10 +416,11 @@ class TestEcommerceOrdersAggregateComprehensive:
         assert cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["tn"] == 0, f'Expected Customer_Id aggregate TN=0, got {cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["tn"]}'
         assert cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["fn"] == 0, f'Expected Customer_Id aggregate FN=0, got {cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["fn"]}'
 
-        # gt_json["Discounts"][0]["Discount_Code"], pred_json["Discounts"][0]["Discount_Code"]: 1 false discovery at object level
+        # gt_json["Discounts"][0]["Discount_Code"], pred_json["Discounts"][0]["Discount_Code"]: 1 false discovery at field level
+        # With threshold-gated recursion: below-threshold matches should have empty "overall" metrics
         assert cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["tp"] == 0, f'Expected Discount_Code overall TP=0, got {cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["tp"]}'
         assert cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["fa"] == 0, f'Expected Discount_Code overall FA=0, got {cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["fa"]}'
-        assert cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["fd"] == 1, f'Expected Discount_Code overall FD=1, got {cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["fd"]}'
+        assert cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["fd"] == 0, f'Expected Discount_Code overall FD=0, got {cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["fd"]}'
         assert cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["tn"] == 0, f'Expected Discount_Code overall TN=0, got {cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["tn"]}'
         assert cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["fn"] == 0, f'Expected Discount_Code overall FN=0, got {cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["fn"]}'
 
@@ -431,6 +432,7 @@ class TestEcommerceOrdersAggregateComprehensive:
         assert cm["fields"]["Discounts"]["fields"]["Discount_Code"]["aggregate"]["fn"] == 0, f'Expected Discount_Code aggregate FN=0, got {cm["fields"]["Discounts"]["fields"]["Discount_Code"]["aggregate"]["fn"]}'
 
         # at the object level with match_threshold = 1.0, 1 false discovery (1 entry is matched, but below threshold)
+        # Object-level metrics are NOT subject to threshold-gating, only field-level metrics are
         assert cm["fields"]["Discounts"]["overall"]["tp"] == 0, f'Expected Discounts overall TP=0, got {cm["fields"]["Discounts"]["overall"]["tp"]}'
         assert cm["fields"]["Discounts"]["overall"]["fa"] == 0, f'Expected Discounts overall FA=0, got {cm["fields"]["Discounts"]["overall"]["fa"]}'
         assert cm["fields"]["Discounts"]["overall"]["fd"] == 1, f'Expected Discounts overall FD=1, got {cm["fields"]["Discounts"]["overall"]["fd"]}'

--- a/tests/structured_object_evaluator/test_ecommerce_orders_aggregate_comprehensive.py
+++ b/tests/structured_object_evaluator/test_ecommerce_orders_aggregate_comprehensive.py
@@ -178,32 +178,6 @@ class TestEcommerceOrdersAggregateComprehensive:
         self.gt_order = Order.from_json(self.gt_json)
         self.pred_order = Order.from_json(self.pred_json)
 
-    def test_full_comparison_with_expected_aggregate_counts(self):
-        """Test the full comparison with expected aggregate counts."""
-        result = self.gt_order.compare_with(
-            self.pred_order, 
-            include_confusion_matrix=True, 
-            document_non_matches=True
-        )
-        
-        # Print the result for debugging
-        print("\n=== FULL COMPARISON RESULT ===")
-        print(json.dumps(result, indent=2, default=str))
-        
-        # Verify that confusion matrix is included
-        assert "confusion_matrix" in result
-        cm = result["confusion_matrix"]
-        
-        # Verify that aggregate metrics are calculated
-        assert "aggregate" in cm
-        aggregate = cm["aggregate"]
-        
-        assert aggregate["tp"] == 17, f'Expected TP=17, got {aggregate["tp"]}'
-        assert aggregate["fa"] == 5, f'Expected FA=5, got {aggregate["fa"]}'
-        assert aggregate["fd"] == 5, f'Expected FD=5, got {aggregate["fd"]}'
-        assert aggregate["tn"] == 8, f'Expected TN=8, got {aggregate["tn"]}'
-        assert aggregate["fn"] == 13, f'Expected FN=11, got {aggregate["fn"]}'
-
     def test_order_info_field_aggregate_counts(self):
         """Test the Order_Info field aggregate counts specifically."""
         result = self.gt_order.compare_with(
@@ -281,10 +255,10 @@ class TestEcommerceOrdersAggregateComprehensive:
         assert cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["aggregate"]["fn"] == 0, f'Expected Order_Notes aggregate FN=0, got {cm["fields"]["Order_Info"]["fields"]["Order_Notes"]["aggregate"]["fn"]}'
 
         # at the object level with exact match, 1 false discovery
-        assert cm["fields"]["Order_Info"]["overall"]["tp"] == 0, f'Expected Order_Info overall TP=5, got {cm["fields"]["Order_Info"]["overall"]["tp"]}'
-        assert cm["fields"]["Order_Info"]["overall"]["fa"] == 0, f'Expected Order_Info overall FA=2, got {cm["fields"]["Order_Info"]["overall"]["fa"]}'
+        assert cm["fields"]["Order_Info"]["overall"]["tp"] == 0, f'Expected Order_Info overall TP=0, got {cm["fields"]["Order_Info"]["overall"]["tp"]}'
+        assert cm["fields"]["Order_Info"]["overall"]["fa"] == 0, f'Expected Order_Info overall FA=0, got {cm["fields"]["Order_Info"]["overall"]["fa"]}'
         assert cm["fields"]["Order_Info"]["overall"]["fd"] == 1, f'Expected Order_Info overall FD=1, got {cm["fields"]["Order_Info"]["overall"]["fd"]}'
-        assert cm["fields"]["Order_Info"]["overall"]["tn"] == 0, f'Expected Order_Info overall TN=1, got {cm["fields"]["Order_Info"]["overall"]["tn"]}'
+        assert cm["fields"]["Order_Info"]["overall"]["tn"] == 0, f'Expected Order_Info overall TN=0, got {cm["fields"]["Order_Info"]["overall"]["tn"]}'
         assert cm["fields"]["Order_Info"]["overall"]["fn"] == 0, f'Expected Order_Info overall FN=0, got {cm["fields"]["Order_Info"]["overall"]["fn"]}'
 
         # at the field level within all nested fields, 5 true positives, 2 false alarms, 1 false discovery and 1 true negative
@@ -305,70 +279,69 @@ class TestEcommerceOrdersAggregateComprehensive:
 
         # Hungarian matches GT[1]->Pred[0] and GT[3]->Pred[1]
 
-        # gt_json["Customers"][0]["Customer_Id"], pred_json["Customers"][0]["Customer_Id"]:  1 true positive
+        # gt_json["Customers"][1]["Customer_Id"], pred_json["Customers"][0]["Customer_Id"]:  1 false discovery
         # gt_json["Customers"][3]["Customer_Id"], pred_json["Customers"][1]["Customer_Id"]:  1 false discovery
-        # gt_json["Customers"][1]["Customer_Id"], gt_json["Customers"][2]["Customer_Id"]:  2 false neagtive
-        assert cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["tp"] == 1, f'Expected Customer_Id aggregate TP=1, got {cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["tp"]}'
+        # gt_json["Customers"][0]["Customer_Id"], gt_json["Customers"][2]["Customer_Id"]:  2 false neagtive
+        assert cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["tp"] == 0, f'Expected Customer_Id aggregate TP=0, got {cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["tp"]}'
         assert cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["fa"] == 0, f'Expected Customer_Id aggregate FA=0, got {cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["fa"]}'
-        assert cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["fd"] == 1, f'Expected Customer_Id aggregate FD=1, got {cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["fd"] == 2, f'Expected Customer_Id aggregate FD=2, got {cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["fd"]}'
         assert cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["tn"] == 0, f'Expected Customer_Id aggregate TN=0, got {cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["tn"]}'
         assert cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["fn"] == 2, f'Expected Customer_Id aggregate FN=2, got {cm["fields"]["Customers"]["fields"]["Customer_Id"]["aggregate"]["fn"]}'
 
-        # gt_json["Customers"][0]["Customer_Type"], pred_json["Customers"][0]["Customer_Type"]:  1 false discovery
+        # gt_json["Customers"][1]["Customer_Type"], pred_json["Customers"][0]["Customer_Type"]:  1 true positive
         # gt_json["Customers"][3]["Customer_Type"], pred_json["Customers"][1]["Customer_Type"]:  1 true positive
-        # gt_json["Customers"][1]["Customer_Type"], gt_json["Customers"][2]["Customer_Type"]:  2 false neagtive
-        assert cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["tp"] == 1, f'Expected Customer_Type aggregate TP=1, got {cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["tp"]}'
+        # gt_json["Customers"][0]["Customer_Type"], gt_json["Customers"][2]["Customer_Type"]:  2 false neagtive
+        assert cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["tp"] == 2, f'Expected Customer_Type aggregate TP=2, got {cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["tp"]}'
         assert cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["fa"] == 0, f'Expected Customer_Type aggregate FA=0, got {cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["fa"]}'
-        assert cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["fd"] == 1, f'Expected Customer_Type aggregate FD=1, got {cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["fd"] == 0, f'Expected Customer_Type aggregate FD=0, got {cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["fd"]}'
         assert cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["tn"] == 0, f'Expected Customer_Type aggregate TN=0, got {cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["tn"]}'
         assert cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["fn"] == 2, f'Expected Customer_Type aggregate FN=2, got {cm["fields"]["Customers"]["fields"]["Customer_Type"]["aggregate"]["fn"]}'
 
-        # gt_json["Customers"][0]["Account_Number"], pred_json["Customers"][0]["Account_Number"]:  1 true positive
+        # gt_json["Customers"][1]["Account_Number"], pred_json["Customers"][0]["Account_Number"]:  1 true positive
         # gt_json["Customers"][3]["Account_Number"], pred_json["Customers"][1]["Account_Number"]:  1 true positive
-        # gt_json["Customers"][1]["Account_Number"], gt_json["Customers"][2]["Account_Number"]:  2 false neagtive
+        # gt_json["Customers"][0]["Account_Number"], gt_json["Customers"][2]["Account_Number"]:  2 false neagtive
         assert cm["fields"]["Customers"]["fields"]["Account_Number"]["aggregate"]["tp"] == 2, f'Expected Account_Number aggregate TP=2, got {cm["fields"]["Customers"]["fields"]["Account_Number"]["aggregate"]["tp"]}'
         assert cm["fields"]["Customers"]["fields"]["Account_Number"]["aggregate"]["fa"] == 0, f'Expected Account_Number aggregate FA=0, got {cm["fields"]["Customers"]["fields"]["Account_Number"]["aggregate"]["fa"]}'
         assert cm["fields"]["Customers"]["fields"]["Account_Number"]["aggregate"]["fd"] == 0, f'Expected Account_Number aggregate FD=0, got {cm["fields"]["Customers"]["fields"]["Account_Number"]["aggregate"]["fd"]}'
         assert cm["fields"]["Customers"]["fields"]["Account_Number"]["aggregate"]["tn"] == 0, f'Expected Account_Number aggregate TN=0, got {cm["fields"]["Customers"]["fields"]["Account_Number"]["aggregate"]["tn"]}'
         assert cm["fields"]["Customers"]["fields"]["Account_Number"]["aggregate"]["fn"] == 2, f'Expected Account_Number aggregate FN=2, got {cm["fields"]["Customers"]["fields"]["Account_Number"]["aggregate"]["fn"]}'
 
-        # gt_json["Customers"][0]["Is_Premium_Member"], pred_json["Customers"][0]["Is_Premium_Member"]:  1 false alarm
+        # gt_json["Customers"][1]["Is_Premium_Member"], pred_json["Customers"][0]["Is_Premium_Member"]:  1 true positive
         # gt_json["Customers"][3]["Is_Premium_Member"], pred_json["Customers"][1]["Is_Premium_Member"]:  1 true positive
-        # gt_json["Customers"][1]["Is_Premium_Member"]:  1 false neagtive
-        # gt_json["Customers"][2]["Is_Premium_Member"]: 1 true negative
-        assert cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["tp"] == 1, f'Expected Is_Premium_Member aggregate TP=1, got {cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["tp"]}'
-        assert cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["fa"] == 1, f'Expected Is_Premium_Member aggregate FA=1, got {cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["fa"]}'
+        # gt_json["Customers"][0]["Is_Premium_Member"], gt_json["Customers"][2]["Is_Premium_Member"]: 2 true negative
+        assert cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["tp"] == 2, f'Expected Is_Premium_Member aggregate TP=2, got {cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["fa"] == 0, f'Expected Is_Premium_Member aggregate FA=0, got {cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["fa"]}'
         assert cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["fd"] == 0, f'Expected Is_Premium_Member aggregate FD=0, got {cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["fd"]}'
-        assert cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["tn"] == 1, f'Expected Is_Premium_Member aggregate TN=1, got {cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["tn"]}'
-        assert cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["fn"] == 1, f'Expected Is_Premium_Member aggregate FN=1, got {cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["fn"]}'
+        assert cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["tn"] == 2, f'Expected Is_Premium_Member aggregate TN=2, got {cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["fn"] == 0, f'Expected Is_Premium_Member aggregate FN=0, got {cm["fields"]["Customers"]["fields"]["Is_Premium_Member"]["aggregate"]["fn"]}'
 
-        # gt_json["Customers"][0]["Customer_Name"], pred_json["Customers"][0]["Customer_Name"]:  1 true positive
+        # gt_json["Customers"][1]["Customer_Name"], pred_json["Customers"][0]["Customer_Name"]:  1 true positive
         # gt_json["Customers"][3]["Customer_Name"], pred_json["Customers"][1]["Customer_Name"]:  1 true positive
-        # gt_json["Customers"][1]["Customer_Name"], gt_json["Customers"][2]["Customer_Name"]:  2 false neagtive
+        # gt_json["Customers"][0]["Customer_Name"], gt_json["Customers"][2]["Customer_Name"]:  2 false neagtive
         assert cm["fields"]["Customers"]["fields"]["Customer_Name"]["aggregate"]["tp"] == 2, f'Expected Customer_Name aggregate TP=2, got {cm["fields"]["Customers"]["fields"]["Customer_Name"]["aggregate"]["tp"]}'
         assert cm["fields"]["Customers"]["fields"]["Customer_Name"]["aggregate"]["fa"] == 0, f'Expected Customer_Name aggregate FA=0, got {cm["fields"]["Customers"]["fields"]["Customer_Name"]["aggregate"]["fa"]}'
         assert cm["fields"]["Customers"]["fields"]["Customer_Name"]["aggregate"]["fd"] == 0, f'Expected Customer_Name aggregate FD=0, got {cm["fields"]["Customers"]["fields"]["Customer_Name"]["aggregate"]["fd"]}'
         assert cm["fields"]["Customers"]["fields"]["Customer_Name"]["aggregate"]["tn"] == 0, f'Expected Customer_Name aggregate TN=0, got {cm["fields"]["Customers"]["fields"]["Customer_Name"]["aggregate"]["tn"]}'
         assert cm["fields"]["Customers"]["fields"]["Customer_Name"]["aggregate"]["fn"] == 2, f'Expected Customer_Name aggregate FN=2, got {cm["fields"]["Customers"]["fields"]["Customer_Name"]["aggregate"]["fn"]}'
 
-        # gt_json["Customers"][0]["Shipping_Address"], pred_json["Customers"][0]["Shipping_Address"]:  1 true positive
+        # gt_json["Customers"][1]["Shipping_Address"], pred_json["Customers"][0]["Shipping_Address"]:  1 true positive
         # gt_json["Customers"][3]["Shipping_Address"], pred_json["Customers"][1]["Shipping_Address"]:  1 true positive
-        # gt_json["Customers"][1]["Shipping_Address"], gt_json["Customers"][2]["Shipping_Address"]:  2 false neagtive
+        # gt_json["Customers"][0]["Shipping_Address"], gt_json["Customers"][2]["Shipping_Address"]:  2 false neagtive
         assert cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["tp"] == 2, f'Expected Shipping_Address aggregate TP=2, got {cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["tp"]}'
         assert cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["fa"] == 0, f'Expected Shipping_Address aggregate FA=0, got {cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["fa"]}'
         assert cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["fd"] == 0, f'Expected Shipping_Address aggregate FD=0, got {cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["fd"]}'
         assert cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["tn"] == 0, f'Expected Shipping_Address aggregate TN=0, got {cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["tn"]}'
         assert cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["fn"] == 2, f'Expected Shipping_Address aggregate FN=2, got {cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["fn"]}'
 
-        # gt_json["Customers"][0]["Loyalty_Status"], pred_json["Customers"][0]["Loyalty_Status"]:  1 false alarm (object level) or 2 false alarm (aggregate level)
+        # gt_json["Customers"][1]["Loyalty_Status"], pred_json["Customers"][0]["Loyalty_Status"]:  1 true positive (object level) or 2 true positive (aggregate level)
         # gt_json["Customers"][3]["Loyalty_Status"], pred_json["Customers"][1]["Loyalty_Status"]:  1 true negative (object level) or 2 true negative (aggregate level)
-        # gt_json["Customers"][1]["Loyalty_Status"]: 1 false negative (object level) or 2 false negative (aggregate level)
+        # gt_json["Customers"][0]["Loyalty_Status"]: 1 true negative (object level) or 2 true negative (aggregate level)
         # gt_json["Customers"][2]["Loyalty_Status"]: 1 true negative (object level) or 2 true negative (aggregate level)
-        assert cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["tp"] == 0, f'Expected Loyalty_Status aggregate TP=0, got {cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["tp"]}'
-        assert cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fa"] == 2, f'Expected Loyalty_Status aggregate FA=2, got {cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["tp"] == 2, f'Expected Loyalty_Status aggregate TP=2, got {cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fa"] == 0, f'Expected Loyalty_Status aggregate FA=0, got {cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fa"]}'
         assert cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fd"] == 0, f'Expected Loyalty_Status aggregate FD=0, got {cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fd"]}'
-        assert cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["tn"] == 4, f'Expected Loyalty_Status aggregate TN=4, got {cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["tn"]}'
-        assert cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fn"] == 2, f'Expected Loyalty_Status aggregate FN=2, got {cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fn"]}'
+        assert cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["tn"] == 6, f'Expected Loyalty_Status aggregate TN=6, got {cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fn"] == 0, f'Expected Loyalty_Status aggregate FN=0, got {cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fn"]}'
 
         # at the object level with match_threshold = 1.0, 2 false discoveries and 2 false negatives (2 entries are matched, but below threshold, 2 entries are missing in prediction)
         assert cm["fields"]["Customers"]["overall"]["tp"] == 0, f'Expected Customers overall TP=0, got {cm["fields"]["Customers"]["overall"]["tp"]}'
@@ -377,12 +350,12 @@ class TestEcommerceOrdersAggregateComprehensive:
         assert cm["fields"]["Customers"]["overall"]["tn"] == 0, f'Expected Customers overall TN=0, got {cm["fields"]["Customers"]["overall"]["tn"]}'
         assert cm["fields"]["Customers"]["overall"]["fn"] == 2, f'Expected Customers overall FN=2, got {cm["fields"]["Customers"]["overall"]["fn"]}'
 
-        # at the field level within all matched entries (2 matched entries are considered for the sub field comparison, 2 unmatched entries are contributing to the fn)     
-        assert cm["fields"]["Customers"]["aggregate"]["tp"] == 9, f'Expected Customers aggregate TP=9, got {cm["fields"]["Customers"]["aggregate"]["tp"]}'
-        assert cm["fields"]["Customers"]["aggregate"]["fa"] == 3, f'Expected Customers aggregate FA=3, got {cm["fields"]["Customers"]["aggregate"]["fa"]}'
+        # at the field level within all matched entries (2 matched entries are considered for the sub field comparison, 2 unmatched entries are contributing to the fn or tn)     
+        assert cm["fields"]["Customers"]["aggregate"]["tp"] == 12, f'Expected Customers aggregate TP=12, got {cm["fields"]["Customers"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Customers"]["aggregate"]["fa"] == 0, f'Expected Customers aggregate FA=0, got {cm["fields"]["Customers"]["aggregate"]["fa"]}'
         assert cm["fields"]["Customers"]["aggregate"]["fd"] == 2, f'Expected Customers aggregate FD=2, got {cm["fields"]["Customers"]["aggregate"]["fd"]}'
-        assert cm["fields"]["Customers"]["aggregate"]["tn"] == 5, f'Expected Customers aggregate TN=5, got {cm["fields"]["Customers"]["aggregate"]["tn"]}'
-        assert cm["fields"]["Customers"]["aggregate"]["fn"] == 13, f'Expected Customers aggregate FN=13, got {cm["fields"]["Customers"]["aggregate"]["fn"]}'
+        assert cm["fields"]["Customers"]["aggregate"]["tn"] == 8, f'Expected Customers aggregate TN=8, got {cm["fields"]["Customers"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Customers"]["aggregate"]["fn"] == 10, f'Expected Customers aggregate FN=10, got {cm["fields"]["Customers"]["aggregate"]["fn"]}'
 
     def test_products_field_aggregate_counts(self):
         """Test the Products field aggregate counts."""
@@ -393,6 +366,8 @@ class TestEcommerceOrdersAggregateComprehensive:
         
         cm = result["confusion_matrix"]
         
+        # Hungarian matches GT[0]->Pred[0] and GT[1]->Pred[1]
+
         # gt_json["Products"][0]["Product_Id"], pred_json["Products"][0]["Product_Id"]:  1 true positive
         # gt_json["Products"][1]["Product_Id"], pred_json["Products"][1]["Product_Id"]:  1 true positive
         assert cm["fields"]["Products"]["fields"]["Product_Id"]["aggregate"]["tp"] == 2, f'Expected Product_Id aggregate TP=2, got {cm["fields"]["Products"]["fields"]["Product_Id"]["aggregate"]["tp"]}'
@@ -433,36 +408,75 @@ class TestEcommerceOrdersAggregateComprehensive:
         
         cm = result["confusion_matrix"]
 
-        # gt_json["Customers"][0]["Customer_Id"], pred_json["Customers"][0]["Customer_Id"]: 1 true positive
-        # gt_json["Customers"][3]["Customer_Id"], pred_json["Customers"][1]["Customer_Id"]: 1 false discovery
+        # Hungarian matches GT[0]->Pred[0] 
+        # gt_json["Discounts"][0]["Customer_Id"], pred_json["Discounts"][0]["Customer_Id"]: 1 true positive
         assert cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["tp"] == 1, f'Expected Customer_Id aggregate TP=1, got {cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["tp"]}'
         assert cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["fa"] == 0, f'Expected Customer_Id aggregate FA=0, got {cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["fa"]}'
-        assert cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["fd"] == 1, f'Expected Customer_Id aggregate FD=1, got {cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["fd"] == 0, f'Expected Customer_Id aggregate FD=0, got {cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["fd"]}'
         assert cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["tn"] == 0, f'Expected Customer_Id aggregate TN=0, got {cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["tn"]}'
-        assert cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["fn"] == 2, f'Expected Customer_Id aggregate FN=2, got {cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["fn"]}'
+        assert cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["fn"] == 0, f'Expected Customer_Id aggregate FN=0, got {cm["fields"]["Discounts"]["fields"]["Customer_Id"]["aggregate"]["fn"]}'
 
-        # at the object level with match_threshold = 1.0, 1 false discovery (no matches are made)
+        # gt_json["Discounts"][0]["Discount_Code"], pred_json["Discounts"][0]["Discount_Code"]: 1 false discovery at object level
+        assert cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["tp"] == 0, f'Expected Discount_Code overall TP=0, got {cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["tp"]}'
+        assert cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["fa"] == 0, f'Expected Discount_Code overall FA=0, got {cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["fa"]}'
+        assert cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["fd"] == 1, f'Expected Discount_Code overall FD=1, got {cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["fd"]}'
+        assert cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["tn"] == 0, f'Expected Discount_Code overall TN=0, got {cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["tn"]}'
+        assert cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["fn"] == 0, f'Expected Discount_Code overall FN=0, got {cm["fields"]["Discounts"]["fields"]["Discount_Code"]["overall"]["fn"]}'
+
+        # Discount_Code at field level 1 tn (Category_Code), 1 fp (Category_Name)
+        assert cm["fields"]["Discounts"]["fields"]["Discount_Code"]["aggregate"]["tp"] == 0, f'Expected Discount_Code aggregate TP=0, got {cm["fields"]["Discounts"]["fields"]["Discount_Code"]["aggregate"]["tp"]}'
+        assert cm["fields"]["Discounts"]["fields"]["Discount_Code"]["aggregate"]["fa"] == 0, f'Expected Discount_Code aggregate FA=0, got {cm["fields"]["Discounts"]["fields"]["Discount_Code"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Discounts"]["fields"]["Discount_Code"]["aggregate"]["fd"] == 1, f'Expected Discount_Code aggregate FD=1, got {cm["fields"]["Discounts"]["fields"]["Discount_Code"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Discounts"]["fields"]["Discount_Code"]["aggregate"]["tn"] == 1, f'Expected Discount_Code aggregate TN=1, got {cm["fields"]["Discounts"]["fields"]["Discount_Code"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Discounts"]["fields"]["Discount_Code"]["aggregate"]["fn"] == 0, f'Expected Discount_Code aggregate FN=0, got {cm["fields"]["Discounts"]["fields"]["Discount_Code"]["aggregate"]["fn"]}'
+
+        # at the object level with match_threshold = 1.0, 1 false discovery (1 entry is matched, but below threshold)
         assert cm["fields"]["Discounts"]["overall"]["tp"] == 0, f'Expected Discounts overall TP=0, got {cm["fields"]["Discounts"]["overall"]["tp"]}'
         assert cm["fields"]["Discounts"]["overall"]["fa"] == 0, f'Expected Discounts overall FA=0, got {cm["fields"]["Discounts"]["overall"]["fa"]}'
         assert cm["fields"]["Discounts"]["overall"]["fd"] == 1, f'Expected Discounts overall FD=1, got {cm["fields"]["Discounts"]["overall"]["fd"]}'
         assert cm["fields"]["Discounts"]["overall"]["tn"] == 0, f'Expected Discounts overall TN=0, got {cm["fields"]["Discounts"]["overall"]["tn"]}'
         assert cm["fields"]["Discounts"]["overall"]["fn"] == 0, f'Expected Discounts overall FN=0, got {cm["fields"]["Discounts"]["overall"]["fn"]}'
 
-        # at the field level within all matched entries (no matches, but same length, so the two entries are compared)  
+        # at the field level within all matched entries (1 entry is matched, compared for field level metrics)  
         assert cm["fields"]["Discounts"]["aggregate"]["tp"] == 1, f'Expected Discounts aggregate TP=1, got {cm["fields"]["Discounts"]["aggregate"]["tp"]}'
         assert cm["fields"]["Discounts"]["aggregate"]["fa"] == 0, f'Expected Discounts aggregate FA=0, got {cm["fields"]["Discounts"]["aggregate"]["fa"]}'
         assert cm["fields"]["Discounts"]["aggregate"]["fd"] == 1, f'Expected Discounts aggregate FD=1, got {cm["fields"]["Discounts"]["aggregate"]["fd"]}'
         assert cm["fields"]["Discounts"]["aggregate"]["tn"] == 1, f'Expected Discounts aggregate TN=1, got {cm["fields"]["Discounts"]["aggregate"]["tn"]}'
         assert cm["fields"]["Discounts"]["aggregate"]["fn"] == 0, f'Expected Discounts aggregate FN=0, got {cm["fields"]["Discounts"]["aggregate"]["fn"]}'
 
+    def test_full_comparison_with_expected_aggregate_counts(self):
+        """Test the full comparison with expected aggregate counts."""
+        result = self.gt_order.compare_with(
+            self.pred_order, 
+            include_confusion_matrix=True, 
+            document_non_matches=True
+        )
+        
+        # Print the result for debugging
+        print("\n=== FULL COMPARISON RESULT ===")
+        print(json.dumps(result, indent=2, default=str))
+        
+        # Verify that confusion matrix is included
+        assert "confusion_matrix" in result
+        cm = result["confusion_matrix"]
+        
+        # Verify that aggregate metrics are calculated
+        assert "aggregate" in cm
+        aggregate = cm["aggregate"]
+        
+        assert aggregate["tp"] == 20, f'Expected TP=20, got {aggregate["tp"]}'
+        assert aggregate["fa"] == 2, f'Expected FA=2, got {aggregate["fa"]}'
+        assert aggregate["fd"] == 5, f'Expected FD=5, got {aggregate["fd"]}'
+        assert aggregate["tn"] == 11, f'Expected TN=11, got {aggregate["tn"]}'
+        assert aggregate["fn"] == 10, f'Expected FN=10, got {aggregate["fn"]}'
+        
     def test_hungarian_matching_verification(self):
         """Test that Hungarian matching works correctly for the Customers list."""
         from stickler.structured_object_evaluator.models.hungarian_helper import HungarianHelper
         
         hungarian_helper = HungarianHelper()
         hungarian_info = hungarian_helper.get_complete_matching_info(
-            self.gt_json["Customers"], 
-            self.pred_json["Customers"]
+            getattr(self.gt_order, "Customers"), getattr(self.pred_order, "Customers")
         )
         matched_pairs = hungarian_info["matched_pairs"]
         
@@ -470,14 +484,14 @@ class TestEcommerceOrdersAggregateComprehensive:
         print(f"Matched pairs: {matched_pairs}")
         
         # Expected from comments:
-        # matched_pairs[0] should be (0, 0, some_number)
+        # matched_pairs[0] should be (1, 0, some_number)
         # matched_pairs[1] should be (3, 1, some_number)
         
         assert len(matched_pairs) == 2, f"Expected 2 matched pairs, got {len(matched_pairs)}"
         
         # Check the first match (GT index 0 should match with Pred index 0)
         gt_idx_0, pred_idx_0, similarity_0 = matched_pairs[0]
-        assert gt_idx_0 == 0, f"Expected GT index 0, got {gt_idx_0}"
+        assert gt_idx_0 == 1, f"Expected GT index 0, got {gt_idx_0}"
         assert pred_idx_0 == 0, f"Expected Pred index 0, got {pred_idx_0}"
         
         # Check the second match (GT index 3 should match with Pred index 1)
@@ -491,8 +505,7 @@ class TestEcommerceOrdersAggregateComprehensive:
         
         hungarian_helper = HungarianHelper()
         hungarian_info = hungarian_helper.get_complete_matching_info(
-            self.gt_json["Products"], 
-            self.pred_json["Products"]
+            getattr(self.gt_order, "Products"), getattr(self.pred_order, "Products")
         )
         matched_pairs = hungarian_info["matched_pairs"]
         
@@ -518,8 +531,7 @@ class TestEcommerceOrdersAggregateComprehensive:
         
         hungarian_helper = HungarianHelper()
         hungarian_info = hungarian_helper.get_complete_matching_info(
-            self.gt_json["Discounts"], 
-            self.pred_json["Discounts"]
+            getattr(self.gt_order, "Discounts"), getattr(self.pred_order, "Discounts")
         )
         matched_pairs = hungarian_info["matched_pairs"]
         

--- a/tests/structured_object_evaluator/test_list_comparator_extraction.py
+++ b/tests/structured_object_evaluator/test_list_comparator_extraction.py
@@ -339,16 +339,18 @@ class TestHungarianMatchingBaseline:
             # Should have nested fields for aggregate metrics
             assert len(nested_fields) > 0, "Should have nested fields for aggregate metrics"
             
-            # Check that overall sections are empty (no matches above threshold)
+            # Check that field-level metrics are generated for poor matches
             for field_name, field_metrics in nested_fields.items():
                 overall_metrics = field_metrics["overall"]
                 aggregate_metrics = field_metrics["aggregate"]
                 
-                # Overall should be empty (no matches above threshold)
-                assert all(overall_metrics[metric] == 0 for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]), \
-                    f"Field {field_name} overall should be empty for poor matches"
+                # With threshold-gated recursion, poor matches should NOT populate overall metrics
+                # Overall metrics should be empty (all zeros) for poor matches
+                for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
+                    assert overall_metrics[metric] == 0, \
+                        f"Field {field_name} overall {metric} should be 0 for poor matches, got {overall_metrics[metric]}"
                 
-                # Aggregate should have the actual metrics from poor matches
+                # Aggregate metrics should contain the field-level analysis for poor matches
                 assert aggregate_metrics["fd"] > 0, \
                     f"Field {field_name} aggregate should have FD metrics from poor matches"
 

--- a/tests/structured_object_evaluator/test_structured_model_evaluator_nested.py
+++ b/tests/structured_object_evaluator/test_structured_model_evaluator_nested.py
@@ -538,23 +538,25 @@ class TestVetRecordsMetricsCalculation(unittest.TestCase):
         # - Threshold-based matching (not just exact field equality)
         # - Object-level similarity scoring for nested structures
         # - Proper aggregation across complex nested hierarchies
-        # Precision = TP/(TP+FD+FA) = 5/(5+1+1) = 5/7 = 0.714
-        # Recall = TP/(TP+FN) = 5/(5+1) = 5/6 = 0.833
-        # F1 = 2*precision*recall/(precision+recall) = 2*0.714*0.833/(0.714+0.833) = 0.769
+        # Updated expected values after implementing threshold-gated overall vs aggregate
+        # Actual aggregate values: TP=9, FA=2, FD=2, FP=4, TN=3, FN=1
+        # Precision = TP/(TP+FP) = 9/(9+4) = 9/13 = 0.692
+        # Recall = TP/(TP+FN) = 9/(9+1) = 9/10 = 0.9
+        # F1 = 2*precision*recall/(precision+recall) = 2*0.692*0.9/(0.692+0.9) = 0.783
         derived_metrics = cm["aggregate"]["derived"]
-        self.assertAlmostEqual(derived_metrics["cm_precision"], 0.714, places=3)
-        self.assertAlmostEqual(derived_metrics["cm_recall"], 0.833, places=3)
-        self.assertAlmostEqual(derived_metrics["cm_f1"], 0.769, places=3)
+        self.assertAlmostEqual(derived_metrics["cm_precision"], 0.692, places=3)
+        self.assertAlmostEqual(derived_metrics["cm_recall"], 0.9, places=3)
+        self.assertAlmostEqual(derived_metrics["cm_f1"], 0.783, places=3)
 
         # Test with alternative recall formula - both modes return same values in this case
         results_alt = gold_record.compare_with(
             pred_record, include_confusion_matrix=True, recall_with_fd=True
         )
         derived_metrics_alt = results_alt["confusion_matrix"]["aggregate"]["derived"]
-        # Both recall modes return the same values for this test case
-        self.assertAlmostEqual(derived_metrics_alt["cm_precision"], 0.714, places=3)
-        self.assertAlmostEqual(derived_metrics_alt["cm_recall"], 0.833, places=3)
-        self.assertAlmostEqual(derived_metrics_alt["cm_f1"], 0.769, places=3)
+        # Both recall modes return the same values for this test case (updated values)
+        self.assertAlmostEqual(derived_metrics_alt["cm_precision"], 0.692, places=3)
+        self.assertAlmostEqual(derived_metrics_alt["cm_recall"], 0.9, places=3)
+        self.assertAlmostEqual(derived_metrics_alt["cm_f1"], 0.783, places=3)
 
 
 if __name__ == "__main__":

--- a/tests/structured_object_evaluator/test_threshold_gated_recursion.py
+++ b/tests/structured_object_evaluator/test_threshold_gated_recursion.py
@@ -118,17 +118,30 @@ def test_threshold_gated_poor_match():
     cm = result["confusion_matrix"]
     products_cm = cm["fields"]["products"]
 
-    # Check that we DON'T have nested field metrics (no recursive analysis)
+    # UPDATED: With universal aggregate feature, nested field metrics are always generated
+    # but "overall" should be empty for poor matches, "aggregate" should have the metrics
     if "fields" in products_cm:
         nested_fields = products_cm["fields"]
         print(f"DEBUG: Found nested fields: {list(nested_fields.keys())}")
 
-        # Should NOT have nested field metrics for poor matches
+        # Should have nested field metrics for aggregate, but overall should be empty for poor matches
         product_fields = ["product_id", "name", "price"]
         for field in product_fields:
-            assert field not in nested_fields, (
-                f"Poor matches should not have nested field metrics for {field}"
-            )
+            if field in nested_fields:
+                field_data = nested_fields[field]
+                # Overall should be empty (no matches above threshold)
+                overall_metrics = field_data["overall"]
+                overall_total = sum(overall_metrics[metric] for metric in ["tp", "fa", "fd", "fp", "tn", "fn"])
+                assert overall_total == 0, (
+                    f"Field {field} overall should be empty for poor matches, got {overall_metrics}"
+                )
+                
+                # Aggregate should have some metrics from poor matches
+                aggregate_metrics = field_data["aggregate"]
+                aggregate_total = sum(aggregate_metrics[metric] for metric in ["tp", "fa", "fd", "fp", "tn", "fn"])
+                assert aggregate_total > 0, (
+                    f"Field {field} aggregate should have metrics from poor matches, got {aggregate_metrics}"
+                )
 
     # Should have non_matches key with the poor match
     if "non_matches" in products_cm:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
*  Deprecate aggregate = True flag in src/stickler/structured_object_evaluator/models/comparable_field.py, src/stickler/structured_object_evaluator/models/comparison_info.py and src/stickler/structured_object_evaluator/models/configuration_helper.py (not currently used in calculation)
* Update exiting test cases for correct universal aggregate metrics calculation without changing the overall metrics related test cases
* Add a new test cases for universal aggregate metrics calculation (tests/structured_object_evaluator/test_ecommerce_orders_aggregate_comprehensive.py)
* Update the evaluator and the bulk evaluator to optionally use aggregate metrics
* Assumption: For aggregate metrics, all matched items (regardless of the similarity score) are considered. For overall metrics, only those above match threshold are considered. 
* TODO: Implementation of the aggregation logic in src/stickler/structured_object_evaluator/models/structured_model.py and src/stickler/structured_object_evaluator/models/structured_list_comparator.py to pass these tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
