### PR TITLE
.tempFeature/vincilb/ruff dev conventions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# This file is for EditorConfig and helps maintain consistent coding styles.
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,12 @@
 .vscode/settings.json
 **/__pycache__/
 **/*.egg-info/
+.venv/
 .coverage
 .ash/
+.temp/
+uv.lock
 
 .kiro/*
 .kiro/**/*
+

--- a/.vscode/settings.json.example
+++ b/.vscode/settings.json.example
@@ -1,0 +1,18 @@
+{
+  "git.openRepositoryInParentFolders": "always",
+  "python.analysis.extraPaths": [],
+  "notebook.formatOnSave.enabled": true,
+  "notebook.codeActionsOnSave": {
+    "notebook.source.fixAll": "explicit",
+    "notebook.source.organizeImports": "explicit"
+  },
+  "[python]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "explicit",
+      "source.organizeImports": "explicit"
+    },
+  },
+  "makefile.configureOnOpen": false
+}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 # Simple Makefile for stickler
 
+# Define color codes for terminal output
+RED := \033[0;31m
+GREEN := \033[0;32m
+YELLOW := \033[1;33m
+NC := \033[0m  # No Color
+
 install:
 	pip install -e .
 
@@ -12,3 +18,27 @@ test:
 clean:
 	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
 	find . -type f -name "*.pyc" -delete
+
+# Run linting checks and automatically fix issues
+lint:
+	ruff check --fix
+
+# CI/CD version of lint that only checks but doesn't modify files
+# Used in CI pipelines to verify code quality without making changes
+lint-cicd:
+	@echo "Running code quality checks..."
+	@if ! ruff check; then \
+		echo -e "$(RED)ERROR: Ruff linting failed!$(NC)"; \
+		echo -e "$(YELLOW)Please run 'make ruff-lint' locally to fix these issues.$(NC)"; \
+		exit 1; \
+	fi
+	@if ! ruff format --check; then \
+		echo -e "$(RED)ERROR: Code formatting check failed!$(NC)"; \
+		echo -e "$(YELLOW)Please run 'make format' locally to fix these issues.$(NC)"; \
+		exit 1; \
+	fi
+	@echo -e "$(GREEN)All code quality checks passed!$(NC)"
+
+# Run unit tests (delegates to tests/Makefile)
+test:
+	$(MAKE) test -C ./tests

--- a/docs/docs/Contributing/code-style.md
+++ b/docs/docs/Contributing/code-style.md
@@ -26,6 +26,23 @@ ruff check --fix .
 ruff check src/stickler/comparators/
 ```
 
+### Automatic Formatting in VS Code
+
+To enable automatic code formatting and linting in VS Code:
+
+1. Copy the example settings file:
+   ```bash
+   cp .vscode/settings.json.example .vscode/settings.json
+   ```
+
+2. Install the Ruff extension for VS Code (if not already installed):
+   - Open VS Code
+   - Go to Extensions (Cmd+Shift+X on macOS, Ctrl+Shift+X on Windows/Linux)
+   - Search for "Ruff" by Charlie Marsh
+   - Click Install
+
+The settings file configures VS Code to automatically format Python files on save and organize imports using Ruff.
+
 ### CI Integration
 
 Linting runs automatically on every push and pull request via GitHub Actions. While currently non-blocking, you should address linting issues before submitting PRs.

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,91 @@
+# Let's exclude some whole directories until we are ready to format them individually
+extend-exclude = []
+
+
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.12
+target-version = "py312"
+
+[lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+# Note: if you're using Ruff to organize imports in VS Code and also expect to run Ruff from the command line, you'll want to enable Ruff's isort rules by adding "I" to your extend-select.
+extend-select = ["I"]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[lint.per-file-ignores]
+# Let's ignore some annoying rules in notebooks
+"notebooks/*" = ["F401"]
+# Disable module level import not at top of file for src (needed for path manipulation)
+"src/**/*.py" = ["E402"]
+
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = false
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"


### PR DESCRIPTION
### What Changed
- ✨ Added `ruff.toml` - comprehensive Ruff linting and formatting configuration
- 🔧 Added `.editorconfig` - consistent coding styles across all editors
- 💻 Added `.vscode/settings.json.example` - VS Code auto-formatting setup
- 🛠️ Enhanced `Makefile` - new lint targets with colored output
- 📚 Updated `docs/docs/Contributing/code-style.md` - VS Code setup instructions
- 🗑️ Updated `.gitignore` - added `.venv/`, `.temp/`, and `uv.lock`

### Why These Changes Matter
Inconsistent code formatting and lack of automated tooling creates friction for contributors. Without standardized formatting, PRs become cluttered with style debates instead of focusing on functionality. Manual formatting is error-prone and time-consuming.

### Value to Users

#### 🚀 For Contributors
- **Zero-config formatting** - Copy one file and get automatic code formatting on save in VS Code
- **Faster development** - No more manual formatting or style debates
- **Consistent codebase** - All code follows the same style automatically
- **Better PR reviews** - Focus on logic, not formatting nitpicks

#### 🔍 For Maintainers
- **Enforced standards** - `make lint-cicd` ensures all code meets quality standards
- **Clear feedback** - Colored terminal output makes issues easy to spot
- **Automated fixes** - `make lint` auto-fixes most issues
- **Cross-editor consistency** - `.editorconfig` works with any editor

#### 🎯 For Everyone
- **Professional codebase** - Consistent formatting improves readability
- **Reduced cognitive load** - Predictable code structure is easier to understand
- **Faster onboarding** - New contributors can match project style instantly
- **CI/CD ready** - `lint-cicd` target integrates seamlessly into pipelines

### Quick Start
```bash
# Set up VS Code auto-formatting
cp .vscode/settings.json.example .vscode/settings.json

# Install Ruff extension in VS Code
# Then code formats automatically on save! ✨

# Or format manually
make lint
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
