### PR TITLE
Feat/universal aggregate metrics dispatcher logic update

### DIFF
--- a/src/stickler/structured_object_evaluator/models/comparison_dispatcher.py
+++ b/src/stickler/structured_object_evaluator/models/comparison_dispatcher.py
@@ -114,14 +114,13 @@ class ComparisonDispatcher:
         # Optional[List[StructuredModel]], etc.). This determines which dispatch
         # path to take.
         is_list_field = self.model._is_list_field(field_name)
+        is_structured_list_field = self.model._is_structured_list_field(field_name)
 
         # Get hierarchical needs for both ground truth and prediction.
         # These flags control whether we need to maintain hierarchical structure
         # for list fields (e.g., List[StructuredModel] vs List[str]).
-        gt_needs_hierarchy = self.model._should_use_hierarchical_structure(gt_val, field_name)
-        pred_needs_hierarchy = self.model._should_use_hierarchical_structure(
-            pred_val, field_name
-        )
+        #gt_needs_hierarchy = self.model._should_use_hierarchical_structure(gt_val, field_name)
+        #pred_needs_hierarchy = self.model._should_use_hierarchical_structure(pred_val, field_name)
 
         # ============================================================================
         # STEP 3: Handle list field null cases (early exit)
@@ -132,7 +131,7 @@ class ComparisonDispatcher:
         # - GT None/empty, Pred populated → FA (False Alarm)
         # - GT populated, Pred None/empty → FN (False Negative)
         # - Both populated → Continue to type-based dispatch (returns None)
-        if is_list_field and not (gt_needs_hierarchy or pred_needs_hierarchy):
+        if is_list_field and not is_structured_list_field:
             list_result = self.handle_list_field_dispatch(gt_val, pred_val, weight)
             if list_result is not None:
                 # Early exit: null case handled, return result
@@ -148,7 +147,7 @@ class ComparisonDispatcher:
         # - GT null, Pred non-null → FA (False Alarm)
         # - GT non-null, Pred null → FN (False Negative)
         # - Both non-null → Continue to type-based dispatch
-        if not (gt_needs_hierarchy or pred_needs_hierarchy):
+        if not is_structured_list_field:
             gt_effectively_null_prim = self.model._is_effectively_null_for_primitives(gt_val)
             pred_effectively_null_prim = self.model._is_effectively_null_for_primitives(
                 pred_val
@@ -190,17 +189,15 @@ class ComparisonDispatcher:
         ):
             return self.field_comparator.compare_primitive_with_scores(gt_val, pred_val, field_name)
         
-        # CASE 2: Both are lists (non-empty, null/empty cases already handled in STEP 3)
-        # Determine if this is a structured list or primitive list by inspecting elements
-        elif isinstance(gt_val, list) and isinstance(pred_val, list):
-            # Check if this is a List[StructuredModel] by inspecting first element
-            #if gt_val and isinstance(gt_val[0], StructuredModel):
-            if gt_needs_hierarchy or pred_needs_hierarchy:
+        # CASE 2: Handle list fields. 
+        # Note, if it's a primitive list, null/empty cases already handled in STEP 3.
+        elif is_list_field:
+            if is_structured_list_field:
                 # Delegate to StructuredListComparator for List[StructuredModel]
                 return self.structured_list_comparator.compare_struct_list_with_scores(
                     gt_val, pred_val, field_name
                 )
-            else:
+            else: 
                 # Delegate to PrimitiveListComparator for List[primitive]
                 return self.primitive_list_comparator.compare_primitive_list_with_scores(
                     gt_val, pred_val, field_name

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -644,6 +644,23 @@ class StructuredModel(BaseModel):
                         return True
         return False
 
+    def _is_structured_list_field(self, field_name: str) -> bool:
+        """Check if a field is a List[StructuredModel] type.
+
+        Args:
+            field_name: Name of the field to check
+
+        Returns:
+            True if the field is a List[StructuredModel] type, False otherwise
+        """
+        field_info = self.__class__.model_fields.get(field_name)
+        if not field_info:
+            return False
+
+        field_type = field_info.annotation
+        # Use the existing class method to check if it's List[StructuredModel]
+        return self.__class__._is_list_of_structured_model_type(field_type)
+
     def _handle_list_field_dispatch(
         self, gt_val: Any, pred_val: Any, weight: float
     ) -> dict:


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:*
Updating the logic in dispatcher:
1) Moving from runtime type checking to static field definition checking. Doing this by moving away from _should_use_hierarchical_structure and using _is_structured_list_field instead. This is done mainly for list fields, both primitive and structured. Future changes could expand to other types as needed.
2) when the field is a structured list, delegate handling all types of values whether null or not, to StructuredListComparator

Updated structured_model:
Add helper method to check if a field is specifically List[StructuredModel], complementing _is_list_field() which checks for any list type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
