### PR TITLE
Handling True Negative cases for Structured List

### DIFF
--- a/src/stickler/structured_object_evaluator/models/structured_list_comparator.py
+++ b/src/stickler/structured_object_evaluator/models/structured_list_comparator.py
@@ -16,8 +16,9 @@ from .hungarian_helper import HungarianHelper
 from .metrics_helper import MetricsHelper
 from .comparable_field import ComparableField
 
-if TYPE_CHECKING:
-    from .structured_model import StructuredModel
+#if TYPE_CHECKING:
+from .structured_model import StructuredModel
+from typing import Type, List, get_origin, get_args, Union
 
 
 class StructuredListComparator:
@@ -66,7 +67,7 @@ class StructuredListComparator:
 
         # Handle empty list cases with beautiful match statements
         early_exit_result = self._handle_struct_list_empty_cases(
-            gt_list, pred_list, weight
+            gt_list, pred_list, weight, field_name
         )
         if early_exit_result is not None:
             return early_exit_result
@@ -119,6 +120,7 @@ class StructuredListComparator:
         gt_list: List["StructuredModel"],
         pred_list: List["StructuredModel"],
         weight: float,
+        field_name: str,
     ) -> dict:
         """Handle empty list cases with beautiful match statements.
 
@@ -136,10 +138,11 @@ class StructuredListComparator:
 
         match (gt_len, pred_len):
             case (0, 0):
+                fields_metrics = self._get_leaves_under_field(self.parent_model.__class__, field_name)
                 # Both empty lists → True Negative
                 return {
                     "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 1, "fn": 0},
-                    "fields": {},
+                    "fields": fields_metrics,
                     "raw_similarity_score": 1.0,
                     "similarity_score": 1.0,
                     "threshold_applied_score": 1.0,
@@ -578,6 +581,93 @@ class StructuredListComparator:
         # UNIFIED STRUCTURE: Wrap primitive field metrics in 'overall' for consistency
         # This ensures all fields use the same access pattern: field_data['overall']
         return {"overall": sub_field_metrics}
+    
+    def _get_all_leaves(self, model_class: Type[StructuredModel], prefix: str) -> List[str]:
+        """Recursively get all leaf nodes in the model."""
+        #leaves = []
+        metrics = {}
+        
+        for fname, field_info in model_class.model_fields.items():
+            if fname == "extra_fields":
+                continue
+                
+            full_path = f"{prefix}.{fname}" if prefix else fname
+            field_type = field_info.annotation
+            
+            # Check if it's a nested StructuredModel
+            nested_model = self._get_nested_model_type(field_type)
+            
+            if nested_model:
+                # Recurse into nested model
+                #leaves.extend()
+                field_metrics = self._get_all_leaves(nested_model, full_path)
+                metrics[fname] = {
+                    "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 1, "fn": 0},
+                    "fields": field_metrics,
+                    }
+            else:
+                # This is a leaf node
+                #leaves.append(full_path)
+                metrics[fname] = {
+                    "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 1, "fn": 0},
+                    "fields": {},
+                    }
+        
+        return metrics
+
+
+    def _get_leaves_under_field(self, model_class: Type[StructuredModel], field_name: str) -> List[str]:
+        """Get all leaf nodes under a specific field."""
+        # Find the field in the model
+        if field_name not in model_class.model_fields:
+            raise ValueError(f"Field '{field_name}' not found in {model_class.__name__}")
+        
+        field_info = model_class.model_fields[field_name]
+        field_type = field_info.annotation
+        
+        # Get the nested model type (handles List[Model] and direct Model)
+        nested_model = self._get_nested_model_type(field_type)
+        
+        if not nested_model:
+            # This field itself is a leaf
+            return [field_name]
+        
+        # Get all leaves under this nested model
+        return self._get_all_leaves(nested_model, field_name)
+
+
+    def _get_nested_model_type(self, field_type) -> Type[StructuredModel]:
+        """
+        Extract nested StructuredModel type from field annotation.
+        Handles: StructuredModel, List[StructuredModel], Optional[StructuredModel], etc.
+        """
+        origin = get_origin(field_type)
+        
+        # Handle Optional/Union types
+        if origin is Union:
+            args = get_args(field_type)
+            for arg in args:
+                if arg is not type(None):
+                    nested = self._get_nested_model_type(arg)
+                    if nested:
+                        return nested
+            return None
+        
+        # Handle List types
+        if origin is list or origin is List:
+            args = get_args(field_type)
+            if args:
+                return self._get_nested_model_type(args[0])
+            return None
+        
+        # Direct StructuredModel type
+        try:
+            if isinstance(field_type, type) and issubclass(field_type, StructuredModel):
+                return field_type
+        except (TypeError, AttributeError):
+            pass
+        
+        return None
 
 
 # Import needed at bottom to avoid circular imports

--- a/tests/structured_object_evaluator/test_aggregate_cases.py
+++ b/tests/structured_object_evaluator/test_aggregate_cases.py
@@ -73,7 +73,7 @@ class TestAggregation(unittest.TestCase):
         agg_results = result['confusion_matrix']['aggregate']
 
         self.assertEqual(agg_results['tp'], 2, 'tp')
-        self.assertEqual(agg_results['tn'], 2, 'tn')
+        self.assertEqual(agg_results['tn'], 6, 'tn')
         self.assertEqual(agg_results['fd'], 1, 'fd')
         self.assertEqual(agg_results['fa'], 1, 'fa')
         self.assertEqual(agg_results['fp'], 2, 'fp')

--- a/tests/structured_object_evaluator/test_classification_logic.py
+++ b/tests/structured_object_evaluator/test_classification_logic.py
@@ -226,7 +226,7 @@ def test_list_classification_logic():
     assert tags_cm["fp"] > 0, (
         "Items in EST but not in GT (null) should be False Alarm (FP)"
     )
-    assert items_cm["tn"] == 1, "Both empty lists should be TN"
+    assert items_cm["tn"] == 1, f"Both empty lists should be TN: {items_cm}"
 
 
 def test_nested_model_classification_logic():

--- a/tests/structured_object_evaluator/test_ecommerce_orders_aggregate_comprehensive.py
+++ b/tests/structured_object_evaluator/test_ecommerce_orders_aggregate_comprehensive.py
@@ -334,12 +334,12 @@ class TestEcommerceOrdersAggregateComprehensive:
         assert cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["fn"] == 2, f'Expected Shipping_Address aggregate FN=2, got {cm["fields"]["Customers"]["fields"]["Shipping_Address"]["aggregate"]["fn"]}'
 
         # gt_json["Customers"][1]["Loyalty_Status"], pred_json["Customers"][0]["Loyalty_Status"]:  1 true positive (object level) or 2 true positive (aggregate level)
-        # gt_json["Customers"][3]["Loyalty_Status"], pred_json["Customers"][1]["Loyalty_Status"]:  1 true negative
+        # gt_json["Customers"][3]["Loyalty_Status"], pred_json["Customers"][1]["Loyalty_Status"]:  2 true negative: one for each of it's child leaf nodes
         # gt_json["Customers"][0]["Loyalty_Status"], gt_json["Customers"][2]["Loyalty_Status"]: Non matches do not contribute to true negatives
         assert cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["tp"] == 2, f'Expected Loyalty_Status aggregate TP=2, got {cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["tp"]}'
         assert cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fa"] == 0, f'Expected Loyalty_Status aggregate FA=0, got {cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fa"]}'
         assert cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fd"] == 0, f'Expected Loyalty_Status aggregate FD=0, got {cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fd"]}'
-        assert cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["tn"] == 1, f'Expected Loyalty_Status aggregate TN=1, got {cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["tn"] == 2, f'Expected Loyalty_Status aggregate TN=2, got {cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["tn"]}'
         assert cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fn"] == 0, f'Expected Loyalty_Status aggregate FN=0, got {cm["fields"]["Customers"]["fields"]["Loyalty_Status"]["aggregate"]["fn"]}'
 
         # at the object level with match_threshold = 1.0, 2 false discoveries and 2 false negatives (2 entries are matched, but below threshold, 2 entries are missing in prediction)
@@ -349,11 +349,12 @@ class TestEcommerceOrdersAggregateComprehensive:
         assert cm["fields"]["Customers"]["overall"]["tn"] == 0, f'Expected Customers overall TN=0, got {cm["fields"]["Customers"]["overall"]["tn"]}'
         assert cm["fields"]["Customers"]["overall"]["fn"] == 2, f'Expected Customers overall FN=2, got {cm["fields"]["Customers"]["overall"]["fn"]}'
 
-        # at the field level all entries, either matched or unmatched, are considered for the sub field comparison   
+        # at the field level all entries, either matched or unmatched, are considered for the sub field comparison
+        # 2 true negative from Loyalty_Status: one for each of it's child leaf nodes
         assert cm["fields"]["Customers"]["aggregate"]["tp"] == 12, f'Expected Customers aggregate TP=12, got {cm["fields"]["Customers"]["aggregate"]["tp"]}'
         assert cm["fields"]["Customers"]["aggregate"]["fa"] == 0, f'Expected Customers aggregate FA=0, got {cm["fields"]["Customers"]["aggregate"]["fa"]}'
         assert cm["fields"]["Customers"]["aggregate"]["fd"] == 2, f'Expected Customers aggregate FD=2, got {cm["fields"]["Customers"]["aggregate"]["fd"]}'
-        assert cm["fields"]["Customers"]["aggregate"]["tn"] == 1, f'Expected Customers aggregate TN=1, got {cm["fields"]["Customers"]["aggregate"]["tn"]}'
+        assert cm["fields"]["Customers"]["aggregate"]["tn"] == 2, f'Expected Customers aggregate TN=2, got {cm["fields"]["Customers"]["aggregate"]["tn"]}'
         assert cm["fields"]["Customers"]["aggregate"]["fn"] == 10, f'Expected Customers aggregate FN=10, got {cm["fields"]["Customers"]["aggregate"]["fn"]}'
 
     def test_products_field_aggregate_counts(self):
@@ -464,8 +465,8 @@ class TestEcommerceOrdersAggregateComprehensive:
         assert aggregate["tp"] == 20, f'Expected TP=20, got {aggregate["tp"]}'
         assert aggregate["fa"] == 2, f'Expected FA=2, got {aggregate["fa"]}'
         assert aggregate["fd"] == 5, f'Expected FD=5, got {aggregate["fd"]}'
-        # 4 TN: Order_Info.Order_Status.Category_Code, Order_Info.Store_Location, Customers.Loyalty_Status, Discounts.Discount_Code
-        assert aggregate["tn"] == 4, f'Expected TN=4, got {aggregate["tn"]}' 
+        # 5 TN: Order_Info.Order_Status.Category_Code, Order_Info.Store_Location, Customers.Loyalty_Status.Category_Code, Customers.Loyalty_Status.Category_Name, Discounts.Discount_Code
+        assert aggregate["tn"] == 5, f'Expected TN=5, got {aggregate["tn"]}' 
         assert aggregate["fn"] == 10, f'Expected FN=10, got {aggregate["fn"]}'
         
     def test_hungarian_matching_verification(self):
@@ -622,9 +623,9 @@ class TestEcommerceOrdersAggregateComprehensive:
         products_agg = cm["fields"]["Products"]["aggregate"]
         discounts_agg = cm["fields"]["Discounts"]["aggregate"]
         
-        assert customers_agg["tn"] == 1, f'Expected Customers TN=1 for empty lists, got {customers_agg["tn"]}'
-        assert products_agg["tn"] == 1, f'Expected Products TN=1 for empty lists, got {products_agg["tn"]}'
-        assert discounts_agg["tn"] == 1, f'Expected Discounts TN=1 for empty lists, got {discounts_agg["tn"]}'
+        assert customers_agg["tn"] == 8, f'Expected Customers TN=8 for empty lists, got {customers_agg["tn"]}'
+        assert products_agg["tn"] == 2, f'Expected Products TN=2 for empty lists, got {products_agg["tn"]}'
+        assert discounts_agg["tn"] == 3, f'Expected Discounts TN=3 for empty lists, got {discounts_agg["tn"]}'
 
     def test_threshold_based_classification(self):
         """Test that threshold-based classification works correctly in aggregates."""


### PR DESCRIPTION
1) Previously when a structured list was empty, it would be counted as one TN for aggregate at the object level but aggregation may miss this (because overall metrics are skipped when there are child instances). This change creates a field dict to capture TN at the child leaf node, so that aggregate metric can trickle up correctly.

2) Updated tests to reflect changes due to above logic

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
