### PR TITLE
Feat/universal aggregate metrics hungarian single item list

### DIFF
--- a/src/stickler/algorithms/hungarian.py
+++ b/src/stickler/algorithms/hungarian.py
@@ -211,7 +211,8 @@ class HungarianMatcher:
             else:
                 score = self.comparator(prepared_list1[0], prepared_list2[0])
 
-            return {
+            if score >= self.match_threshold:
+                return {
                     "matched_pairs": [(0, 0, score)],
                     "tp": 1,
                     "fp": 0,
@@ -219,6 +220,16 @@ class HungarianMatcher:
                     "precision": 1.0,
                     "recall": 1.0,
                     "f1": 1.0,
+                }
+            else:
+                return {
+                    "matched_pairs": [(0, 0, score)],
+                    "tp": 0,
+                    "fp": 1,
+                    "fn": 0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
                 }
 
         # Handle empty lists

--- a/src/stickler/structured_object_evaluator/models/structured_list_comparator.py
+++ b/src/stickler/structured_object_evaluator/models/structured_list_comparator.py
@@ -584,7 +584,6 @@ class StructuredListComparator:
     
     def _get_all_leaves(self, model_class: Type[StructuredModel], prefix: str) -> List[str]:
         """Recursively get all leaf nodes in the model."""
-        #leaves = []
         metrics = {}
         
         for fname, field_info in model_class.model_fields.items():
@@ -599,7 +598,6 @@ class StructuredListComparator:
             
             if nested_model:
                 # Recurse into nested model
-                #leaves.extend()
                 field_metrics = self._get_all_leaves(nested_model, full_path)
                 metrics[fname] = {
                     "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 1, "fn": 0},
@@ -607,7 +605,6 @@ class StructuredListComparator:
                     }
             else:
                 # This is a leaf node
-                #leaves.append(full_path)
                 metrics[fname] = {
                     "overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 1, "fn": 0},
                     "fields": {},

--- a/tests/common/algorithms/test_hungarian.py
+++ b/tests/common/algorithms/test_hungarian.py
@@ -171,7 +171,7 @@ class TestHungarianMatcher(unittest.TestCase):
         metrics = self.matcher.calculate_metrics("apple", "banana")
         self.assertEqual(metrics["tp"], 0)
         self.assertEqual(metrics["fp"], 1)
-        self.assertEqual(metrics["fn"], 1)
+        self.assertEqual(metrics["fn"], 0)
 
     def test_string_list_parsing(self):
         """Test parsing of string representations of lists."""


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Update hungarian to better handle single-item lists. Always match single-item lists, count as tp if the item similarity score is higher than match_threshold. Update fn count for a test_hungarian test case
* Clean up some unused, commented out variable


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
