### PR TITLE
Sr/fix 17

### DIFF
--- a/src/stickler/structured_object_evaluator/models/structured_list_comparator.py
+++ b/src/stickler/structured_object_evaluator/models/structured_list_comparator.py
@@ -464,15 +464,51 @@ class StructuredListComparator:
         matched_gt_indices: set,
         matched_pred_indices: set,
     ) -> Dict[str, Any]:
-        """Handle primitive fields with simple aggregation across matched pairs.
+        """Handle non-hierarchical fields with aggregation across matched pairs.
 
-        PHASE 3 FIX: Now only processes good matched pairs (similarity >= match_threshold).
+        Handles both true primitive fields (str, int, etc.) and simple list fields
+        (List[str], List[int], etc.). Simple list fields are dispatched through
+        _dispatch_field_comparison to use PrimitiveListComparator for element-level
+        comparison, rather than being treated as atomic primitive values.
+
+        See: https://github.com/awslabs/stickler/issues/33
         """
 
-        # Initialize collection for primitive fields across all objects
+        # Check if this field is a simple list type (e.g., List[str]) by inspecting
+        # the first available GT item's model definition.
+        is_simple_list = False
+        if gt_list:
+            is_simple_list = gt_list[0]._is_list_field(sub_field_name)
+
+        if is_simple_list:
+            # Simple list fields (List[str], List[int], etc.) need element-level
+            # comparison via _dispatch_field_comparison → PrimitiveListComparator.
+            # Use the same aggregation pattern as _handle_hierarchical_field.
+            pair_results = []
+
+            for gt_idx, pred_idx, similarity in matched_pairs:
+                if gt_idx < len(gt_list) and pred_idx < len(pred_list):
+                    gt_item = gt_list[gt_idx]
+                    pred_item = pred_list[pred_idx]
+                    gt_sub_value = getattr(gt_item, sub_field_name)
+                    pred_sub_value = getattr(pred_item, sub_field_name)
+
+                    pair_result = gt_item._dispatch_field_comparison(
+                        sub_field_name, gt_sub_value, pred_sub_value
+                    )
+                    pair_results.append(pair_result)
+
+            aggregated_result = self._recursive_aggregate_metrics(pair_results)
+            self._add_derived_metrics_recursively(aggregated_result)
+            return (
+                aggregated_result
+                if pair_results
+                else {"overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}}
+            )
+
+        # True primitive fields — use flat classification
         sub_field_metrics = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
 
-        # PHASE 3 FIX: Now only processes pairs that passed the threshold filter
         for gt_idx, pred_idx, similarity in matched_pairs:
             if gt_idx < len(gt_list) and pred_idx < len(pred_list):
                 gt_item = gt_list[gt_idx]
@@ -480,33 +516,27 @@ class StructuredListComparator:
                 gt_sub_value = getattr(gt_item, sub_field_name)
                 pred_sub_value = getattr(pred_item, sub_field_name)
 
-                # Regular field - use flat classification
                 field_classification = gt_item._classify_field_for_confusion_matrix(
                     sub_field_name, pred_sub_value
                 )
 
-                # Aggregate field metrics across all objects
                 for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
                     sub_field_metrics[metric] += field_classification.get(metric, 0)
 
         # Handle unmatched objects for primitive fields
-        # Handle unmatched GT objects (contribute FN to field-level)
         for gt_idx, gt_item in enumerate(gt_list):
             if gt_idx not in matched_gt_indices:
                 gt_sub_value = getattr(gt_item, sub_field_name)
-                if gt_sub_value is not None:  # Only count non-null values as FN
+                if gt_sub_value is not None:
                     sub_field_metrics["fn"] += 1
 
-        # Handle unmatched pred objects (contribute FA to field-level)
         for pred_idx, pred_item in enumerate(pred_list):
             if pred_idx not in matched_pred_indices:
                 pred_sub_value = getattr(pred_item, sub_field_name)
-                if pred_sub_value is not None:  # Only count non-null values as FA
+                if pred_sub_value is not None:
                     sub_field_metrics["fa"] += 1
                     sub_field_metrics["fp"] += 1
 
-        # UNIFIED STRUCTURE: Wrap primitive field metrics in 'overall' for consistency
-        # This ensures all fields use the same access pattern: field_data['overall']
         return {"overall": sub_field_metrics}
 
 

--- a/src/stickler/structured_object_evaluator/models/structured_list_comparator.py
+++ b/src/stickler/structured_object_evaluator/models/structured_list_comparator.py
@@ -278,7 +278,7 @@ class StructuredListComparator:
                         )
                     else:
                         # Handle primitive fields with simple aggregation - ONLY for good matches
-                        field_details[sub_field_name] = self._handle_primitive_field(
+                        field_details[sub_field_name] = self._handle_non_hierarchical_field(
                             sub_field_name,
                             gt_list,
                             pred_list,
@@ -455,7 +455,7 @@ class StructuredListComparator:
                     )
                 # If neither "overall" nor "tp" is present, it might be an empty structure - skip
 
-    def _handle_primitive_field(
+    def _handle_non_hierarchical_field(
         self,
         sub_field_name: str,
         gt_list: List["StructuredModel"],
@@ -499,12 +499,28 @@ class StructuredListComparator:
                     pair_results.append(pair_result)
 
             aggregated_result = self._recursive_aggregate_metrics(pair_results)
+
+            # Handle unmatched objects — count each list element as FN or FA
+            for gt_idx, gt_item in enumerate(gt_list):
+                if gt_idx not in matched_gt_indices:
+                    gt_sub_value = getattr(gt_item, sub_field_name)
+                    if isinstance(gt_sub_value, list) and gt_sub_value:
+                        aggregated_result["overall"]["fn"] += len(gt_sub_value)
+                    elif gt_sub_value is not None:
+                        aggregated_result["overall"]["fn"] += 1
+
+            for pred_idx, pred_item in enumerate(pred_list):
+                if pred_idx not in matched_pred_indices:
+                    pred_sub_value = getattr(pred_item, sub_field_name)
+                    if isinstance(pred_sub_value, list) and pred_sub_value:
+                        aggregated_result["overall"]["fa"] += len(pred_sub_value)
+                        aggregated_result["overall"]["fp"] += len(pred_sub_value)
+                    elif pred_sub_value is not None:
+                        aggregated_result["overall"]["fa"] += 1
+                        aggregated_result["overall"]["fp"] += 1
+
             self._add_derived_metrics_recursively(aggregated_result)
-            return (
-                aggregated_result
-                if pair_results
-                else {"overall": {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}}
-            )
+            return aggregated_result
 
         # True primitive fields — use flat classification
         sub_field_metrics = {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}

--- a/tests/structured_object_evaluator/test_comparable_field_none_default.py
+++ b/tests/structured_object_evaluator/test_comparable_field_none_default.py
@@ -1,0 +1,65 @@
+"""
+Regression test for first-field None auto-population bug.
+
+Validates that ComparableField defaults to None correctly for all fields,
+regardless of position. Previously the first field would auto-populate
+with a FieldInfo object instead of remaining None.
+
+See: https://github.com/awslabs/stickler/issues/17
+"""
+
+from typing import Any, Optional
+
+from stickler.structured_object_evaluator.models.comparable_field import ComparableField
+from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+
+
+class TwoFieldModel(StructuredModel):
+    code: Optional[str] = ComparableField(weight=1.0)
+    description: Optional[str] = ComparableField(weight=1.0)
+
+
+def test_first_field_none_stays_none():
+    """First field set to None should remain None, not become FieldInfo."""
+    data = TwoFieldModel(**{"code": None})
+    assert data.code is None
+    assert data.description is None
+
+
+def test_second_field_none_stays_none():
+    """Second field set to None should remain None."""
+    data = TwoFieldModel(**{"code": "C", "description": None})
+    assert data.code == "C"
+    assert data.description is None
+
+
+def test_both_fields_none():
+    """Both fields explicitly None."""
+    data = TwoFieldModel(**{"code": None, "description": None})
+    assert data.code is None
+    assert data.description is None
+
+
+def test_omitted_fields_default_to_none():
+    """Fields not provided at all should default to None."""
+    data = TwoFieldModel(**{})
+    assert data.code is None
+    assert data.description is None
+
+
+def test_first_field_none_classification():
+    """When first field is None in pred but has value in GT, should be FN not FD.
+
+    This is the core classification error from the issue: if the first field
+    incorrectly becomes FieldInfo, the comparison sees two non-null values
+    and classifies as FD instead of FN.
+    """
+    gt = TwoFieldModel(code="ABC", description="test")
+    pred = TwoFieldModel(**{"code": None, "description": "test"})
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    code_cm = result["confusion_matrix"]["fields"]["code"]["overall"]
+
+    assert code_cm["fn"] == 1, "Missing prediction should be FN"
+    assert code_cm["fd"] == 0, "Should not be FD"
+    assert code_cm["tp"] == 0

--- a/tests/structured_object_evaluator/test_comparable_field_none_default.py
+++ b/tests/structured_object_evaluator/test_comparable_field_none_default.py
@@ -8,7 +8,7 @@ with a FieldInfo object instead of remaining None.
 See: https://github.com/awslabs/stickler/issues/17
 """
 
-from typing import Any, Optional
+from typing import Optional
 
 from stickler.structured_object_evaluator.models.comparable_field import ComparableField
 from stickler.structured_object_evaluator.models.structured_model import StructuredModel

--- a/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
+++ b/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
@@ -1,0 +1,229 @@
+"""
+Regression tests for simple list fields within structured lists.
+
+Validates that List[str] (and similar primitive list types) inside a
+List[StructuredModel] are compared element-by-element using Hungarian matching,
+not treated as atomic primitive values.
+
+See: https://github.com/awslabs/stickler/issues/33
+"""
+
+from typing import Any, List, Optional
+
+from stickler.comparators.exact import ExactComparator
+from stickler.comparators.levenshtein import LevenshteinComparator
+from stickler.structured_object_evaluator.models.comparable_field import ComparableField
+from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+
+
+# ---------------------------------------------------------------------------
+# Models — match_threshold=1.0 (strict, used in the original issue)
+# ---------------------------------------------------------------------------
+
+class LineItemsInfo(StructuredModel):
+    LineItemDays: Optional[List[str]] | Any = ComparableField(weight=1.0)
+    match_threshold = 1.0
+
+
+class Invoice(StructuredModel):
+    LineItems: Optional[List[LineItemsInfo]] | Any = ComparableField(weight=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Models — lower threshold so partial-match tests get field recursion
+# ---------------------------------------------------------------------------
+
+class TaggedItem(StructuredModel):
+    tags: List[str] = ComparableField(
+        comparator=LevenshteinComparator(), threshold=0.7, weight=1.0
+    )
+    match_threshold = 0.3  # Low threshold so most pairs get field recursion
+
+
+class TaggedContainer(StructuredModel):
+    items: List[TaggedItem] = ComparableField(weight=1.0)
+
+
+class TaskItem(StructuredModel):
+    tags: List[str] = ComparableField(
+        comparator=LevenshteinComparator(), threshold=0.7, weight=1.0
+    )
+    priority: str = ComparableField(
+        comparator=ExactComparator(), threshold=1.0, weight=1.0
+    )
+    match_threshold = 0.7
+
+
+class TaskList(StructuredModel):
+    tasks: List[TaskItem] = ComparableField(weight=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _overall(cm, *field_path):
+    """Navigate into cm['fields'][f1]['fields'][f2]...['overall']."""
+    node = cm
+    for f in field_path:
+        node = node["fields"][f]
+    return {k: v for k, v in node["overall"].items()
+            if k in ("tp", "fa", "fd", "fp", "tn", "fn")}
+
+
+# ---------------------------------------------------------------------------
+# Tests — exact reproduction of issue #33
+# ---------------------------------------------------------------------------
+
+def test_issue_33_exact_repro():
+    """Exact scenario from the GitHub issue — comparing identical data."""
+    gt_data = {
+        "LineItems": [
+            {"LineItemDays": ["M", "T", "W", "Th", "F"]},
+            {"LineItemDays": ["Su"]},
+        ]
+    }
+    gt = Invoice(**gt_data)
+    pred = Invoice(**gt_data)
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    agg = result["confusion_matrix"]["aggregate"]
+
+    # 5 elements + 1 element = 6 TPs total
+    assert agg["tp"] == 6
+    assert agg["fa"] == 0
+    assert agg["fd"] == 0
+    assert agg["fp"] == 0
+    assert agg["fn"] == 0
+
+
+def test_issue_33_field_level_metrics():
+    """Verify field-level metrics show element counts, not object counts."""
+    gt_data = {
+        "LineItems": [
+            {"LineItemDays": ["M", "T", "W"]},
+        ]
+    }
+    gt = Invoice(**gt_data)
+    pred = Invoice(**gt_data)
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    metrics = _overall(result["confusion_matrix"], "LineItems", "LineItemDays")
+
+    assert metrics["tp"] == 3
+    assert metrics["fn"] == 0
+    assert metrics["fa"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests — partial matches / mismatches in simple lists
+# Uses TaggedItem with low match_threshold so field recursion happens
+# ---------------------------------------------------------------------------
+
+def test_simple_list_missing_elements():
+    """Prediction list shorter than GT → FN for missing elements."""
+    gt = TaggedContainer(items=[TaggedItem(tags=["M", "T", "W"])])
+    pred = TaggedContainer(items=[TaggedItem(tags=["M"])])
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    metrics = _overall(result["confusion_matrix"], "items", "tags")
+
+    assert metrics["tp"] == 1
+    assert metrics["fn"] == 2
+
+
+def test_simple_list_extra_elements():
+    """Prediction list longer than GT → FA for extra elements."""
+    gt = TaggedContainer(items=[TaggedItem(tags=["M"])])
+    pred = TaggedContainer(items=[TaggedItem(tags=["M", "T", "W"])])
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    metrics = _overall(result["confusion_matrix"], "items", "tags")
+
+    assert metrics["tp"] == 1
+    assert metrics["fa"] == 2
+
+
+def test_simple_list_no_match():
+    """Completely different elements — objects don't match, classified at object level."""
+    gt = TaggedContainer(items=[TaggedItem(tags=["X", "Y"])])
+    pred = TaggedContainer(items=[TaggedItem(tags=["A", "B"])])
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    obj_metrics = _overall(result["confusion_matrix"], "items")
+
+    # Object similarity is ~0 (completely different tags), so Hungarian pairs them
+    # but they fall below match_threshold → object-level FD or FN/FA.
+    # Either way, no field-level recursion happens for the tags.
+    total_classified = (obj_metrics["tp"] + obj_metrics["fd"]
+                        + obj_metrics["fn"] + obj_metrics["fa"])
+    assert total_classified >= 1
+
+
+# ---------------------------------------------------------------------------
+# Tests — multiple structured list items with simple lists
+# ---------------------------------------------------------------------------
+
+def test_multiple_items_aggregate_correctly():
+    """Element counts from multiple structured list items should sum."""
+    gt = Invoice(
+        LineItems=[
+            LineItemsInfo(LineItemDays=["A", "B", "C"]),
+            LineItemsInfo(LineItemDays=["X", "Y"]),
+        ]
+    )
+    pred = Invoice(
+        LineItems=[
+            LineItemsInfo(LineItemDays=["A", "B", "C"]),
+            LineItemsInfo(LineItemDays=["X", "Y"]),
+        ]
+    )
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    agg = result["confusion_matrix"]["aggregate"]
+
+    assert agg["tp"] == 5  # 3 + 2
+    assert agg["fn"] == 0
+    assert agg["fa"] == 0
+
+
+def test_simple_list_alongside_primitive_field():
+    """Simple list and primitive field coexist correctly in the same structured item."""
+    gt = TaskList(
+        tasks=[
+            TaskItem(tags=["urgent", "backend"], priority="high"),
+            TaskItem(tags=["frontend"], priority="low"),
+        ]
+    )
+    pred = TaskList(
+        tasks=[
+            TaskItem(tags=["urgent", "backend"], priority="high"),
+            TaskItem(tags=["frontend"], priority="low"),
+        ]
+    )
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    cm = result["confusion_matrix"]
+
+    tags_metrics = _overall(cm, "tasks", "tags")
+    priority_metrics = _overall(cm, "tasks", "priority")
+
+    # tags: 2 + 1 = 3 element-level TPs
+    assert tags_metrics["tp"] == 3
+
+    # priority: 2 field-level TPs (one per matched task item)
+    assert priority_metrics["tp"] == 2
+
+
+def test_empty_simple_list_within_structured_list():
+    """Empty simple lists on both sides — objects with only empty fields
+    get similarity 0 and don't match, so field-level metrics are all zeros.
+    This is pre-existing behavior for objects whose only field is an empty list."""
+    gt = Invoice(LineItems=[LineItemsInfo(LineItemDays=[])])
+    pred = Invoice(LineItems=[LineItemsInfo(LineItemDays=[])])
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    obj_metrics = _overall(result["confusion_matrix"], "LineItems")
+
+    # Objects with only empty-list fields get similarity 0 → unmatched
+    assert obj_metrics["fn"] + obj_metrics["fa"] >= 1

--- a/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
+++ b/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
@@ -15,7 +15,6 @@ from stickler.comparators.levenshtein import LevenshteinComparator
 from stickler.structured_object_evaluator.models.comparable_field import ComparableField
 from stickler.structured_object_evaluator.models.structured_model import StructuredModel
 
-
 # ---------------------------------------------------------------------------
 # Models — match_threshold=1.0 (strict, used in the original issue)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #33 — Simple list fields (e.g., `List[str]`) inside `List[StructuredModel]` were being 
treated as atomic primitive values instead of compared element-by-element using Hungarian matching. 
Renamed `_handle_primitive_field` → `_handle_non_hierarchical_field` and added dispatch logic to 
route simple list types through `PrimitiveListComparator`.

Also adds regression tests for #17 — validates that `ComparableField` defaults to `None` correctly 
regardless of field position, preventing the first-field `FieldInfo` auto-population bug.

## Changes

- `structured_list_comparator.py`: Detect simple list types and dispatch through 
  `_dispatch_field_comparison` for element-level comparison
- `test_simple_list_in_structured_list.py`: Regression tests for issue #33
- `test_comparable_field_none_default.py`: Regression tests for issue #17
