### PR TITLE
Fix: include static assets in package distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ package-dir = {"" = "src"}
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+stickler = ["reporting/html/styling/*.css", "reporting/html/interactive/*.js"]
+
 [tool.bandit]
 exclude_dirs = ["tests"]
 


### PR DESCRIPTION
The HTML reporter relies on `styling/style.css` and `interactive/main.js` at runtime, but setuptools only packages `.py` files by default. When installed from PyPI, these files are missing, causing `_get_basic_css()` to return `None` and rendering the HTML report without any styling.

- Add `[tool.setuptools.package-data]` to `pyproject.toml` to explicitly include `.css` and `.js` files

Current rendering with the problem:
<img width="984" height="357" alt="Screenshot_20260317_124357" src="https://github.com/user-attachments/assets/80246c02-ec06-4429-b8de-746c4dd90b58" />
