### PR TITLE
fix: use innerHTML instead of textContent in createElement helper

### DIFF
--- a/src/stickler/reporting/html/interactive/main.js
+++ b/src/stickler/reporting/html/interactive/main.js
@@ -29,7 +29,7 @@ const setStyle = (selector, styles) => { const el = getElement(selector); if (el
 const createElement = (tag, className, innerHTML) => {
     const el = document.createElement(tag);
     if (className) el.className = className;
-    if (innerHTML) el.textContent = innerHTML;
+    if (innerHTML) el.innerHTML = innerHTML;
     return el;
 };
 

--- a/src/stickler/reporting/html/interactive/main.js
+++ b/src/stickler/reporting/html/interactive/main.js
@@ -382,11 +382,11 @@ const updateNonMatchesTable = (data) => {
     tableBody.innerHTML = '';
     data.forEach(row => {
         const tr = createElement('tr', '', `
-            <td>${row.doc_id}</td>
-            <td>${row.field_path}</td>
-            <td>${row.non_match_type}</td>
-            <td>${row.ground_truth_value}</td>
-            <td>${row.prediction_value}</td>
+            <td>${escapeHtml(row.doc_id)}</td>
+            <td>${escapeHtml(row.field_path)}</td>
+            <td>${escapeHtml(row.non_match_type)}</td>
+            <td>${escapeHtml(row.ground_truth_value)}</td>
+            <td>${escapeHtml(row.prediction_value)}</td>
         `);
         tableBody.appendChild(tr);
     });
@@ -537,10 +537,11 @@ const loadPDF = (url, canvasId, loadingId, errorId) => {
     
     pdfjsLib.getDocument(url).promise.then(pdf => {
         const pdfContainer = canvas.parentElement;
+        const safeDocId = escapeHtml(docId);
         const navControls = createElement('div', 'pdf-navigation', `
-            <button class="btn btn-primary pdf-nav-btn" id="prev-${docId}" onclick="navigatePDF('${docId}', -1)">← Previous</button>
-            <span class="pdf-page-info" id="page-info-${docId}">Page 1 of ${pdf.numPages}</span>
-            <button class="btn btn-primary pdf-nav-btn" id="next-${docId}" onclick="navigatePDF('${docId}', 1)">Next →</button>
+            <button class="btn btn-primary pdf-nav-btn" id="prev-${safeDocId}" onclick="navigatePDF('${safeDocId}', -1)">← Previous</button>
+            <span class="pdf-page-info" id="page-info-${safeDocId}">Page 1 of ${pdf.numPages}</span>
+            <button class="btn btn-primary pdf-nav-btn" id="next-${safeDocId}" onclick="navigatePDF('${safeDocId}', 1)">Next →</button>
         `);
         pdfContainer.appendChild(navControls);
         

--- a/src/stickler/reporting/html/interactive/main.js
+++ b/src/stickler/reporting/html/interactive/main.js
@@ -406,13 +406,13 @@ const updateDocumentFiles = (data) => {
 
             const pdfContainer = createElement('div', 'pdf-container');
             const canvas = document.createElement('canvas');
-            canvas.id = `pdf-canvas-${escapeHtml(docId)}`;
+            canvas.id = `pdf-canvas-${docId}`;
             canvas.className = 'pdf-canvas';
             const loading = createElement('div', 'pdf-loading');
-            loading.id = `pdf-loading-${escapeHtml(docId)}`;
+            loading.id = `pdf-loading-${docId}`;
             loading.textContent = 'Loading PDF...';
             const error = createElement('div', 'pdf-error');
-            error.id = `pdf-error-${escapeHtml(docId)}`;
+            error.id = `pdf-error-${docId}`;
             error.textContent = 'Error loading PDF';
             error.style.display = 'none';
             pdfContainer.appendChild(canvas);
@@ -537,12 +537,28 @@ const loadPDF = (url, canvasId, loadingId, errorId) => {
     
     pdfjsLib.getDocument(url).promise.then(pdf => {
         const pdfContainer = canvas.parentElement;
-        const safeDocId = escapeHtml(docId);
-        const navControls = createElement('div', 'pdf-navigation', `
-            <button class="btn btn-primary pdf-nav-btn" id="prev-${safeDocId}" onclick="navigatePDF('${safeDocId}', -1)">← Previous</button>
-            <span class="pdf-page-info" id="page-info-${safeDocId}">Page 1 of ${pdf.numPages}</span>
-            <button class="btn btn-primary pdf-nav-btn" id="next-${safeDocId}" onclick="navigatePDF('${safeDocId}', 1)">Next →</button>
-        `);
+        const navControls = createElement('div', 'pdf-navigation');
+
+        const prevBtn = document.createElement('button');
+        prevBtn.className = 'btn btn-primary pdf-nav-btn';
+        prevBtn.id = `prev-${docId}`;
+        prevBtn.textContent = '← Previous';
+        prevBtn.addEventListener('click', () => navigatePDF(docId, -1));
+
+        const pageInfo = document.createElement('span');
+        pageInfo.className = 'pdf-page-info';
+        pageInfo.id = `page-info-${docId}`;
+        pageInfo.textContent = `Page 1 of ${pdf.numPages}`;
+
+        const nextBtn = document.createElement('button');
+        nextBtn.className = 'btn btn-primary pdf-nav-btn';
+        nextBtn.id = `next-${docId}`;
+        nextBtn.textContent = 'Next →';
+        nextBtn.addEventListener('click', () => navigatePDF(docId, 1));
+
+        navControls.appendChild(prevBtn);
+        navControls.appendChild(pageInfo);
+        navControls.appendChild(nextBtn);
         pdfContainer.appendChild(navControls);
         
         window.pdfData = window.pdfData || {};

--- a/src/stickler/reporting/html/interactive/main.js
+++ b/src/stickler/reporting/html/interactive/main.js
@@ -32,6 +32,11 @@ const createElement = (tag, className, innerHTML) => {
     if (innerHTML) el.innerHTML = innerHTML;
     return el;
 };
+const escapeHtml = (text) => {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+};
 
 // Utility functions
 const getPerformanceColor = (value) => value >= 0.8 ? '#28a745' : value >= 0.6 ? '#ffc107' : '#dc3545';
@@ -390,12 +395,6 @@ const updateNonMatchesTable = (data) => {
 const updateDocumentFiles = (data) => {
     const documentGallery = getElement('.document-gallery');
     if (!documentGallery || !data) return;
-
-    const escapeHtml = (text) => {
-        const div = document.createElement('div');
-        div.textContent = text;
-        return div.innerHTML;
-    };
 
     documentGallery.innerHTML = '';
     Object.entries(data).forEach(([docId, filePath]) => {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

The `createElement` utility in `main.js` names its third parameter `innerHTML` but assigns it via `el.textContent`, which escapes HTML. This causes dynamically injected elements (report filter controls, non-match table rows, PDF navigation buttons) to render as raw HTML strings instead of interactive UI components.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Before the fix:
<img width="1401" height="355" alt="Screenshot_20260317_134132" src="https://github.com/user-attachments/assets/1cb2124c-2928-4228-8bab-564acfa22a05" />
