### PR TITLE
fix: remove unused inspect import

### DIFF
--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -4,7 +4,6 @@ This module provides the StructuredModel class for defining structured data mode
 with comparison configuration and evaluation capabilities.
 """
 
-import inspect
 from typing import (
     Any,
     ClassVar,


### PR DESCRIPTION
# Pull Request

## Issue Reference
N/A — lint cleanup discovered during dev setup.

## Description of Changes

### Changes Made
- Removed unused `import inspect` from `src/stickler/structured_object_evaluator/models/structured_model.py`

### Why These Changes Are Needed
`ruff check` flags this as an unused import (F401). Cleaning it up keeps the codebase lint-clean.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

896 passed, 10 skipped — no regressions.

## Checklist
- [x] Code follows the project's coding standards
- [x] Self-review of code completed
- [ ] Documentation updated (if applicable)
- [ ] Tests added/updated for new functionality
- [x] All CI checks are passing
- [x] Ready for review

## Additional Notes
One-line deletion. No behavioral change.