### PR TITLE
fix: resolve PR #102 review feedback — round-trip fidelity, doc corrections, version bump to 0.3.0

### DIFF
--- a/docs/docs/Getting-Started/README.md
+++ b/docs/docs/Getting-Started/README.md
@@ -105,7 +105,7 @@ for gt_json, pred_json, doc_id in your_test_set:
     evaluator.update(gt, pred, doc_id)
 
 result = evaluator.compute()
-print(f"Aggregate F1: {result.overall_metrics['f1']:.3f}")
+print(f"Aggregate F1: {result.metrics['cm_f1']:.3f}")
 ```
 
 See [Bulk Evaluation](../Guides/Evaluation/bulk-evaluation.md) for the full guide.

--- a/docs/docs/Guides/Document_Packet_Splitting.md
+++ b/docs/docs/Guides/Document_Packet_Splitting.md
@@ -145,7 +145,7 @@ Each row represents one page in the packet:
 - One row per page in the packet
 - `group_id` values don't need to match `group_id_predicted` — clustering metrics compare partition structure, not labels
 - `page_number` represents page ordering within a document. Both within-document numbering (1, 2, 3 per document) and global-sequential numbering (e.g., form-01 uses 4, 5 if it starts at the 4th page) are valid — Kendall's Tau only compares relative ordering
-- Single-page groups are excluded from ordering score
+- Single-page groups receive a perfect ordering score of 1.0 (trivially correct order)
 - `strict_clustering=True` penalizes misclassification by breaking clustering credit for misclassified pages
 
 ### Example

--- a/examples/notebooks/Complex_nested_structure.ipynb
+++ b/examples/notebooks/Complex_nested_structure.ipynb
@@ -297,7 +297,7 @@
    "outputs": [],
    "source": [
     "# Use evaluator format for detailed analysis\n",
-    "result = ground_truth.compare_with(prediction, evaluator_format=True)\n",
+    "result = ground_truth.compare_with(prediction, evaluator_format=True, include_confusion_matrix=True)\n",
     "\n",
     "print(\"📊 DETAILED EVALUATION METRICS\")\n",
     "print(\"=\" * 50)\n",

--- a/examples/notebooks/Custom_Comparator_Demo.ipynb
+++ b/examples/notebooks/Custom_Comparator_Demo.ipynb
@@ -675,9 +675,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "agentic-idp",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "agentic-idp"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/examples/notebooks/Quick_start.ipynb
+++ b/examples/notebooks/Quick_start.ipynb
@@ -249,7 +249,7 @@
    "outputs": [],
    "source": [
     "# Use evaluator for detailed batch analysis\n",
-    "batch_eval_result = gt_batch.compare_with(pred_batch, evaluator_format=True)\n",
+    "batch_eval_result = gt_batch.compare_with(pred_batch, evaluator_format=True, include_confusion_matrix=True)\n",
     "\n",
     "print(\"📈 Detailed Batch Evaluation:\")\n",
     "print(f\"Overall Precision: {batch_eval_result['overall']['precision']:.3f}\")\n",
@@ -371,9 +371,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "agentic-idp",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "agentic-idp"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stickler-eval"
-version = "0.2.1"
+version = "0.3.0"
 description = "Structured object comparison and evaluation library"
 authors = [
     {name = "Spencer Romo", email = "sromo@amazon.com"},

--- a/src/stickler/__init__.py
+++ b/src/stickler/__init__.py
@@ -16,7 +16,7 @@ from .structured_object_evaluator import (
     compare_structured_models,
 )
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 
 __all__ = [
     "StructuredModel",

--- a/src/stickler/doc_split/README.md
+++ b/src/stickler/doc_split/README.md
@@ -198,7 +198,7 @@ Full column reference:
 - One row per page in the packet.
 - `group_id` values do not need to match `group_id_predicted` values — clustering metrics compare the partition structure, not the labels.
 - `page_number` represents page ordering within a document. Both within-document numbering (1, 2, 3 per document) and global-sequential numbering (e.g., form-01 uses 4, 5 if it starts at the 4th page) are valid — Kendall's Tau only compares relative ordering.
-- Single-page groups are excluded from ordering score (Kendall's Tau is undefined for n=1).
+- Single-page groups receive a perfect ordering score of 1.0 (a single page is trivially in the correct order).
 - `strict_clustering=True` breaks clustering credit for misclassified pages by assigning them unique error IDs internally.
 
 ---

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -1218,6 +1218,10 @@ class StructuredModel(BaseModel):
             # Check if nested StructuredModel - recursively export to maintain full configuration
             if cls._is_structured_model_type(field_type):
                 property_schema = field_type.to_json_schema()
+                metadata = converter._extract_field_metadata(field_info)
+                metadata.pop("comparator", None)
+                extensions = converter._build_comparison_extensions(metadata, output_format="json_schema")
+                property_schema.update(extensions)
             elif get_origin(field_type) is list:
                 # Handle List[StructuredModel] or List[primitive]
                 args = get_args(field_type)
@@ -1235,6 +1239,10 @@ class StructuredModel(BaseModel):
                         "type": "array",
                         "items": element_type.to_json_schema(),
                     }
+                    metadata = converter._extract_field_metadata(field_info)
+                    metadata.pop("comparator", None)
+                    extensions = converter._build_comparison_extensions(metadata, output_format="json_schema")
+                    property_schema.update(extensions)
                 else:
                     # Primitive list - build array schema manually
                     json_element_type = PYTHON_TYPE_TO_JSON_TYPE.get(
@@ -1357,6 +1365,10 @@ class StructuredModel(BaseModel):
                     field_config["model_name"] = nested_config["model_name"]
                 if nested_config.get("match_threshold") is not None:
                     field_config["match_threshold"] = nested_config["match_threshold"]
+                metadata = converter._extract_field_metadata(field_info)
+                metadata.pop("comparator", None)
+                extensions = converter._build_comparison_extensions(metadata, output_format="stickler_config")
+                field_config.update(extensions)
             elif get_origin(field_type) is list:
                 # Handle List[StructuredModel] or List[primitive]
                 args = get_args(field_type)
@@ -1375,6 +1387,10 @@ class StructuredModel(BaseModel):
                         field_config["model_name"] = nested_config["model_name"]
                     if nested_config.get("match_threshold") is not None:
                         field_config["match_threshold"] = nested_config["match_threshold"]
+                    metadata = converter._extract_field_metadata(field_info)
+                    metadata.pop("comparator", None)
+                    extensions = converter._build_comparison_extensions(metadata, output_format="stickler_config")
+                    field_config.update(extensions)
                 else:
                     # Primitive list - pass element type, then fix up type string
                     field_config = converter.field_to_stickler_config(

--- a/src/stickler/structured_object_evaluator/utils/pretty_print.py
+++ b/src/stickler/structured_object_evaluator/utils/pretty_print.py
@@ -276,6 +276,9 @@ def _normalize_results_format(
 
     # Handle regular single document results
     elif isinstance(results, dict) and "confusion_matrix" in results:
+        cm = results["confusion_matrix"]
+        if not cm or "overall" not in cm:
+            return None
         return results
 
     # Handle direct metrics dict (fallback)

--- a/tests/structured_object_evaluator/test_export_roundtrip.py
+++ b/tests/structured_object_evaluator/test_export_roundtrip.py
@@ -242,6 +242,82 @@ def test_optional_field_roundtrip():
     assert result_recon["overall_score"] == 1.0
 
 
+def test_nested_model_custom_weight_json_schema_roundtrip():
+    """Test that non-default weight on a nested StructuredModel field survives JSON Schema round-trip."""
+
+    class Order(StructuredModel):
+        order_id: str = ComparableField(threshold=1.0, default=...)
+        product: Product = ComparableField(weight=3.0, clip_under_threshold=False, default=...)
+
+    schema = Order.to_json_schema()
+
+    assert schema["properties"]["product"].get("x-aws-stickler-weight") == 3.0
+    assert schema["properties"]["product"].get("x-aws-stickler-clip-under-threshold") is False
+
+    ReconstructedOrder = StructuredModel.from_json_schema(schema)
+
+    product_field = ReconstructedOrder.model_fields["product"]
+    assert product_field.json_schema_extra._weight == 3.0
+    assert product_field.json_schema_extra._clip_under_threshold is False
+
+
+def test_nested_model_custom_weight_stickler_config_roundtrip():
+    """Test that non-default weight on a nested StructuredModel field survives Stickler config round-trip."""
+
+    class Order(StructuredModel):
+        order_id: str = ComparableField(threshold=1.0, default=...)
+        product: Product = ComparableField(weight=3.0, clip_under_threshold=False, default=...)
+
+    config = Order.to_stickler_config()
+
+    assert config["fields"]["product"]["weight"] == 3.0
+    assert config["fields"]["product"]["clip_under_threshold"] is False
+
+    ReconstructedOrder = StructuredModel.model_from_json(config)
+
+    product_field = ReconstructedOrder.model_fields["product"]
+    assert product_field.json_schema_extra._weight == 3.0
+    assert product_field.json_schema_extra._clip_under_threshold is False
+
+
+def test_list_model_custom_weight_json_schema_roundtrip():
+    """Test that non-default weight on a List[StructuredModel] field survives JSON Schema round-trip."""
+
+    class Cart(StructuredModel):
+        cart_id: str = ComparableField(threshold=1.0, default=...)
+        products: List[Product] = ComparableField(weight=5.0, clip_under_threshold=False, default=...)
+
+    schema = Cart.to_json_schema()
+
+    assert schema["properties"]["products"].get("x-aws-stickler-weight") == 5.0
+    assert schema["properties"]["products"].get("x-aws-stickler-clip-under-threshold") is False
+
+    ReconstructedCart = StructuredModel.from_json_schema(schema)
+
+    products_field = ReconstructedCart.model_fields["products"]
+    assert products_field.json_schema_extra._weight == 5.0
+    assert products_field.json_schema_extra._clip_under_threshold is False
+
+
+def test_list_model_custom_weight_stickler_config_roundtrip():
+    """Test that non-default weight on a List[StructuredModel] field survives Stickler config round-trip."""
+
+    class Cart(StructuredModel):
+        cart_id: str = ComparableField(threshold=1.0, default=...)
+        products: List[Product] = ComparableField(weight=5.0, clip_under_threshold=False, default=...)
+
+    config = Cart.to_stickler_config()
+
+    assert config["fields"]["products"]["weight"] == 5.0
+    assert config["fields"]["products"]["clip_under_threshold"] is False
+
+    ReconstructedCart = StructuredModel.model_from_json(config)
+
+    products_field = ReconstructedCart.model_fields["products"]
+    assert products_field.json_schema_extra._weight == 5.0
+    assert products_field.json_schema_extra._clip_under_threshold is False
+
+
 def test_numeric_comparator_tolerance_roundtrip():
     """Test that NumericComparator tolerance is preserved after round-trip."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -3056,7 +3056,7 @@ wheels = [
 
 [[package]]
 name = "stickler-eval"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
*Issue #, if available:*

Addresses review feedback on PR #102

*Description of changes:*

## Summary

- **Round-trip fidelity**: `to_json_schema()` and `to_stickler_config()` now preserve field-level extensions (weight, threshold, clip_under_threshold, aggregate) on nested `StructuredModel` and `List[StructuredModel]` fields. Comparator keys are excluded since nested models use recursive comparison.
- **Doc corrections**: Fixed two docs (`src/stickler/doc_split/README.md`, `docs/docs/Guides/Document_Packet_Splitting.md`) that incorrectly stated single-page groups are "excluded" from ordering score — the implementation assigns them 1.0.
- **Code example fix**: Getting Started guide now uses the correct API (`result.metrics['cm_f1']` instead of `result.overall_metrics['f1']`).
- **Version bump**: 0.2.1 → 0.3.0 in `__init__.py` and `pyproject.toml` to reflect new features in the release (DocSplit metrics, StructuredModel export helpers).

## Test plan

- [x] 4 new round-trip tests verify non-default weights survive export/reimport for nested and list-of-model fields (both JSON schema and stickler config paths)
- [x] Pre-existing `test_list_model_roundtrip` now passes (was broken by the same comparator-on-nested-field issue)
- [x] Full test suite: 900 passed, 0 failed
- [x] `ruff check .` passes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.