### PR TITLE
fix: keep semantic model_id as string

### DIFF
--- a/src/stickler/comparators/semantic.py
+++ b/src/stickler/comparators/semantic.py
@@ -51,7 +51,7 @@ class SemanticComparator(BaseComparator):
         if embedding_function is not None:
             self.embedding_function = embedding_function
         else:
-            self.model_id = (model_id,)
+            self.model_id = model_id
             self.embedding_function = partial(
                 generate_bedrock_embedding, model_id=model_id
             )

--- a/tests/common/comparators/test_semantic.py
+++ b/tests/common/comparators/test_semantic.py
@@ -1,0 +1,10 @@
+"""Tests for the semantic comparator."""
+
+from stickler.comparators.semantic import SemanticComparator
+
+
+def test_model_id_remains_a_string_when_using_default_embedding():
+    comparator = SemanticComparator(model_id="test-model")
+
+    assert comparator.model_id == "test-model"
+    assert isinstance(comparator.model_id, str)


### PR DESCRIPTION
Fixes #112

### Changes
- Store SemanticComparator.model_id as the configured model ID string instead of a one-item tuple.
- Add a focused regression test for the default embedding path.

### Tests
- uv run pytest tests/common/comparators/test_semantic.py -q
- uv run pytest tests/common/comparators -q
- uv run pytest tests/ -q
- uv run ruff check src/stickler/comparators/semantic.py tests/common/comparators/test_semantic.py