### PR TITLE
fix: log semantic embedding fallback failures

### DIFF
--- a/src/stickler/comparators/semantic.py
+++ b/src/stickler/comparators/semantic.py
@@ -1,5 +1,6 @@
 """Semantic comparator for embedding-based similarity."""
 
+import logging
 from functools import partial
 from typing import Callable, Optional
 
@@ -7,6 +8,8 @@ from scipy import spatial
 
 from stickler.comparators.base import BaseComparator
 from stickler.comparators.utils import generate_bedrock_embedding
+
+logger = logging.getLogger(__name__)
 
 
 class SemanticComparator(BaseComparator):
@@ -76,5 +79,18 @@ class SemanticComparator(BaseComparator):
             x, y = self.embedding_function(str1), self.embedding_function(str2)
             return self.similarity_function(x, y)
         except Exception:
+            logger.exception(
+                "Semantic embedding comparison failed; falling back to string equality",
+                extra={
+                    "embedding_function": getattr(
+                        self.embedding_function,
+                        "__name__",
+                        type(self.embedding_function).__name__,
+                    ),
+                    "input_1_length": len(str1),
+                    "input_2_length": len(str2),
+                    "similarity_function": self.sim_function,
+                },
+            )
             # Fallback to string equality if embedding fails
             return 1.0 if str1 == str2 else 0.0

--- a/src/stickler/comparators/semantic.py
+++ b/src/stickler/comparators/semantic.py
@@ -1,6 +1,7 @@
 """Semantic comparator for embedding-based similarity."""
 
 import logging
+import sys
 from functools import partial
 from typing import Callable, Optional
 
@@ -10,6 +11,25 @@ from stickler.comparators.base import BaseComparator
 from stickler.comparators.utils import generate_bedrock_embedding
 
 logger = logging.getLogger(__name__)
+
+
+def _embedding_function_name(embedding_function: Callable) -> str:
+    """Return a useful name for custom callables and functools.partial wrappers."""
+    if isinstance(embedding_function, partial):
+        return getattr(
+            embedding_function.func,
+            "__name__",
+            type(embedding_function.func).__name__,
+        )
+    return getattr(embedding_function, "__name__", type(embedding_function).__name__)
+
+
+def _input_length(value) -> int:
+    """Return a log-safe length for primitive values routed to semantic compare."""
+    try:
+        return len(value)
+    except TypeError:
+        return len(str(value))
 
 
 class SemanticComparator(BaseComparator):
@@ -51,10 +71,10 @@ class SemanticComparator(BaseComparator):
         """
         super().__init__(threshold=threshold)
 
+        self.model_id = model_id
         if embedding_function is not None:
             self.embedding_function = embedding_function
         else:
-            self.model_id = model_id
             self.embedding_function = partial(
                 generate_bedrock_embedding, model_id=model_id
             )
@@ -63,11 +83,15 @@ class SemanticComparator(BaseComparator):
         self.similarity_function = self.SIMILARITY_FUNCTIONS[self.sim_function]
 
     def compare(self, str1: str, str2: str) -> float:
-        """Compare two strings using semantic similarity.
+        """Compare two values using semantic similarity.
+
+        If embedding generation fails, this logs the model ID, embedding function,
+        input lengths, similarity function, and exception type before falling back
+        to raw equality.
 
         Args:
-            str1: First string
-            str2: Second string
+            str1: First value
+            str2: Second value
 
         Returns:
             Similarity score between 0.0 and 1.0
@@ -82,14 +106,14 @@ class SemanticComparator(BaseComparator):
             logger.exception(
                 "Semantic embedding comparison failed; falling back to string equality",
                 extra={
-                    "embedding_function": getattr(
-                        self.embedding_function,
-                        "__name__",
-                        type(self.embedding_function).__name__,
+                    "embedding_function": _embedding_function_name(
+                        self.embedding_function
                     ),
-                    "input_1_length": len(str1),
-                    "input_2_length": len(str2),
+                    "model_id": getattr(self, "model_id", None),
+                    "input_1_length": _input_length(str1),
+                    "input_2_length": _input_length(str2),
                     "similarity_function": self.sim_function,
+                    "exception_type": type(sys.exc_info()[1]).__name__,
                 },
             )
             # Fallback to string equality if embedding fails

--- a/tests/common/comparators/test_semantic.py
+++ b/tests/common/comparators/test_semantic.py
@@ -1,5 +1,7 @@
 """Tests for the semantic comparator."""
 
+import logging
+
 from stickler.comparators.semantic import SemanticComparator
 
 
@@ -8,3 +10,30 @@ def test_model_id_remains_a_string_when_using_default_embedding():
 
     assert comparator.model_id == "test-model"
     assert isinstance(comparator.model_id, str)
+
+
+def test_compare_logs_embedding_failures_before_fallback(caplog):
+    def raise_embedding_failure(_value):
+        raise RuntimeError("simulated embedding outage")
+
+    comparator = SemanticComparator(embedding_function=raise_embedding_failure)
+
+    with caplog.at_level(logging.ERROR, logger="stickler.comparators.semantic"):
+        score = comparator.compare("cat on mat", "feline on rug")
+
+    assert score == 0.0
+    assert "Semantic embedding comparison failed" in caplog.text
+    assert "simulated embedding outage" in caplog.text
+
+
+def test_compare_keeps_exact_match_fallback_when_embedding_fails(caplog):
+    def raise_embedding_failure(_value):
+        raise RuntimeError("simulated embedding outage")
+
+    comparator = SemanticComparator(embedding_function=raise_embedding_failure)
+
+    with caplog.at_level(logging.ERROR, logger="stickler.comparators.semantic"):
+        score = comparator.compare("same", "same")
+
+    assert score == 1.0
+    assert "Semantic embedding comparison failed" in caplog.text

--- a/tests/common/comparators/test_semantic.py
+++ b/tests/common/comparators/test_semantic.py
@@ -1,39 +1,92 @@
-"""Tests for the semantic comparator."""
+"""Tests for SemanticComparator."""
 
 import logging
 
-from stickler.comparators.semantic import SemanticComparator
+from stickler.comparators import SemanticComparator
 
 
-def test_model_id_remains_a_string_when_using_default_embedding():
-    comparator = SemanticComparator(model_id="test-model")
+class TestSemanticComparator:
+    """Test semantic comparator fallback behavior."""
 
-    assert comparator.model_id == "test-model"
-    assert isinstance(comparator.model_id, str)
+    def test_model_id_remains_a_string_when_using_default_embedding(self):
+        """Default embedding setup stores model_id as a string."""
+        comparator = SemanticComparator(model_id="test-model")
 
+        assert comparator.model_id == "test-model"
+        assert isinstance(comparator.model_id, str)
 
-def test_compare_logs_embedding_failures_before_fallback(caplog):
-    def raise_embedding_failure(_value):
-        raise RuntimeError("simulated embedding outage")
+    def test_compare_logs_embedding_failures_before_fallback(self, caplog):
+        """Embedding failures are logged before returning unequal fallback."""
 
-    comparator = SemanticComparator(embedding_function=raise_embedding_failure)
+        def raise_embedding_failure(_value):
+            raise RuntimeError("simulated embedding outage")
 
-    with caplog.at_level(logging.ERROR, logger="stickler.comparators.semantic"):
-        score = comparator.compare("cat on mat", "feline on rug")
+        comparator = SemanticComparator(
+            embedding_function=raise_embedding_failure, model_id="custom-model"
+        )
 
-    assert score == 0.0
-    assert "Semantic embedding comparison failed" in caplog.text
-    assert "simulated embedding outage" in caplog.text
+        with caplog.at_level(logging.ERROR, logger="stickler.comparators.semantic"):
+            score = comparator.compare("cat on mat", "feline on rug")
 
+        record = caplog.records[0]
+        assert score == 0.0
+        assert "Semantic embedding comparison failed" in caplog.text
+        assert "simulated embedding outage" in caplog.text
+        assert record.embedding_function == "raise_embedding_failure"
+        assert record.model_id == "custom-model"
+        assert record.input_1_length == len("cat on mat")
+        assert record.input_2_length == len("feline on rug")
+        assert record.exception_type == "RuntimeError"
 
-def test_compare_keeps_exact_match_fallback_when_embedding_fails(caplog):
-    def raise_embedding_failure(_value):
-        raise RuntimeError("simulated embedding outage")
+    def test_compare_keeps_exact_match_fallback_when_embedding_fails(self, caplog):
+        """Embedding failures keep exact-match fallback semantics."""
 
-    comparator = SemanticComparator(embedding_function=raise_embedding_failure)
+        def raise_embedding_failure(_value):
+            raise RuntimeError("simulated embedding outage")
 
-    with caplog.at_level(logging.ERROR, logger="stickler.comparators.semantic"):
-        score = comparator.compare("same", "same")
+        comparator = SemanticComparator(embedding_function=raise_embedding_failure)
 
-    assert score == 1.0
-    assert "Semantic embedding comparison failed" in caplog.text
+        with caplog.at_level(logging.ERROR, logger="stickler.comparators.semantic"):
+            score = comparator.compare("same", "same")
+
+        assert score == 1.0
+        assert "Semantic embedding comparison failed" in caplog.text
+
+    def test_compare_logs_non_string_input_lengths_before_fallback(self, caplog):
+        """Fallback logging does not raise for primitive non-string inputs."""
+
+        def raise_embedding_failure(_value):
+            raise RuntimeError("simulated embedding outage")
+
+        comparator = SemanticComparator(embedding_function=raise_embedding_failure)
+
+        with caplog.at_level(logging.ERROR, logger="stickler.comparators.semantic"):
+            score = comparator.compare(123, 456)
+
+        record = caplog.records[0]
+        assert score == 0.0
+        assert record.input_1_length == len("123")
+        assert record.input_2_length == len("456")
+
+    def test_default_bedrock_fallback_log_includes_function_and_model(
+        self, caplog, monkeypatch
+    ):
+        """Default Bedrock partial logs the wrapped function name and model ID."""
+
+        def raise_bedrock_failure(_value, model_id):
+            raise RuntimeError(f"simulated {model_id} outage")
+
+        monkeypatch.setattr(
+            "stickler.comparators.semantic.generate_bedrock_embedding",
+            raise_bedrock_failure,
+        )
+        comparator = SemanticComparator(model_id="amazon.test-model")
+
+        with caplog.at_level(logging.ERROR, logger="stickler.comparators.semantic"):
+            score = comparator.compare("cat", "dog")
+
+        record = caplog.records[0]
+        assert score == 0.0
+        assert record.embedding_function == "raise_bedrock_failure"
+        assert record.model_id == "amazon.test-model"
+        assert record.exception_type == "RuntimeError"


### PR DESCRIPTION
*Issue #, if available:*

Fixes #113

*Description of changes:*

SemanticComparator currently falls back to string equality if embedding generation raises, but the failure is silent. This change logs the exception before preserving the existing fallback behavior, so Bedrock/network/custom embedding failures are diagnosable without changing current score semantics.

Added regression coverage for both fallback paths:
- different strings still return `0.0` when embedding generation fails
- identical strings still return `1.0` when embedding generation fails
- both cases emit an error log with the original exception

Validation:
- `uv run ruff check src/stickler/comparators/semantic.py tests/common/comparators/test_semantic.py`
- `uv run pytest tests/common/comparators/test_semantic.py tests/common/comparators/test_comparators.py -q`
- `uv run pytest tests/ -q`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
