### PR TITLE
feat: export comparators from top-level stickler package (#110)

### DIFF
--- a/.github/workflows/run_pytest.yaml
+++ b/.github/workflows/run_pytest.yaml
@@ -19,7 +19,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: uv sync --extra llm --frozen
+        # --extra bert installs evaluate, so the BERTComparator positive branch
+        # (_HAS_BERT = True gating in src/stickler/__init__.py) is exercised in CI.
+        run: uv sync --extra llm --extra bert --frozen
       - name: Test with pytest
         run: uv run coverage run -m pytest -v -s
       - name: Generate Coverage Report

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ pip install stickler-eval
 ```python
 # pip install stickler-eval
 from typing import List
-from stickler import StructuredModel, ComparableField
-from stickler.comparators import ExactComparator, NumericComparator, LevenshteinComparator
+from stickler import StructuredModel, ComparableField, ExactComparator, NumericComparator, LevenshteinComparator
 
 # Define your models
 class LineItem(StructuredModel):
@@ -99,8 +98,7 @@ pytest tests/
 ### Static Model Definition
 
 ```python
-from stickler import StructuredModel, ComparableField
-from stickler.comparators.levenshtein import LevenshteinComparator
+from stickler import StructuredModel, ComparableField, LevenshteinComparator
 
 # Define your data structure
 class Invoice(StructuredModel):
@@ -156,7 +154,7 @@ print(results.confidence_metrics["overall"]["auroc"]["value"])
 Create models from JSON configuration for maximum flexibility:
 
 ```python
-from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+from stickler import StructuredModel
 
 # Define model configuration
 config = {

--- a/docs/docs/Advanced/aggregate-metrics.md
+++ b/docs/docs/Advanced/aggregate-metrics.md
@@ -17,7 +17,7 @@ Stickler automatically includes an `aggregate` field at every node in the confus
 
 ```python
 from stickler import StructuredModel, ComparableField
-from stickler.comparators.exact import ExactComparator
+from stickler import ExactComparator
 
 class Contact(StructuredModel):
     phone: str = ComparableField(comparator=ExactComparator(), threshold=1.0)

--- a/docs/docs/Advanced/threshold-gated-evaluation.md
+++ b/docs/docs/Advanced/threshold-gated-evaluation.md
@@ -33,9 +33,7 @@ For each matched pair, compare the similarity score against `StructuredModel.mat
 ## Code Example
 
 ```python
-from stickler import StructuredModel, ComparableField
-from stickler.comparators.levenshtein import LevenshteinComparator
-from stickler.comparators.exact import ExactComparator
+from stickler import StructuredModel, ComparableField, LevenshteinComparator, ExactComparator
 from typing import List
 
 class Product(StructuredModel):

--- a/docs/docs/Getting-Started/Contributing/code-style.md
+++ b/docs/docs/Getting-Started/Contributing/code-style.md
@@ -324,7 +324,6 @@ from pydantic import Field, BaseModel
 
 # Local imports
 from stickler import StructuredModel, ComparableField, LevenshteinComparator
-
 ```
 
 ### Import Guidelines

--- a/docs/docs/Getting-Started/Contributing/code-style.md
+++ b/docs/docs/Getting-Started/Contributing/code-style.md
@@ -231,7 +231,7 @@ strings based on edit distance. It's useful for handling typos and
 minor variations in text fields.
 
 Example:
-    >>> from stickler.comparators.levenshtein import LevenshteinComparator
+    >>> from stickler import LevenshteinComparator
     >>> comparator = LevenshteinComparator()
     >>> comparator.compare("hello", "helo")
     0.8
@@ -323,9 +323,8 @@ import pytest
 from pydantic import Field, BaseModel
 
 # Local imports
-from stickler.structured_object_evaluator import StructuredModel
-from stickler.structured_object_evaluator.models.comparable_field import ComparableField
-from stickler.comparators.levenshtein import LevenshteinComparator
+from stickler import StructuredModel, ComparableField, LevenshteinComparator
+
 ```
 
 ### Import Guidelines
@@ -336,13 +335,13 @@ from stickler.comparators.levenshtein import LevenshteinComparator
 
 ```python
 # Good
-from stickler.comparators.levenshtein import LevenshteinComparator
+from stickler import LevenshteinComparator
 
 # Acceptable for commonly used items
 from typing import List, Optional, Dict
 
 # Avoid
-from stickler.comparators import *
+from stickler import *
 ```
 
 ## Code Organization

--- a/docs/docs/Getting-Started/Contributing/testing-guide.md
+++ b/docs/docs/Getting-Started/Contributing/testing-guide.md
@@ -50,7 +50,7 @@ tests/
 Use for simple, independent tests:
 
 ```python
-from stickler.comparators.levenshtein import LevenshteinComparator
+from stickler import LevenshteinComparator
 
 def test_exact_match():
     """Test exact string match returns 1.0."""
@@ -70,7 +70,7 @@ Use when tests share setup or test a single component:
 
 ```python
 import pytest
-from stickler.comparators.levenshtein import LevenshteinComparator
+from stickler import LevenshteinComparator
 
 class TestLevenshteinComparator:
     """Test cases for the LevenshteinComparator."""
@@ -99,10 +99,7 @@ Define test models within test files for isolated testing:
 
 ```python
 from typing import Optional
-from stickler.structured_object_evaluator.models.structured_model import StructuredModel
-from stickler.structured_object_evaluator.models.comparable_field import ComparableField
-from stickler.comparators.levenshtein import LevenshteinComparator
-from stickler.comparators.exact import ExactComparator
+from stickler import StructuredModel, ComparableField, LevenshteinComparator, ExactComparator
 
 # Define test model
 class SimpleTestModel(StructuredModel):
@@ -146,7 +143,7 @@ Use `pytest.mark.parametrize` for testing multiple inputs:
 
 ```python
 import pytest
-from stickler.comparators.levenshtein import LevenshteinComparator
+from stickler import LevenshteinComparator
 
 @pytest.mark.parametrize("str1,str2,expected_min,expected_max", [
     ("hello", "hello", 1.0, 1.0),       # Exact match

--- a/docs/docs/Getting-Started/README.md
+++ b/docs/docs/Getting-Started/README.md
@@ -16,7 +16,7 @@ Stickler answers these questions. It compares structured AI output against groun
 # pip install stickler-eval
 from typing import List
 from stickler import StructuredModel, ComparableField
-from stickler.comparators import ExactComparator, NumericComparator, LevenshteinComparator
+from stickler import ExactComparator, NumericComparator, LevenshteinComparator
 
 # Define your models
 class LineItem(StructuredModel):

--- a/docs/docs/Guides/Best-Practices/README.md
+++ b/docs/docs/Guides/Best-Practices/README.md
@@ -54,7 +54,7 @@ Once you have calibrated thresholds, encode them as pytest unit tests so they do
 
 ```python
 import pytest
-from stickler.comparators import LevenshteinComparator
+from stickler import LevenshteinComparator
 
 comparator = LevenshteinComparator()
 

--- a/docs/docs/Guides/Comparators/README.md
+++ b/docs/docs/Guides/Comparators/README.md
@@ -28,7 +28,7 @@ Checks for exact string matching after normalizing whitespace, punctuation, and 
 
 ```python
 from stickler import StructuredModel, ComparableField
-from stickler.comparators import ExactComparator
+from stickler import ExactComparator
 
 class Order(StructuredModel):
     order_id: str = ComparableField(
@@ -55,7 +55,7 @@ Calculates the Levenshtein edit distance between two strings and returns a norma
 
 ```python
 from stickler import StructuredModel, ComparableField
-from stickler.comparators import LevenshteinComparator
+from stickler import LevenshteinComparator
 
 class Contact(StructuredModel):
     name: str = ComparableField(
@@ -81,7 +81,7 @@ Extracts numeric values from strings or numbers and compares them with configura
 
 ```python
 from stickler import StructuredModel, ComparableField
-from stickler.comparators import NumericComparator
+from stickler import NumericComparator
 
 class Invoice(StructuredModel):
     amount: float = ComparableField(
@@ -109,7 +109,7 @@ Uses the [rapidfuzz](https://github.com/rapidfuzz/RapidFuzz) library for advance
 
 ```python
 from stickler import StructuredModel, ComparableField
-from stickler.comparators import FuzzyComparator
+from stickler import FuzzyComparator
 
 class Product(StructuredModel):
     description: str = ComparableField(
@@ -146,7 +146,7 @@ Uses AWS Bedrock Titan embeddings to generate vector representations of text, th
 
 ```python
 from stickler import StructuredModel, ComparableField
-from stickler.comparators import SemanticComparator
+from stickler import SemanticComparator
 
 class Review(StructuredModel):
     summary: str = ComparableField(
@@ -174,7 +174,7 @@ Uses the BERTScore metric (via the `evaluate` library) to calculate contextual s
 
 ```python
 from stickler import StructuredModel, ComparableField
-from stickler.comparators import BERTComparator
+from stickler import BERTComparator
 
 class Document(StructuredModel):
     summary: str = ComparableField(
@@ -201,7 +201,7 @@ Uses a Large Language Model (via AWS Bedrock and the `strands-agents` library) t
 
 ```python
 from stickler import StructuredModel, ComparableField
-from stickler.comparators import LLMComparator
+from stickler import LLMComparator
 
 class Address(StructuredModel):
     street: str = ComparableField(
@@ -248,7 +248,7 @@ You can create your own comparator by extending `BaseComparator`. The only requi
 ### The BaseComparator Interface
 
 ```python
-from stickler.comparators.base import BaseComparator
+from stickler import BaseComparator
 
 class BaseComparator(ABC):
     def __init__(self, threshold: float = 0.7):
@@ -278,7 +278,7 @@ class BaseComparator(ABC):
 ```python
 import re
 from typing import Any
-from stickler.comparators.base import BaseComparator
+from stickler import BaseComparator
 
 class RegexComparator(BaseComparator):
     """Comparator that checks if a value matches a reference regex pattern."""

--- a/docs/docs/Guides/Comparators/llm-as-a-judge.md
+++ b/docs/docs/Guides/Comparators/llm-as-a-judge.md
@@ -41,7 +41,7 @@ export AWS_DEFAULT_REGION=us-east-1
 
 ```python
 from stickler import StructuredModel, ComparableField
-from stickler.comparators import SemanticComparator
+from stickler import SemanticComparator
 
 class DeliveryNote(StructuredModel):
     description: str = ComparableField(
@@ -114,7 +114,7 @@ The model is loaded globally as `distilbert-base-uncased` via the `evaluate` lib
 
 ```python
 from stickler import StructuredModel, ComparableField
-from stickler.comparators import BERTComparator
+from stickler import BERTComparator
 
 class Article(StructuredModel):
     headline: str = ComparableField(
@@ -188,7 +188,7 @@ This example is based on the [`examples/scripts/llm_comparator_demo.py`](https:/
 
 ```python
 from stickler import StructuredModel, ComparableField
-from stickler.comparators import ExactComparator, LevenshteinComparator, LLMComparator
+from stickler import ExactComparator, LevenshteinComparator, LLMComparator
 
 class CustomerAddress(StructuredModel):
     street: str = ComparableField(
@@ -264,7 +264,7 @@ In practice, you will often use different comparators for different fields in a 
 
 ```python
 from stickler import StructuredModel, ComparableField
-from stickler.comparators import (
+from stickler import (
     ExactComparator,
     NumericComparator,
     LevenshteinComparator,

--- a/docs/docs/Guides/Evaluation/README.md
+++ b/docs/docs/Guides/Evaluation/README.md
@@ -74,12 +74,14 @@ Fields with higher weights pull the overall score toward their individual result
 ### Example Model
 
 ```python
-from stickler.comparators.levenshtein import LevenshteinComparator
-from stickler.comparators.exact import ExactComparator
-from stickler.comparators.numeric import NumericComparator
-from stickler.comparators.fuzzy import FuzzyComparator
-from stickler.structured_object_evaluator.models.comparable_field import ComparableField
-from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+from stickler import (
+    ComparableField,
+    ExactComparator,
+    FuzzyComparator,
+    LevenshteinComparator,
+    NumericComparator,
+    StructuredModel,
+)
 
 
 class Invoice(StructuredModel):
@@ -222,7 +224,7 @@ Add these extensions to any property in your JSON Schema to control comparison b
 ### Loading a Schema
 
 ```python
-from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+from stickler import StructuredModel
 import json
 
 with open("invoice_schema.json") as f:

--- a/docs/docs/Guides/Evaluation/bulk-evaluation.md
+++ b/docs/docs/Guides/Evaluation/bulk-evaluation.md
@@ -311,10 +311,7 @@ Stickler can generate interactive HTML reports from evaluation results. See [Und
 ## Complete Example
 
 ```python
-from stickler.comparators.levenshtein import LevenshteinComparator
-from stickler.comparators.exact import ExactComparator
-from stickler.structured_object_evaluator.models.comparable_field import ComparableField
-from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+from stickler import ComparableField, ExactComparator, LevenshteinComparator, StructuredModel
 from stickler.structured_object_evaluator.bulk_structured_model_evaluator import (
     BulkStructuredModelEvaluator,
 )

--- a/docs/docs/Guides/Evaluation/bulk-evaluation.md
+++ b/docs/docs/Guides/Evaluation/bulk-evaluation.md
@@ -280,9 +280,7 @@ When these conditions are met, `update_from_comparison_result()` produces identi
 For simpler cases where you have a list of comparison results in memory:
 
 ```python
-from stickler.structured_object_evaluator.bulk_structured_model_evaluator import (
-    aggregate_from_comparisons,
-)
+from stickler import aggregate_from_comparisons
 
 results = [comp1, comp2, comp3]  # list of compare_with() outputs
 evaluation = aggregate_from_comparisons(results)

--- a/docs/docs/Guides/Use-Cases/README.md
+++ b/docs/docs/Guides/Use-Cases/README.md
@@ -24,7 +24,7 @@ The primary use case. Extract structured data from documents (invoices, forms, r
 ```python
 from typing import List
 from stickler import StructuredModel, ComparableField
-from stickler.comparators import ExactComparator, NumericComparator, LevenshteinComparator, FuzzyComparator
+from stickler import ExactComparator, NumericComparator, LevenshteinComparator, FuzzyComparator
 
 class LineItem(StructuredModel):
     description: str = ComparableField(comparator=FuzzyComparator(), weight=1.0)
@@ -51,7 +51,7 @@ Compare OCR engine output against ground truth transcriptions. `LevenshteinCompa
 
 ```python
 from stickler import StructuredModel, ComparableField
-from stickler.comparators import LevenshteinComparator, NumericComparator
+from stickler import LevenshteinComparator, NumericComparator
 
 class OCRTextBlock(StructuredModel):
     text: str = ComparableField(
@@ -77,7 +77,7 @@ Named entity recognition (NER) and entity extraction from text. Compare extracte
 ```python
 from typing import List
 from stickler import StructuredModel, ComparableField
-from stickler.comparators import ExactComparator, LevenshteinComparator, NumericComparator
+from stickler import ExactComparator, LevenshteinComparator, NumericComparator
 
 class Entity(StructuredModel):
     name: str = ComparableField(
@@ -106,7 +106,7 @@ Compare ML model predictions against ground truth labels. Useful for both regres
 ```python
 from typing import List
 from stickler import StructuredModel, ComparableField
-from stickler.comparators import ExactComparator, NumericComparator
+from stickler import ExactComparator, NumericComparator
 
 class Prediction(StructuredModel):
     sample_id: str = ComparableField(comparator=ExactComparator(), weight=1.0)
@@ -135,7 +135,7 @@ Validate that ETL pipeline outputs match expected results. Stickler ensures data
 ```python
 from typing import List
 from stickler import StructuredModel, ComparableField
-from stickler.comparators import ExactComparator, NumericComparator, LevenshteinComparator
+from stickler import ExactComparator, NumericComparator, LevenshteinComparator
 
 class TransformedRecord(StructuredModel):
     record_id: str = ComparableField(
@@ -166,7 +166,7 @@ Ongoing monitoring of data quality by comparing incoming data against baseline o
 
 ```python
 from stickler import StructuredModel, ComparableField
-from stickler.comparators import ExactComparator, NumericComparator, LevenshteinComparator
+from stickler import ExactComparator, NumericComparator, LevenshteinComparator
 
 class CustomerRecord(StructuredModel):
     customer_id: str = ComparableField(

--- a/docs/docs/Guides/Use-Cases/idp-accelerator.md
+++ b/docs/docs/Guides/Use-Cases/idp-accelerator.md
@@ -26,7 +26,7 @@ Create `StructuredModel` classes that mirror the fields your IDP pipeline extrac
 ```python
 from typing import List
 from stickler import StructuredModel, ComparableField
-from stickler.comparators import ExactComparator, NumericComparator, LevenshteinComparator, FuzzyComparator
+from stickler import ExactComparator, NumericComparator, LevenshteinComparator, FuzzyComparator
 
 class IDPLineItem(StructuredModel):
     description: str = ComparableField(comparator=FuzzyComparator(), weight=1.0)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -12,7 +12,7 @@ Generative AI models extract structured data from documents — invoices, forms,
 
 ```python
 from stickler import StructuredModel, ComparableField
-from stickler.comparators import ExactComparator, NumericComparator
+from stickler import ExactComparator, NumericComparator
 
 # 1. Define what "correct" looks like — each field gets its own comparator and weight
 class Invoice(StructuredModel):

--- a/examples/notebooks/Bulk_Confidence_AUROC.ipynb
+++ b/examples/notebooks/Bulk_Confidence_AUROC.ipynb
@@ -18,9 +18,13 @@
     "import random\n",
     "from typing import Optional\n",
     "\n",
-    "from stickler.comparators import ExactComparator, LevenshteinComparator, NumericComparator\n",
-    "from stickler.structured_object_evaluator.models.comparable_field import ComparableField\n",
-    "from stickler.structured_object_evaluator.models.structured_model import StructuredModel\n",
+    "from stickler import (\n",
+    "    ComparableField,\n",
+    "    ExactComparator,\n",
+    "    LevenshteinComparator,\n",
+    "    NumericComparator,\n",
+    "    StructuredModel,\n",
+    ")\n",
     "from stickler.structured_object_evaluator.bulk_structured_model_evaluator import BulkStructuredModelEvaluator\n",
     "from stickler.structured_object_evaluator.models.confidence import AUROCMetric, BrierScoreMetric, ECEMetric, ErrorCaptureAtBudgetMetric"
    ]

--- a/examples/notebooks/Complex_nested_structure.ipynb
+++ b/examples/notebooks/Complex_nested_structure.ipynb
@@ -31,11 +31,9 @@
     "import json\n",
     "from typing import List, Optional\n",
     "\n",
-    "from stickler.comparators.exact import ExactComparator\n",
-    "from stickler.comparators.levenshtein import LevenshteinComparator\n",
-    "from stickler.comparators.numeric import NumericComparator\n",
-    "from stickler.structured_object_evaluator.models.comparable_field import ComparableField\n",
-    "from stickler.structured_object_evaluator.models.structured_model import StructuredModel"
+    "from stickler import (\n",
+    "    StructuredModel, ComparableField, ExactComparator, LevenshteinComparator, NumericComparator\n",
+    ")"
    ]
   },
   {

--- a/examples/notebooks/Confidence_Estimation.ipynb
+++ b/examples/notebooks/Confidence_Estimation.ipynb
@@ -17,9 +17,13 @@
    "source": [
     "from typing import Optional\n",
     "\n",
-    "from stickler.comparators import ExactComparator, LevenshteinComparator, NumericComparator\n",
-    "from stickler.structured_object_evaluator.models.comparable_field import ComparableField\n",
-    "from stickler.structured_object_evaluator.models.structured_model import StructuredModel"
+    "from stickler import (\n",
+    "    ComparableField,\n",
+    "    ExactComparator,\n",
+    "    LevenshteinComparator,\n",
+    "    NumericComparator,\n",
+    "    StructuredModel,\n",
+    ")"
    ]
   },
   {
@@ -196,7 +200,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# No confidence data \u2014 confidence_metrics present but all values are None\n",
+    "# No confidence data — confidence_metrics present but all values are None\n",
     "pred_plain = Invoice(invoice_number=\"INV-2024-001\", vendor=\"Acme Corporation\", total=1247.50)\n",
     "r_plain = gt.compare_with(pred_plain, add_confidence_metrics=True, document_field_comparisons=True)\n",
     "print(f\"No confidence data: 'confidence_metrics' in result = {'confidence_metrics' in r_plain}\")\n",
@@ -234,7 +238,7 @@
     "\n",
     "print(f\"Fields with confidence: {list(pred_partial.get_all_confidences().keys())}\")\n",
     "print(f\"Fields in confidence_metrics: {list(r_partial['confidence_metrics']['fields'].keys())}\")\n",
-    "print(\"\\n'vendor' is excluded \u2014 no confidence score to evaluate.\")"
+    "print(\"\\n'vendor' is excluded — no confidence score to evaluate.\")"
    ]
   }
  ],

--- a/examples/notebooks/Custom_Comparator_Demo.ipynb
+++ b/examples/notebooks/Custom_Comparator_Demo.ipynb
@@ -51,11 +51,9 @@
     "import pandas as pd\n",
     "\n",
     "# Import stickler library components\n",
-    "from stickler.comparators.base import BaseComparator\n",
-    "from stickler.comparators.exact import ExactComparator\n",
-    "from stickler.comparators.levenshtein import LevenshteinComparator\n",
-    "from stickler.structured_object_evaluator.models.comparable_field import ComparableField\n",
-    "from stickler.structured_object_evaluator.models.structured_model import StructuredModel\n",
+    "from stickler import (\n",
+    "    StructuredModel, ComparableField, BaseComparator, ExactComparator, LevenshteinComparator\n",
+    ")\n",
     "\n",
     "print(\"✓ Successfully imported stickler library components\")"
    ]

--- a/examples/notebooks/Map_Reduce_Evaluation.ipynb
+++ b/examples/notebooks/Map_Reduce_Evaluation.ipynb
@@ -20,12 +20,16 @@
     "from pathlib import Path\n",
     "from typing import Optional\n",
     "\n",
-    "from stickler.comparators import ExactComparator, LevenshteinComparator, NumericComparator\n",
-    "from stickler.structured_object_evaluator.models.comparable_field import ComparableField\n",
-    "from stickler.structured_object_evaluator.models.structured_model import StructuredModel\n",
+    "from stickler import (\n",
+    "    ComparableField,\n",
+    "    ExactComparator,\n",
+    "    LevenshteinComparator,\n",
+    "    NumericComparator,\n",
+    "    StructuredModel,\n",
+    "    aggregate_from_comparisons,\n",
+    ")\n",
     "from stickler.structured_object_evaluator.bulk_structured_model_evaluator import (\n",
     "    BulkStructuredModelEvaluator,\n",
-    "    aggregate_from_comparisons,\n",
     ")"
    ]
   },
@@ -259,7 +263,10 @@
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {"name": "ipython", "version": 3},
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",

--- a/examples/notebooks/Quick_start.ipynb
+++ b/examples/notebooks/Quick_start.ipynb
@@ -30,9 +30,7 @@
    "source": [
     "from typing import List\n",
     "\n",
-    "from stickler.comparators.levenshtein import LevenshteinComparator\n",
-    "from stickler.structured_object_evaluator.models.comparable_field import ComparableField\n",
-    "from stickler.structured_object_evaluator.models.structured_model import StructuredModel"
+    "from stickler import StructuredModel, ComparableField, LevenshteinComparator"
    ]
   },
   {

--- a/examples/scripts/aggregate_metrics_demo.py
+++ b/examples/scripts/aggregate_metrics_demo.py
@@ -15,11 +15,13 @@ Key Features:
 
 from typing import List, Optional
 
-from stickler.comparators.exact import ExactComparator
-from stickler.comparators.levenshtein import LevenshteinComparator
-from stickler.comparators.numeric import NumericComparator
-from stickler.structured_object_evaluator.models.comparable_field import ComparableField
-from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+from stickler import (
+    ComparableField,
+    ExactComparator,
+    LevenshteinComparator,
+    NumericComparator,
+    StructuredModel,
+)
 
 
 # Define nested data models

--- a/examples/scripts/bert_comparator_demo.py
+++ b/examples/scripts/bert_comparator_demo.py
@@ -33,9 +33,7 @@ except ImportError as e:
     )
     raise SystemExit(1)
 
-from stickler.comparators.exact import ExactComparator
-from stickler.structured_object_evaluator.models.comparable_field import ComparableField
-from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+from stickler import ComparableField, ExactComparator, StructuredModel
 
 
 def print_section_header(title: str):

--- a/examples/scripts/bulk_evaluation_demo.py
+++ b/examples/scripts/bulk_evaluation_demo.py
@@ -13,12 +13,11 @@ import random
 import time
 from typing import List
 
-from stickler.comparators.levenshtein import LevenshteinComparator
+from stickler import LevenshteinComparator
 from stickler.structured_object_evaluator.bulk_structured_model_evaluator import (
     BulkStructuredModelEvaluator,
 )
-from stickler.structured_object_evaluator.models.comparable_field import ComparableField
-from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+from stickler import ComparableField, StructuredModel
 
 
 # Define a simple document model for demonstration

--- a/examples/scripts/bulk_evaluation_demo.py
+++ b/examples/scripts/bulk_evaluation_demo.py
@@ -13,11 +13,10 @@ import random
 import time
 from typing import List
 
-from stickler import LevenshteinComparator
+from stickler import ComparableField, LevenshteinComparator, StructuredModel
 from stickler.structured_object_evaluator.bulk_structured_model_evaluator import (
     BulkStructuredModelEvaluator,
 )
-from stickler import ComparableField, StructuredModel
 
 
 # Define a simple document model for demonstration

--- a/examples/scripts/confidence_score_demo.py
+++ b/examples/scripts/confidence_score_demo.py
@@ -11,9 +11,12 @@ This script shows how to:
 
 from typing import List, Optional
 
-from stickler.comparators import LevenshteinComparator, NumericComparator
-from stickler.structured_object_evaluator.models.comparable_field import ComparableField
-from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+from stickler import (
+    ComparableField,
+    LevenshteinComparator,
+    NumericComparator,
+    StructuredModel,
+)
 
 
 # Define a Product model

--- a/examples/scripts/html_report_demo.py
+++ b/examples/scripts/html_report_demo.py
@@ -2,12 +2,11 @@
 Demo script showing how to use the EvaluationHTMLReporter with bulk evaluation.
 """
 
-from stickler import LevenshteinComparator
+from stickler import ComparableField, LevenshteinComparator, StructuredModel
 from stickler.reporting.html import EvaluationHTMLReporter, ReportConfig
 from stickler.structured_object_evaluator.bulk_structured_model_evaluator import (
     BulkStructuredModelEvaluator,
 )
-from stickler import ComparableField, StructuredModel
 
 
 # Define a simple model for testing

--- a/examples/scripts/html_report_demo.py
+++ b/examples/scripts/html_report_demo.py
@@ -2,13 +2,12 @@
 Demo script showing how to use the EvaluationHTMLReporter with bulk evaluation.
 """
 
-from stickler.comparators.levenshtein import LevenshteinComparator
+from stickler import LevenshteinComparator
 from stickler.reporting.html import EvaluationHTMLReporter, ReportConfig
 from stickler.structured_object_evaluator.bulk_structured_model_evaluator import (
     BulkStructuredModelEvaluator,
 )
-from stickler.structured_object_evaluator.models.comparable_field import ComparableField
-from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+from stickler import ComparableField, StructuredModel
 
 
 # Define a simple model for testing

--- a/examples/scripts/json_schema_demo.py
+++ b/examples/scripts/json_schema_demo.py
@@ -11,7 +11,7 @@ Key Features:
 - Full evaluation with confusion matrices and metrics
 """
 
-from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+from stickler import StructuredModel
 
 
 def basic_json_schema_example():

--- a/examples/scripts/json_to_evaluation_demo.py
+++ b/examples/scripts/json_to_evaluation_demo.py
@@ -16,7 +16,7 @@ import os
 import tempfile
 from pathlib import Path
 
-from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+from stickler import StructuredModel
 
 
 def create_sample_json_files():

--- a/examples/scripts/llm_comparator_demo.py
+++ b/examples/scripts/llm_comparator_demo.py
@@ -11,11 +11,13 @@ Requirements:
 - AWS credentials configured for Bedrock access
 - Environment variables for model configuration (optional)
 """
-from stickler.comparators.exact import ExactComparator
-from stickler.comparators.levenshtein import LevenshteinComparator
-from stickler.comparators.llm import LLMComparator
-from stickler.structured_object_evaluator.models.comparable_field import ComparableField
-from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+from stickler import (
+    ComparableField,
+    ExactComparator,
+    LLMComparator,
+    LevenshteinComparator,
+    StructuredModel,
+)
 
 
 def print_section_header(title: str):

--- a/examples/scripts/model_from_json_demo.py
+++ b/examples/scripts/model_from_json_demo.py
@@ -9,7 +9,7 @@ capabilities including nested models and custom comparators.
 
 import json
 
-from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+from stickler import StructuredModel
 
 
 def demo_basic_model_creation():

--- a/examples/scripts/non_match_analysis_demo.py
+++ b/examples/scripts/non_match_analysis_demo.py
@@ -12,9 +12,7 @@ Usage:
 import json
 from typing import List
 
-from stickler.comparators.levenshtein import LevenshteinComparator
-from stickler.structured_object_evaluator.models.comparable_field import ComparableField
-from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+from stickler import ComparableField, LevenshteinComparator, StructuredModel
 
 
 # Define our data structures

--- a/examples/scripts/print_results_demo.py
+++ b/examples/scripts/print_results_demo.py
@@ -12,11 +12,10 @@ Usage:
 
 from typing import List
 
-from stickler import LevenshteinComparator
+from stickler import ComparableField, LevenshteinComparator, StructuredModel
 from stickler.structured_object_evaluator.bulk_structured_model_evaluator import (
     BulkStructuredModelEvaluator,
 )
-from stickler import ComparableField, StructuredModel
 
 # Import the beautiful print functions
 from stickler.structured_object_evaluator.utils.pretty_print import (

--- a/examples/scripts/print_results_demo.py
+++ b/examples/scripts/print_results_demo.py
@@ -12,12 +12,11 @@ Usage:
 
 from typing import List
 
-from stickler.comparators.levenshtein import LevenshteinComparator
+from stickler import LevenshteinComparator
 from stickler.structured_object_evaluator.bulk_structured_model_evaluator import (
     BulkStructuredModelEvaluator,
 )
-from stickler.structured_object_evaluator.models.comparable_field import ComparableField
-from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+from stickler import ComparableField, StructuredModel
 
 # Import the beautiful print functions
 from stickler.structured_object_evaluator.utils.pretty_print import (

--- a/examples/scripts/quick_start.py
+++ b/examples/scripts/quick_start.py
@@ -12,9 +12,7 @@ Usage:
 
 from typing import List
 
-from stickler.comparators.levenshtein import LevenshteinComparator
-from stickler.structured_object_evaluator.models.comparable_field import ComparableField
-from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+from stickler import ComparableField, LevenshteinComparator, StructuredModel
 
 
 # Step 1: Define your data structures

--- a/src/stickler/__init__.py
+++ b/src/stickler/__init__.py
@@ -1,10 +1,18 @@
 """
 stickler: Structured object comparison and evaluation library.
-
 This library provides tools for comparing complex structured objects
 with configurable comparison strategies and detailed evaluation metrics.
 """
 
+# Always-available comparators (core deps)
+from .comparators.base import BaseComparator
+from .comparators.exact import ExactComparator
+from .comparators.fuzzy import FuzzyComparator
+from .comparators.levenshtein import LevenshteinComparator
+from .comparators.llm import STRANDS_AVAILABLE as _HAS_LLM
+from .comparators.numeric import NumericComparator
+from .comparators.semantic import SemanticComparator
+from .comparators.structured import StructuredModelComparator
 from .structured_object_evaluator import (
     ComparableField,
     NonMatchField,
@@ -16,9 +24,21 @@ from .structured_object_evaluator import (
     compare_structured_models,
 )
 
-__version__ = "0.4.0"
+# Optional: LLM comparator (requires strands-agents)
+if _HAS_LLM:
+    from .comparators.llm import LLMComparator  # noqa: F401
 
+# Optional: BERT comparator (import fails without evaluate package)
+try:
+    from .comparators.bert import BERTComparator  # noqa: F401
+
+    _HAS_BERT = True
+except ModuleNotFoundError:
+    _HAS_BERT = False
+
+__version__ = "0.4.0"
 __all__ = [
+    # Models and evaluation
     "StructuredModel",
     "ComparableField",
     "NonMatchField",
@@ -27,4 +47,19 @@ __all__ = [
     "anls_score",
     "compare_json",
     "aggregate_from_comparisons",
+    # Comparators (always available)
+    "BaseComparator",
+    "ExactComparator",
+    "FuzzyComparator",
+    "LevenshteinComparator",
+    "NumericComparator",
+    "SemanticComparator",
+    "StructuredModelComparator",
 ]
+
+# Conditionally add optional comparators to __all__
+if _HAS_LLM:
+    __all__.append("LLMComparator")
+
+if _HAS_BERT:
+    __all__.append("BERTComparator")

--- a/src/stickler/__init__.py
+++ b/src/stickler/__init__.py
@@ -1,5 +1,6 @@
 """
 stickler: Structured object comparison and evaluation library.
+
 This library provides tools for comparing complex structured objects
 with configurable comparison strategies and detailed evaluation metrics.
 """
@@ -28,12 +29,15 @@ from .structured_object_evaluator import (
 if _HAS_LLM:
     from .comparators.llm import LLMComparator  # noqa: F401
 
-# Optional: BERT comparator (import fails without evaluate package)
+# Optional: BERT comparator (requires the `bert` extra: torch, bert-score,
+# evaluate). Catch broad ImportError, not just ModuleNotFoundError: a
+# version-skewed transitive dep (datasets/pyarrow/huggingface_hub) raises plain
+# ImportError, and a broken optional extra must not take down `import stickler`.
 try:
     from .comparators.bert import BERTComparator  # noqa: F401
 
     _HAS_BERT = True
-except ModuleNotFoundError:
+except ImportError:
     _HAS_BERT = False
 
 __version__ = "0.4.0"

--- a/src/stickler/comparators/llm.py
+++ b/src/stickler/comparators/llm.py
@@ -15,7 +15,7 @@ Note:
 
 Example:
     Integration with StructuredModel:
-        >>> from stickler.structured_object_evaluator.models.comparable_field import ComparableField
+        >>> from stickler import ComparableField
         >>>
         >>> class Address(StructuredModel):
         ...     street: str = ComparableField(

--- a/src/stickler/structured_object_evaluator/README.md
+++ b/src/stickler/structured_object_evaluator/README.md
@@ -25,8 +25,7 @@ pip install stickler
 ### Defining Structured Models
 
 ```python
-from stickler.structured_object_evaluator import StructuredModel, ComparableField
-from stickler.comparators.levenshtein import LevenshteinComparator
+from stickler import StructuredModel, ComparableField, LevenshteinComparator
 from pydantic import Field
 
 # Define a simple structured model

--- a/src/stickler/structured_object_evaluator/models/model_factory.py
+++ b/src/stickler/structured_object_evaluator/models/model_factory.py
@@ -78,7 +78,7 @@ class ModelFactory:
             KeyError: If required configuration keys are missing
 
         Examples:
-            >>> from stickler.structured_object_evaluator.models import StructuredModel
+            >>> from stickler import StructuredModel
             >>> config = {
             ...     "model_name": "Product",
             ...     "match_threshold": 0.8,
@@ -206,9 +206,9 @@ class ModelFactory:
             
         Examples:
             >>> from pydantic import Field
-            >>> from stickler.structured_object_evaluator.models import StructuredModel
-            >>> from stickler.structured_object_evaluator.models.comparable_field import ComparableField
-            >>> from stickler.comparators.levenshtein import LevenshteinComparator
+            >>> from stickler import StructuredModel
+            >>> from stickler import ComparableField
+            >>> from stickler import LevenshteinComparator
             >>> 
             >>> # Create field definitions directly
             >>> field_defs = {

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -158,9 +158,9 @@ class StructuredModel(BaseModel):
 
     Example Usage:
     --------------
-    >>> from stickler.structured_object_evaluator.models import StructuredModel
-    >>> from stickler.structured_object_evaluator.models import ComparableField
-    >>> from stickler.comparators import LevenshteinComparator
+    >>> from stickler import StructuredModel
+    >>> from stickler import ComparableField
+    >>> from stickler import LevenshteinComparator
     >>>
     >>> class Product(StructuredModel):
     ...     name: str = ComparableField(

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,6 +38,7 @@ pytest tests/ -n auto
 
 ```
 tests/
+├── test_top_level_exports.py      # Top-level package re-exports
 ├── structured_object_evaluator/   # Core evaluation tests
 │   ├── test_structured_model.py           # StructuredModel tests
 │   ├── test_comparators.py                # Comparator integration
@@ -61,7 +62,7 @@ tests/
 ### Basic Test Pattern
 
 ```python
-from stickler.comparators.levenshtein import LevenshteinComparator
+from stickler import LevenshteinComparator
 
 def test_exact_match():
     """Test exact string match returns 1.0."""
@@ -72,9 +73,7 @@ def test_exact_match():
 ### StructuredModel Test Pattern
 
 ```python
-from stickler.structured_object_evaluator.models.structured_model import StructuredModel
-from stickler.structured_object_evaluator.models.comparable_field import ComparableField
-from stickler.comparators.levenshtein import LevenshteinComparator
+from stickler import ComparableField, LevenshteinComparator, StructuredModel
 
 class TestModel(StructuredModel):
     name: str = ComparableField(comparator=LevenshteinComparator())

--- a/tests/test_top_level_exports.py
+++ b/tests/test_top_level_exports.py
@@ -1,0 +1,139 @@
+"""Smoke tests for top-level stickler package exports.
+
+Verifies that re-exported names are the canonical classes from their
+source modules, not accidental rebindings.
+"""
+
+import importlib
+import sys
+
+import pytest
+
+import stickler
+
+# Mapping of public name -> canonical source module
+ALWAYS_AVAILABLE_EXPORTS = {
+    "BaseComparator": "stickler.comparators.base",
+    "ExactComparator": "stickler.comparators.exact",
+    "FuzzyComparator": "stickler.comparators.fuzzy",
+    "LevenshteinComparator": "stickler.comparators.levenshtein",
+    "NumericComparator": "stickler.comparators.numeric",
+    "SemanticComparator": "stickler.comparators.semantic",
+    "StructuredModelComparator": "stickler.comparators.structured",
+}
+
+MODEL_AND_EVALUATION_EXPORTS = {
+    "StructuredModel": "stickler.structured_object_evaluator",
+    "ComparableField": "stickler.structured_object_evaluator",
+    "NonMatchField": "stickler.structured_object_evaluator",
+    "NonMatchType": "stickler.structured_object_evaluator",
+    "compare_structured_models": "stickler.structured_object_evaluator",
+    "anls_score": "stickler.structured_object_evaluator",
+    "compare_json": "stickler.structured_object_evaluator",
+    "aggregate_from_comparisons": "stickler.structured_object_evaluator",
+}
+
+
+class TestReexportIdentity:
+    """Verify re-exports are identical to canonical source objects."""
+
+    @pytest.mark.parametrize(
+        "name,module", ALWAYS_AVAILABLE_EXPORTS.items()
+    )
+    def test_comparator_is_canonical_class(self, name, module):
+        """Test that stickler.X is stickler.comparators.x.X."""
+        canonical = getattr(importlib.import_module(module), name)
+        exported = getattr(stickler, name)
+        assert exported is canonical
+
+    @pytest.mark.parametrize(
+        "name,module", MODEL_AND_EVALUATION_EXPORTS.items()
+    )
+    def test_model_export_is_canonical(self, name, module):
+        """Test that model/evaluation exports are canonical objects."""
+        canonical = getattr(importlib.import_module(module), name)
+        exported = getattr(stickler, name)
+        assert exported is canonical
+
+
+class TestAllConsistency:
+    """Verify __all__ is consistent with actual module attributes."""
+
+    def test_all_entries_are_importable(self):
+        """Every name in __all__ must exist as an attribute."""
+        for name in stickler.__all__:
+            assert hasattr(stickler, name), (
+                f"{name!r} is in __all__ but not an attribute of stickler"
+            )
+
+    def test_star_import_matches_all(self):
+        """from stickler import * should yield exactly __all__."""
+        ns = {}
+        exec("from stickler import *", ns)  # noqa: S102
+        exported_names = set(ns) - {"__builtins__"}
+        assert exported_names == set(stickler.__all__)
+
+    def test_always_available_in_all(self):
+        """All always-available comparators must be in __all__."""
+        for name in ALWAYS_AVAILABLE_EXPORTS:
+            assert name in stickler.__all__
+
+    def test_numeric_exact_c_not_in_all(self):
+        """NumericExactC is a compat alias - not re-exported at top level."""
+        assert "NumericExactC" not in stickler.__all__
+        assert not hasattr(stickler, "NumericExactC")
+
+
+class TestOptionalGating:
+    """Verify optional comparators are gated correctly in __all__."""
+
+    def test_llm_in_all_iff_strands_available(self):
+        """LLMComparator in __all__ only when strands-agents is installed."""
+        from stickler.comparators.llm import STRANDS_AVAILABLE
+
+        if STRANDS_AVAILABLE:
+            assert "LLMComparator" in stickler.__all__
+        else:
+            assert "LLMComparator" not in stickler.__all__
+
+    def test_bert_in_all_iff_evaluate_available(self):
+        """BERTComparator in __all__ only when evaluate is installed."""
+        try:
+            import evaluate  # noqa: F401
+
+            assert "BERTComparator" in stickler.__all__
+        except ModuleNotFoundError:
+            assert "BERTComparator" not in stickler.__all__
+
+    def test_llm_import_gated(self):
+        """LLMComparator is only importable from stickler when strands is installed."""
+        from stickler.comparators.llm import STRANDS_AVAILABLE
+
+        if STRANDS_AVAILABLE:
+            from stickler import LLMComparator
+            from stickler.comparators.llm import LLMComparator as Canonical
+
+            assert LLMComparator is Canonical
+        else:
+            assert not hasattr(stickler, "LLMComparator")
+
+    def test_llm_not_exported_when_strands_missing(self, monkeypatch):
+        """Simulate missing strands-agents and verify LLMComparator is excluded."""
+        # Block strands from importing
+        monkeypatch.setitem(sys.modules, "strands", None)
+        monkeypatch.setitem(sys.modules, "strands.agent", None)
+
+        # Clear cached modules so reload picks up the block
+        modules_to_clear = [
+            k for k in sys.modules if k.startswith("stickler")
+        ]
+        for mod in modules_to_clear:
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+
+        # Re-import with strands blocked
+        import stickler as reloaded
+
+        importlib.reload(reloaded)
+
+        assert "LLMComparator" not in reloaded.__all__
+        assert not hasattr(reloaded, "LLMComparator")

--- a/tests/test_top_level_exports.py
+++ b/tests/test_top_level_exports.py
@@ -83,6 +83,15 @@ class TestAllConsistency:
         assert "NumericExactC" not in stickler.__all__
         assert not hasattr(stickler, "NumericExactC")
 
+    def test_numeric_exact_c_importable_via_canonical_path(self):
+        """The compat alias stays importable from its canonical module."""
+        from stickler.comparators.numeric import (
+            NumericComparator,
+            NumericExactC,
+        )
+
+        assert NumericExactC is NumericComparator
+
 
 class TestOptionalGating:
     """Verify optional comparators are gated correctly in __all__."""
@@ -119,21 +128,20 @@ class TestOptionalGating:
 
     def test_llm_not_exported_when_strands_missing(self, monkeypatch):
         """Simulate missing strands-agents and verify LLMComparator is excluded."""
-        # Block strands from importing
+        # Block strands from importing (covers strands.* submodules too).
         monkeypatch.setitem(sys.modules, "strands", None)
-        monkeypatch.setitem(sys.modules, "strands.agent", None)
 
-        # Clear cached modules so reload picks up the block
+        # Clear cached stickler modules so the fresh import re-runs __init__
+        # with the block active. Match the package exactly, not a prefix, so an
+        # unrelated `sticklerfoo` package wouldn't be cleared.
         modules_to_clear = [
-            k for k in sys.modules if k.startswith("stickler")
+            k for k in sys.modules if k == "stickler" or k.startswith("stickler.")
         ]
         for mod in modules_to_clear:
             monkeypatch.delitem(sys.modules, mod, raising=False)
 
-        # Re-import with strands blocked
+        # Fresh import re-executes __init__ with strands blocked.
         import stickler as reloaded
-
-        importlib.reload(reloaded)
 
         assert "LLMComparator" not in reloaded.__all__
         assert not hasattr(reloaded, "LLMComparator")


### PR DESCRIPTION
# Pull Request

## Issue Reference
Fixes #110

## Description of Changes

### Changes Made
- Re-export all built-in comparators from `src/stickler/__init__.py` so users can write `from stickler import ExactComparator, StructuredModel`
- Always-available comparators exported unconditionally: `BaseComparator`, `ExactComparator`, `FuzzyComparator`, `LevenshteinComparator`, `NumericComparator`, `SemanticComparator`, `StructuredModelComparator`
- `NumericExactC` kept importable but excluded from `__all__` (backwards-compat alias, not promoted to public API)
- Optional comparators gated via availability flags: `LLMComparator` (keyed off `STRANDS_AVAILABLE`), `BERTComparator` (`except ModuleNotFoundError`)
- Updated all `examples/scripts/` and `examples/notebooks/` to use top-level imports (no format-only churn)
- Updated README, all mkdocs pages, and docstring `>>>` examples to advertise top-level imports
- Rewrote `tests/test_top_level_exports.py` with identity assertions, `__all__` consistency checks, and monkeypatch-based gating tests

### Why These Changes Are Needed
Nearly every user-facing example uses at least one comparator, so the nested-path import pattern (`from stickler.comparators.exact import ExactComparator`) adds friction. Since `StructuredModel` is already top-level, comparators should be too for a consistent public API.

## Testing
- [x] Unit tests added/updated (`tests/test_top_level_exports.py` - parameterized identity tests, star-import consistency, optional gating with monkeypatch)
- [ ] Integration tests added/updated
- [x] Manual testing completed (all notebooks executed via `jupyter nbconvert --execute`)
- [x] All existing tests pass

## Reviewers
@adiadd

## Checklist
- [x] Code follows the project's coding standards
- [x] Self-review of code completed
- [x] Documentation updated (README, mkdocs, docstrings, examples)
- [x] Tests added/updated for new functionality
- [ ] All CI checks are passing
- [x] Ready for review

## Additional Notes
Purely additive re-exports - no behavior change. Old import paths continue to work.
