### PR TITLE
fix: expose weight-aware aggregate in BulkStructuredModelEvaluator (#122)

### DIFF
--- a/docs/docs/Getting-Started/README.md
+++ b/docs/docs/Getting-Started/README.md
@@ -105,8 +105,9 @@ for gt_json, pred_json, doc_id in your_test_set:
     evaluator.update(gt, pred, doc_id)
 
 result = evaluator.compute()
-print(f"Aggregate F1: {result.metrics['cm_f1']:.3f}")
+print(f"Weighted Score: {result.metrics['weighted_overall_score']:.3f}")
+print(f"Aggregate F1:   {result.metrics['cm_f1']:.3f}")
 ```
 
-See [Bulk Evaluation](../Guides/Evaluation/bulk-evaluation.md) for the full guide.
+`metrics["weighted_overall_score"]` is the weight-aware dataset headline -- the mean of each document's per-field-weighted `overall_score`. Prefer it over `cm_f1` whenever your schema assigns non-uniform `weight=...` values, since `cm_f1` treats every field-match equally regardless of business importance. See [Bulk Evaluation](../Guides/Evaluation/bulk-evaluation.md#weighted-overall-score) for the full guide.
 

--- a/docs/docs/Guides/Best-Practices/README.md
+++ b/docs/docs/Guides/Best-Practices/README.md
@@ -105,6 +105,9 @@ class Invoice(StructuredModel):
     internal_notes: str = ComparableField(weight=0.2) # No operational impact
 ```
 
+!!! tip "Dataset-level headline: use `weighted_overall_score`"
+    When evaluating a corpus with `BulkStructuredModelEvaluator`, read the headline number from `result.metrics["weighted_overall_score"]` -- it preserves your declared weights across the dataset. `cm_f1` ignores weights and treats every field-match equally, so a high-weight field being wrong can look identical to a low-weight field being wrong in that single number. See [Weighted Overall Score](../Evaluation/bulk-evaluation.md#weighted-overall-score).
+
 ---
 
 ## Performance Optimization

--- a/docs/docs/Guides/Evaluation/README.md
+++ b/docs/docs/Guides/Evaluation/README.md
@@ -64,7 +64,7 @@ See the [Comparators](../Comparators/README.md) section for the complete list an
 overall_score = sum(field_score * weight) / sum(weights)
 ```
 
-Fields with higher weights pull the overall score toward their individual result.
+Fields with higher weights pull the overall score toward their individual result. At the dataset level, `BulkStructuredModelEvaluator.compute()` exposes this weight-aware aggregate as `metrics["weighted_overall_score"]` -- prefer it over `cm_f1` when weights are non-uniform, since `cm_f1` treats every field-match equally. See [Weighted Overall Score](bulk-evaluation.md#weighted-overall-score) in the bulk-evaluation guide.
 
 **`clip_under_threshold`** -- When enabled (the default), a field that scores below its threshold contributes 0.0 to the weighted average instead of its partial similarity. This prevents low-confidence matches from inflating the overall score.
 

--- a/docs/docs/Guides/Evaluation/bulk-evaluation.md
+++ b/docs/docs/Guides/Evaluation/bulk-evaluation.md
@@ -123,11 +123,23 @@ final = evaluator.compute()
 | Attribute | Type | Description |
 |-----------|------|-------------|
 | `document_count` | `int` | Total number of documents processed. |
-| `metrics` | `dict` | Overall confusion matrix counts (`tp`, `fp`, `tn`, `fn`, `fd`, `fa`) plus derived metrics (`cm_precision`, `cm_recall`, `cm_f1`, `cm_accuracy`). |
-| `field_metrics` | `dict` | Per-field metrics with the same structure as `metrics`, keyed by dotted field path (e.g., `"customer.name"`). |
+| `metrics` | `dict` | Overall confusion matrix counts (`tp`, `fp`, `tn`, `fn`, `fd`, `fa`), derived metrics (`cm_precision`, `cm_recall`, `cm_f1`, `cm_accuracy`), and the weight-aware `weighted_overall_score`. |
+| `field_metrics` | `dict` | Per-field metrics with the same confusion-matrix structure as `metrics`, plus `mean_score` (arithmetic mean of the per-document `threshold_applied_score` at that path). Keyed by dotted field path (e.g., `"customer.name"`). |
 | `errors` | `list` | Records for any documents that raised exceptions during processing. |
 | `total_time` | `float` | Wall-clock time in seconds since the evaluator was created or last reset. |
 | `non_matches` | `list` | Detailed non-match records (when `document_non_matches=True`), each tagged with `doc_id`. |
+
+---
+
+### Weighted Overall Score
+
+`metrics["weighted_overall_score"]` is the arithmetic mean of each document's weight-aware `overall_score` returned by `compare_with()`. Prefer it over `cm_f1` whenever your schema uses non-uniform `ComparableField(weight=...)` values -- `cm_f1` treats every field-match equally regardless of its declared weight, so a high-weight field being wrong can look identical to a low-weight field being wrong in the headline number. `weighted_overall_score` preserves that weighting across the dataset.
+
+Because each document's `overall_score = Σ_f(score × weight) / Σ_f(weight)` already divides by the schema-constant total weight, the mean-of-per-document-overalls equals the `(doc, field)`-weighted aggregate -- a single key suffices.
+
+Documents that raised an exception during `update()` are excluded from the denominator, matching how `document_count` treats the `_processed_count` for successful docs.
+
+Per-field `mean_score` follows the same pattern at every nested path (leaf and object/list aggregates), averaging over the documents where that path was actually scored.
 
 ---
 

--- a/docs/docs/Guides/Evaluation/bulk-evaluation.md
+++ b/docs/docs/Guides/Evaluation/bulk-evaluation.md
@@ -124,7 +124,7 @@ final = evaluator.compute()
 |-----------|------|-------------|
 | `document_count` | `int` | Total number of documents processed. |
 | `metrics` | `dict` | Overall confusion matrix counts (`tp`, `fp`, `tn`, `fn`, `fd`, `fa`), derived metrics (`cm_precision`, `cm_recall`, `cm_f1`, `cm_accuracy`), and the weight-aware `weighted_overall_score`. |
-| `field_metrics` | `dict` | Per-field metrics with the same confusion-matrix structure as `metrics`, plus `mean_score` (arithmetic mean of the per-document `threshold_applied_score` at that path). Keyed by dotted field path (e.g., `"customer.name"`). |
+| `field_metrics` | `dict` | Per-field metrics with the same confusion-matrix structure as `metrics`, plus `mean_score` (arithmetic mean of the per-document `threshold_applied_score` at that path) when that path was actually scored. Keyed by dotted field path (e.g., `"customer.name"`). |
 | `errors` | `list` | Records for any documents that raised exceptions during processing. |
 | `total_time` | `float` | Wall-clock time in seconds since the evaluator was created or last reset. |
 | `non_matches` | `list` | Detailed non-match records (when `document_non_matches=True`), each tagged with `doc_id`. |
@@ -137,9 +137,9 @@ final = evaluator.compute()
 
 Because each document's `overall_score = Σ_f(score × weight) / Σ_f(weight)` already divides by the schema-constant total weight, the mean-of-per-document-overalls equals the `(doc, field)`-weighted aggregate -- a single key suffices.
 
-Documents that raised an exception during `update()` are excluded from the denominator, matching how `document_count` treats the `_processed_count` for successful docs.
+The denominator is the count of documents whose `overall_score` was a finite number: error docs (`update()` raised) and successful docs carrying a non-finite or missing `overall_score` are both excluded. With zero eligible documents the score is `0.0` — disambiguate via `document_count` when that matters.
 
-Per-field `mean_score` follows the same pattern at every nested path (leaf and object/list aggregates), averaging over the documents where that path was actually scored.
+Per-field `mean_score` is reported at every nested path (leaf and object/list aggregate) where `threshold_applied_score` was observed in at least one document, averaging over just those documents. Paths with confusion-matrix counts but no score data (e.g., leaves inside `List[StructuredModel]`, where `compare_with()` only emits the score at the list parent) are surfaced without a `mean_score` key rather than reported as `0.0`.
 
 ---
 

--- a/docs/docs/Guides/Evaluation/understanding-results.md
+++ b/docs/docs/Guides/Evaluation/understanding-results.md
@@ -254,6 +254,36 @@ This is useful for comprehensive auditing of all comparisons, not just failures.
 
 ---
 
+## Dataset-Level Weighted Aggregate
+
+The per-document `overall_score` above is a weighted average of field scores. When you aggregate across many documents with `BulkStructuredModelEvaluator.compute()`, the weight information is preserved via two keys:
+
+- **`metrics["weighted_overall_score"]`** (float) -- Arithmetic mean of each document's `overall_score`. Prefer this over `cm_f1` whenever your schema uses non-uniform `ComparableField(weight=...)` values: `cm_f1` treats every field-match equally, while `weighted_overall_score` preserves the declared per-field weights across the dataset.
+- **`field_metrics[path]["mean_score"]`** (float, when present) -- Arithmetic mean of each document's `threshold_applied_score` at that path, reported at every nested node that was actually scored. Paths with confusion-matrix counts but no score data (e.g., leaves inside `List[StructuredModel]`, where `compare_with()` only emits the score at the list parent) are surfaced without a `mean_score` key rather than as `0.0`.
+
+```python
+from stickler.structured_object_evaluator.bulk_structured_model_evaluator import (
+    BulkStructuredModelEvaluator,
+)
+
+evaluator = BulkStructuredModelEvaluator(target_schema=Invoice)
+for gt, pred in dataset:
+    evaluator.update(gt, pred)
+result = evaluator.compute()
+
+print(f"Weighted Score: {result.metrics['weighted_overall_score']:.3f}")
+print(f"Aggregate F1:   {result.metrics['cm_f1']:.3f}")
+
+for field_path, fm in result.field_metrics.items():
+    mean = fm.get("mean_score")
+    mean_str = f"{mean:.3f}" if mean is not None else "n/a"
+    print(f"  {field_path}: mean={mean_str} | f1={fm.get('cm_f1', 0):.3f}")
+```
+
+Documents whose `overall_score` is missing or non-finite are excluded from the `weighted_overall_score` denominator (error docs are excluded from every aggregate). With zero eligible documents the score is `0.0`; disambiguate via `document_count` when that matters. See [Bulk Evaluation → Weighted Overall Score](bulk-evaluation.md#weighted-overall-score) for the full semantics.
+
+---
+
 ## HTML Reports
 
 Stickler includes an `EvaluationHTMLReporter` that generates interactive HTML reports from evaluation results. The reporter supports both individual comparison results and `ProcessEvaluation` objects from `BulkStructuredModelEvaluator`.

--- a/docs/docs/Guides/Use-Cases/idp-accelerator.md
+++ b/docs/docs/Guides/Use-Cases/idp-accelerator.md
@@ -86,9 +86,14 @@ for doc_id, ground_truth_data, extracted_data in idp_results:
     evaluator.update(gt, pred, doc_id)
 
 result = evaluator.compute()
+print(f"Weighted Score: {result.metrics['weighted_overall_score']:.3f}")
+print(f"Aggregate F1:   {result.metrics['cm_f1']:.3f}")
+
 evaluator.save_metrics("idp_evaluation_metrics.json")
 evaluator.pretty_print_metrics()
 ```
+
+IDP schemas typically assign much higher `weight` to invoice numbers and totals than to descriptive fields. Read the headline from `weighted_overall_score` rather than `cm_f1` -- the weighted aggregate reflects the fact that a wrong invoice number is operationally worse than a wrong line-item description, where `cm_f1` would treat both as a single false discovery. See [Weighted Overall Score](../Evaluation/bulk-evaluation.md#weighted-overall-score) for the full semantics.
 
 ## Comparator Selection for Document Fields
 

--- a/src/stickler/structured_object_evaluator/bulk_structured_model_evaluator.py
+++ b/src/stickler/structured_object_evaluator/bulk_structured_model_evaluator.py
@@ -11,6 +11,7 @@ memory-efficient processing of large datasets through accumulation-based evaluat
 import gc
 import json
 import logging
+import math
 import time
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
@@ -91,6 +92,12 @@ class BulkStructuredModelEvaluator:
             "fields": defaultdict(lambda: defaultdict(int)),
         }
 
+        # Weight-aware score accumulators (issue #122).
+        self._overall_score_sum: float = 0.0
+        self._overall_score_count: int = 0
+        self._field_score_sums: Dict[str, float] = defaultdict(float)
+        self._field_score_counts: Dict[str, int] = defaultdict(int)
+
         # Non-match tracking (when document_non_matches=True)
         self._non_matches = []
 
@@ -166,6 +173,13 @@ class BulkStructuredModelEvaluator:
         StructuredModel.compare_with(include_confusion_matrix=True) and
         accumulates its confusion matrix.
 
+        When present, the weight-aware ``overall_score`` and nested ``fields``
+        tree are also accumulated (best-effort) for ``weighted_overall_score``
+        and per-field ``mean_score`` reporting. Missing keys are silently
+        skipped so pre-existing minimal input contracts still hold. Documents
+        that raise an exception during processing are excluded from the score
+        denominator, matching the semantics of ``_processed_count``.
+
         Args:
             comparison_result: Dictionary returned by StructuredModel.compare_with()
                 with include_confusion_matrix=True. Must contain a "confusion_matrix" key.
@@ -189,7 +203,20 @@ class BulkStructuredModelEvaluator:
                     self._non_matches.append(non_match_with_doc)
 
             # Accumulate the confusion matrix
-            self._accumulate_confusion_matrix(comparison_result["confusion_matrix"])
+            cm_result = comparison_result["confusion_matrix"]
+            self._accumulate_confusion_matrix(cm_result)
+
+            # Best-effort accumulation of weight-aware scores (issue #122).
+            # The per-doc overall_score is the weight-aware aggregate from
+            # compare_with(); the per-field threshold_applied_score values
+            # live inside the confusion_matrix["fields"] tree.
+            if "overall_score" in comparison_result:
+                self._accumulate_overall_score(comparison_result["overall_score"])
+
+            if isinstance(cm_result, dict) and isinstance(
+                cm_result.get("fields"), dict
+            ):
+                self._accumulate_field_scores_recursive(cm_result["fields"], "")
 
             self._processed_count += 1
 
@@ -404,6 +431,41 @@ class BulkStructuredModelEvaluator:
             ):
                 self._confusion_matrix["fields"][field_path][metric_name] += value
 
+    def _accumulate_overall_score(self, overall_score: Any) -> None:
+        """Accumulate a per-document weight-aware overall score.
+
+        Non-numeric, NaN, or infinite values are silently skipped.
+        """
+        if isinstance(overall_score, (int, float)) and math.isfinite(overall_score):
+            self._overall_score_sum += float(overall_score)
+            self._overall_score_count += 1
+
+    def _accumulate_field_scores_recursive(
+        self, fields_dict: Dict[str, Any], path_prefix: str
+    ) -> None:
+        """Recursively accumulate per-field ``threshold_applied_score`` values.
+
+        Walks the nested ``comparison_result["fields"]`` tree, recording the
+        score at every node that exposes ``threshold_applied_score`` (leaf
+        fields and object/list aggregates). Nodes without the key (e.g.,
+        list-level ``overall``-only summaries) are skipped.
+        """
+        for field_name, field_data in fields_dict.items():
+            if not isinstance(field_data, dict):
+                continue
+
+            current_path = f"{path_prefix}.{field_name}" if path_prefix else field_name
+
+            score = field_data.get("threshold_applied_score")
+            if isinstance(score, (int, float)) and math.isfinite(score):
+                self._field_score_sums[current_path] += float(score)
+                self._field_score_counts[current_path] += 1
+
+            if "fields" in field_data and isinstance(field_data["fields"], dict):
+                self._accumulate_field_scores_recursive(
+                    field_data["fields"], current_path
+                )
+
     def _calculate_derived_metrics(
         self, cm_dict: Dict[str, Union[int, float]]
     ) -> Dict[str, float]:
@@ -452,12 +514,35 @@ class BulkStructuredModelEvaluator:
         overall_derived = self._calculate_derived_metrics(overall_cm)
         overall_metrics = {**overall_cm, **overall_derived}
 
+        # Weight-aware aggregate (issue #122): mean of per-doc overall_score
+        # over successful documents. Error docs are excluded via the
+        # accumulator's count.
+        overall_metrics["weighted_overall_score"] = (
+            self._overall_score_sum / self._overall_score_count
+            if self._overall_score_count > 0
+            else 0.0
+        )
+
         # Calculate derived metrics for each field
         field_metrics = {}
         for field_path, field_cm in self._confusion_matrix["fields"].items():
             field_cm_dict = dict(field_cm)
             field_derived = self._calculate_derived_metrics(field_cm_dict)
             field_metrics[field_path] = {**field_cm_dict, **field_derived}
+
+            count = self._field_score_counts.get(field_path, 0)
+            field_metrics[field_path]["mean_score"] = (
+                self._field_score_sums[field_path] / count if count > 0 else 0.0
+            )
+
+        # Defensive: emit mean_score for paths that have scores but no cm entry.
+        for field_path, count in self._field_score_counts.items():
+            if field_path not in field_metrics:
+                field_metrics[field_path] = {
+                    "mean_score": (
+                        self._field_score_sums[field_path] / count if count > 0 else 0.0
+                    )
+                }
 
         total_time = time.time() - self._start_time
 
@@ -560,6 +645,10 @@ class BulkStructuredModelEvaluator:
         print(f"  Recall:        {overall_metrics.get('cm_recall', 0.0):.4f}")
         print(f"  F1 Score:      {overall_metrics.get('cm_f1', 0.0):.4f}")
         print(f"  Accuracy:      {overall_metrics.get('cm_accuracy', 0.0):.4f}")
+        print(
+            f"  Weighted Overall Score: "
+            f"{overall_metrics.get('weighted_overall_score', 0.0):.4f}"
+        )
 
         # Field-level metrics
         if process_eval.field_metrics:
@@ -580,11 +669,12 @@ class BulkStructuredModelEvaluator:
                 precision = field_metrics.get("cm_precision", 0.0)
                 recall = field_metrics.get("cm_recall", 0.0)
                 f1 = field_metrics.get("cm_f1", 0.0)
+                mean_score = field_metrics.get("mean_score", 0.0)
 
                 # Only show fields with some activity
                 if tp + fp + fn > 0:
                     print(
-                        f"  {field_path:30} P: {precision:.3f} | R: {recall:.3f} | F1: {f1:.3f} | TP: {tp:,} | FP: {fp:,} | FN: {fn:,}"
+                        f"  {field_path:30} Mean: {mean_score:.3f} | P: {precision:.3f} | R: {recall:.3f} | F1: {f1:.3f} | TP: {tp:,} | FP: {fp:,} | FN: {fn:,}"
                     )
 
         # Error summary
@@ -644,6 +734,11 @@ class BulkStructuredModelEvaluator:
             "errors": list(self._errors),
             "processed_count": self._processed_count,
             "start_time": self._start_time,
+            # Weight-aware score accumulators (issue #122).
+            "overall_score_sum": self._overall_score_sum,
+            "overall_score_count": self._overall_score_count,
+            "field_score_sums": dict(self._field_score_sums),
+            "field_score_counts": dict(self._field_score_counts),
             # Configuration
             "target_schema": self._schema_name,
             "elide_errors": self.elide_errors,
@@ -682,6 +777,13 @@ class BulkStructuredModelEvaluator:
         self._processed_count = state["processed_count"]
         self._start_time = state["start_time"]
 
+        # Weight-aware score accumulators (issue #122). Use .get() for
+        # backwards compatibility with pre-#122 state dicts.
+        self._overall_score_sum = float(state.get("overall_score_sum", 0.0))
+        self._overall_score_count = int(state.get("overall_score_count", 0))
+        self._field_score_sums = defaultdict(float, state.get("field_score_sums", {}))
+        self._field_score_counts = defaultdict(int, state.get("field_score_counts", {}))
+
         if self.verbose:
             print(f"Loaded state: {self._processed_count} documents processed")
 
@@ -715,6 +817,15 @@ class BulkStructuredModelEvaluator:
         # Merge errors and counts
         self._errors.extend(other_state["errors"])
         self._processed_count += other_state["processed_count"]
+
+        # Merge weight-aware score accumulators (issue #122). Use .get() for
+        # backwards compatibility with pre-#122 peer state dicts.
+        self._overall_score_sum += float(other_state.get("overall_score_sum", 0.0))
+        self._overall_score_count += int(other_state.get("overall_score_count", 0))
+        for path, s in other_state.get("field_score_sums", {}).items():
+            self._field_score_sums[path] += float(s)
+        for path, c in other_state.get("field_score_counts", {}).items():
+            self._field_score_counts[path] += int(c)
 
         if self.verbose:
             print(

--- a/src/stickler/structured_object_evaluator/bulk_structured_model_evaluator.py
+++ b/src/stickler/structured_object_evaluator/bulk_structured_model_evaluator.py
@@ -92,7 +92,6 @@ class BulkStructuredModelEvaluator:
             "fields": defaultdict(lambda: defaultdict(int)),
         }
 
-        # Weight-aware score accumulators (issue #122).
         self._overall_score_sum: float = 0.0
         self._overall_score_count: int = 0
         self._field_score_sums: Dict[str, float] = defaultdict(float)
@@ -173,12 +172,12 @@ class BulkStructuredModelEvaluator:
         StructuredModel.compare_with(include_confusion_matrix=True) and
         accumulates its confusion matrix.
 
-        When present, the weight-aware ``overall_score`` and nested ``fields``
-        tree are also accumulated (best-effort) for ``weighted_overall_score``
-        and per-field ``mean_score`` reporting. Missing keys are silently
-        skipped so pre-existing minimal input contracts still hold. Documents
-        that raise an exception during processing are excluded from the score
-        denominator, matching the semantics of ``_processed_count``.
+        When present, the top-level ``overall_score`` and any
+        ``threshold_applied_score`` values inside the ``fields`` tree are also
+        accumulated for ``weighted_overall_score`` and per-field
+        ``mean_score`` reporting. Missing keys are silently skipped. Documents
+        that raise during processing are excluded from the score denominator,
+        matching ``_processed_count``.
 
         Args:
             comparison_result: Dictionary returned by StructuredModel.compare_with()
@@ -202,14 +201,9 @@ class BulkStructuredModelEvaluator:
                     non_match_with_doc["doc_id"] = doc_id
                     self._non_matches.append(non_match_with_doc)
 
-            # Accumulate the confusion matrix
             cm_result = comparison_result["confusion_matrix"]
             self._accumulate_confusion_matrix(cm_result)
 
-            # Best-effort accumulation of weight-aware scores (issue #122).
-            # The per-doc overall_score is the weight-aware aggregate from
-            # compare_with(); the per-field threshold_applied_score values
-            # live inside the confusion_matrix["fields"] tree.
             if "overall_score" in comparison_result:
                 self._accumulate_overall_score(comparison_result["overall_score"])
 
@@ -431,16 +425,16 @@ class BulkStructuredModelEvaluator:
             ):
                 self._confusion_matrix["fields"][field_path][metric_name] += value
 
-    def _accumulate_overall_score(self, overall_score: Any) -> None:
-        """Accumulate a per-document weight-aware overall score.
+    @staticmethod
+    def _is_valid_score(value: Any) -> bool:
+        return (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and math.isfinite(value)
+        )
 
-        Non-numeric, bool, NaN, or infinite values are silently skipped.
-        """
-        if (
-            isinstance(overall_score, (int, float))
-            and not isinstance(overall_score, bool)
-            and math.isfinite(overall_score)
-        ):
+    def _accumulate_overall_score(self, overall_score: Any) -> None:
+        if self._is_valid_score(overall_score):
             self._overall_score_sum += float(overall_score)
             self._overall_score_count += 1
 
@@ -451,10 +445,9 @@ class BulkStructuredModelEvaluator:
 
         Walks the nested ``comparison_result["fields"]`` tree, recording the
         score at every node that exposes ``threshold_applied_score`` (leaf
-        fields and object/list aggregates). Nodes without the key (e.g.,
-        list-level ``overall``-only summaries) are skipped. Also descends
-        through ``nested_fields`` entries on list-of-StructuredModel nodes
-        when present, for parity with ``_accumulate_field_metrics``.
+        fields and object/list aggregates). Also descends through
+        ``nested_fields`` on list-of-StructuredModel nodes, for parity with
+        ``_accumulate_field_metrics``.
         """
         for field_name, field_data in fields_dict.items():
             if not isinstance(field_data, dict):
@@ -463,22 +456,16 @@ class BulkStructuredModelEvaluator:
             current_path = f"{path_prefix}.{field_name}" if path_prefix else field_name
 
             score = field_data.get("threshold_applied_score")
-            if (
-                isinstance(score, (int, float))
-                and not isinstance(score, bool)
-                and math.isfinite(score)
-            ):
+            if self._is_valid_score(score):
                 self._field_score_sums[current_path] += float(score)
                 self._field_score_counts[current_path] += 1
 
-            if "fields" in field_data and isinstance(field_data["fields"], dict):
+            if isinstance(field_data.get("fields"), dict):
                 self._accumulate_field_scores_recursive(
                     field_data["fields"], current_path
                 )
 
-            if "nested_fields" in field_data and isinstance(
-                field_data["nested_fields"], dict
-            ):
+            if isinstance(field_data.get("nested_fields"), dict):
                 self._accumulate_field_scores_recursive(
                     field_data["nested_fields"], current_path
                 )
@@ -531,9 +518,8 @@ class BulkStructuredModelEvaluator:
         overall_derived = self._calculate_derived_metrics(overall_cm)
         overall_metrics = {**overall_cm, **overall_derived}
 
-        # Weight-aware aggregate (issue #122): mean of per-doc overall_score
-        # over successful documents. Error docs are excluded via the
-        # accumulator's count.
+        # Error docs are excluded from the mean via the accumulator's count,
+        # which only increments on successful update_from_comparison_result.
         overall_metrics["weighted_overall_score"] = (
             self._overall_score_sum / self._overall_score_count
             if self._overall_score_count > 0
@@ -547,23 +533,14 @@ class BulkStructuredModelEvaluator:
             field_derived = self._calculate_derived_metrics(field_cm_dict)
             field_metrics[field_path] = {**field_cm_dict, **field_derived}
 
+            # .get() (not []) avoids resurrecting zero entries in the
+            # defaultdict on every compute() call.
             count = self._field_score_counts.get(field_path, 0)
             field_metrics[field_path]["mean_score"] = (
                 self._field_score_sums.get(field_path, 0.0) / count
                 if count > 0
                 else 0.0
             )
-
-        # Defensive: emit mean_score for paths that have scores but no cm entry.
-        for field_path, count in self._field_score_counts.items():
-            if field_path not in field_metrics:
-                field_metrics[field_path] = {
-                    "mean_score": (
-                        self._field_score_sums.get(field_path, 0.0) / count
-                        if count > 0
-                        else 0.0
-                    )
-                }
 
         total_time = time.time() - self._start_time
 
@@ -755,7 +732,6 @@ class BulkStructuredModelEvaluator:
             "errors": list(self._errors),
             "processed_count": self._processed_count,
             "start_time": self._start_time,
-            # Weight-aware score accumulators (issue #122).
             "overall_score_sum": self._overall_score_sum,
             "overall_score_count": self._overall_score_count,
             "field_score_sums": dict(self._field_score_sums),
@@ -798,8 +774,7 @@ class BulkStructuredModelEvaluator:
         self._processed_count = state["processed_count"]
         self._start_time = state["start_time"]
 
-        # Weight-aware score accumulators (issue #122). Use .get() for
-        # backwards compatibility with pre-#122 state dicts.
+        # .get() keeps older state dicts (no score keys) loadable.
         self._overall_score_sum = float(state.get("overall_score_sum", 0.0))
         self._overall_score_count = int(state.get("overall_score_count", 0))
         self._field_score_sums = defaultdict(float, state.get("field_score_sums", {}))
@@ -839,8 +814,7 @@ class BulkStructuredModelEvaluator:
         self._errors.extend(other_state["errors"])
         self._processed_count += other_state["processed_count"]
 
-        # Merge weight-aware score accumulators (issue #122). Use .get() for
-        # backwards compatibility with pre-#122 peer state dicts.
+        # .get() keeps older peer states (no score keys) mergeable.
         self._overall_score_sum += float(other_state.get("overall_score_sum", 0.0))
         self._overall_score_count += int(other_state.get("overall_score_count", 0))
         for path, s in other_state.get("field_score_sums", {}).items():

--- a/src/stickler/structured_object_evaluator/bulk_structured_model_evaluator.py
+++ b/src/stickler/structured_object_evaluator/bulk_structured_model_evaluator.py
@@ -175,9 +175,15 @@ class BulkStructuredModelEvaluator:
         When present, the top-level ``overall_score`` and any
         ``threshold_applied_score`` values inside the ``fields`` tree are also
         accumulated for ``weighted_overall_score`` and per-field
-        ``mean_score`` reporting. Missing keys are silently skipped. Documents
-        that raise during processing are excluded from the score denominator,
-        matching ``_processed_count``.
+        ``mean_score`` reporting. Missing keys are silently skipped.
+
+        Score-denominator semantics differ from ``_processed_count``:
+        ``weighted_overall_score`` only counts docs whose ``overall_score``
+        is a finite number, and a field's ``mean_score`` only counts docs
+        whose ``threshold_applied_score`` at that path is a finite number.
+        Docs that omit the key or carry a non-finite value still count
+        toward ``_processed_count`` and the confusion matrix. Docs that
+        raise during processing are excluded from every aggregate.
 
         Args:
             comparison_result: Dictionary returned by StructuredModel.compare_with()
@@ -443,11 +449,11 @@ class BulkStructuredModelEvaluator:
     ) -> None:
         """Recursively accumulate per-field ``threshold_applied_score`` values.
 
-        Walks the nested ``comparison_result["fields"]`` tree, recording the
-        score at every node that exposes ``threshold_applied_score`` (leaf
-        fields and object/list aggregates). Also descends through
-        ``nested_fields`` on list-of-StructuredModel nodes, for parity with
-        ``_accumulate_field_metrics``.
+        Walks the nested ``confusion_matrix["fields"]`` tree passed in as
+        ``fields_dict``, recording the score at every node that exposes
+        ``threshold_applied_score`` (leaf fields and object/list aggregates).
+        Also descends through ``nested_fields`` on list-of-StructuredModel
+        nodes, for parity with ``_accumulate_field_metrics``.
         """
         for field_name, field_data in fields_dict.items():
             if not isinstance(field_data, dict):

--- a/src/stickler/structured_object_evaluator/bulk_structured_model_evaluator.py
+++ b/src/stickler/structured_object_evaluator/bulk_structured_model_evaluator.py
@@ -443,7 +443,7 @@ class BulkStructuredModelEvaluator:
         if self._is_valid_score(overall_score):
             self._overall_score_sum += float(overall_score)
             self._overall_score_count += 1
-        elif self.verbose:
+        else:
             logger.debug(
                 "Skipping non-finite overall_score=%r from weighted aggregate",
                 overall_score,
@@ -460,10 +460,9 @@ class BulkStructuredModelEvaluator:
         Also descends through ``nested_fields`` on list-of-StructuredModel
         nodes, for parity with ``_accumulate_field_metrics``.
 
-        Note: leaves inside ``List[StructuredModel]`` never surface a
-        ``threshold_applied_score`` because ``compare_with()`` only emits
-        the score at the list parent node. Those leaves will have CM
-        counts but no ``mean_score`` in the final ``field_metrics``.
+        ``compare_with()`` emits ``threshold_applied_score`` at the list
+        parent for ``List[StructuredModel]`` but not at the nested leaves,
+        so those leaves end up with CM counts and no ``mean_score``.
         """
         for field_name, field_data in fields_dict.items():
             if not isinstance(field_data, dict):
@@ -476,7 +475,7 @@ class BulkStructuredModelEvaluator:
                 if self._is_valid_score(score):
                     self._field_score_sums[current_path] += float(score)
                     self._field_score_counts[current_path] += 1
-                elif self.verbose:
+                else:
                     logger.debug(
                         "Skipping non-finite threshold_applied_score=%r at %s",
                         score,
@@ -549,8 +548,8 @@ class BulkStructuredModelEvaluator:
             else 0.0
         )
 
-        # Union of cm paths and score paths surfaces fields seen via the
-        # minimal-input contract of update_from_comparison_result.
+        # Union covers score-only paths (e.g., List[StructuredModel] parents
+        # emitted by compare_with but not recorded in the cm fields tree).
         field_metrics = {}
         field_paths = set(self._confusion_matrix["fields"].keys())
         field_paths.update(self._field_score_sums.keys())
@@ -559,11 +558,9 @@ class BulkStructuredModelEvaluator:
             field_derived = self._calculate_derived_metrics(field_cm_dict)
             field_metrics[field_path] = {**field_cm_dict, **field_derived}
 
-            # .get() (not []) avoids resurrecting zero entries in the
-            # defaultdict on every compute() call. mean_score is only
-            # emitted when a finite threshold_applied_score was observed at
-            # this path in at least one document — omitting the key keeps
-            # "no data" distinguishable from "every observation was 0.0".
+            # .get() avoids resurrecting zero entries in the defaultdicts.
+            # Omitting mean_score (vs. reporting 0.0) preserves the
+            # "no data" vs. "observed zero" distinction downstream.
             count = self._field_score_counts.get(field_path, 0)
             if count > 0:
                 field_metrics[field_path]["mean_score"] = (

--- a/src/stickler/structured_object_evaluator/bulk_structured_model_evaluator.py
+++ b/src/stickler/structured_object_evaluator/bulk_structured_model_evaluator.py
@@ -434,9 +434,13 @@ class BulkStructuredModelEvaluator:
     def _accumulate_overall_score(self, overall_score: Any) -> None:
         """Accumulate a per-document weight-aware overall score.
 
-        Non-numeric, NaN, or infinite values are silently skipped.
+        Non-numeric, bool, NaN, or infinite values are silently skipped.
         """
-        if isinstance(overall_score, (int, float)) and math.isfinite(overall_score):
+        if (
+            isinstance(overall_score, (int, float))
+            and not isinstance(overall_score, bool)
+            and math.isfinite(overall_score)
+        ):
             self._overall_score_sum += float(overall_score)
             self._overall_score_count += 1
 
@@ -448,7 +452,9 @@ class BulkStructuredModelEvaluator:
         Walks the nested ``comparison_result["fields"]`` tree, recording the
         score at every node that exposes ``threshold_applied_score`` (leaf
         fields and object/list aggregates). Nodes without the key (e.g.,
-        list-level ``overall``-only summaries) are skipped.
+        list-level ``overall``-only summaries) are skipped. Also descends
+        through ``nested_fields`` entries on list-of-StructuredModel nodes
+        when present, for parity with ``_accumulate_field_metrics``.
         """
         for field_name, field_data in fields_dict.items():
             if not isinstance(field_data, dict):
@@ -457,13 +463,24 @@ class BulkStructuredModelEvaluator:
             current_path = f"{path_prefix}.{field_name}" if path_prefix else field_name
 
             score = field_data.get("threshold_applied_score")
-            if isinstance(score, (int, float)) and math.isfinite(score):
+            if (
+                isinstance(score, (int, float))
+                and not isinstance(score, bool)
+                and math.isfinite(score)
+            ):
                 self._field_score_sums[current_path] += float(score)
                 self._field_score_counts[current_path] += 1
 
             if "fields" in field_data and isinstance(field_data["fields"], dict):
                 self._accumulate_field_scores_recursive(
                     field_data["fields"], current_path
+                )
+
+            if "nested_fields" in field_data and isinstance(
+                field_data["nested_fields"], dict
+            ):
+                self._accumulate_field_scores_recursive(
+                    field_data["nested_fields"], current_path
                 )
 
     def _calculate_derived_metrics(
@@ -532,7 +549,9 @@ class BulkStructuredModelEvaluator:
 
             count = self._field_score_counts.get(field_path, 0)
             field_metrics[field_path]["mean_score"] = (
-                self._field_score_sums[field_path] / count if count > 0 else 0.0
+                self._field_score_sums.get(field_path, 0.0) / count
+                if count > 0
+                else 0.0
             )
 
         # Defensive: emit mean_score for paths that have scores but no cm entry.
@@ -540,7 +559,9 @@ class BulkStructuredModelEvaluator:
             if field_path not in field_metrics:
                 field_metrics[field_path] = {
                     "mean_score": (
-                        self._field_score_sums[field_path] / count if count > 0 else 0.0
+                        self._field_score_sums.get(field_path, 0.0) / count
+                        if count > 0
+                        else 0.0
                     )
                 }
 

--- a/src/stickler/structured_object_evaluator/bulk_structured_model_evaluator.py
+++ b/src/stickler/structured_object_evaluator/bulk_structured_model_evaluator.py
@@ -443,6 +443,11 @@ class BulkStructuredModelEvaluator:
         if self._is_valid_score(overall_score):
             self._overall_score_sum += float(overall_score)
             self._overall_score_count += 1
+        elif self.verbose:
+            logger.debug(
+                "Skipping non-finite overall_score=%r from weighted aggregate",
+                overall_score,
+            )
 
     def _accumulate_field_scores_recursive(
         self, fields_dict: Dict[str, Any], path_prefix: str
@@ -454,6 +459,11 @@ class BulkStructuredModelEvaluator:
         ``threshold_applied_score`` (leaf fields and object/list aggregates).
         Also descends through ``nested_fields`` on list-of-StructuredModel
         nodes, for parity with ``_accumulate_field_metrics``.
+
+        Note: leaves inside ``List[StructuredModel]`` never surface a
+        ``threshold_applied_score`` because ``compare_with()`` only emits
+        the score at the list parent node. Those leaves will have CM
+        counts but no ``mean_score`` in the final ``field_metrics``.
         """
         for field_name, field_data in fields_dict.items():
             if not isinstance(field_data, dict):
@@ -461,10 +471,17 @@ class BulkStructuredModelEvaluator:
 
             current_path = f"{path_prefix}.{field_name}" if path_prefix else field_name
 
-            score = field_data.get("threshold_applied_score")
-            if self._is_valid_score(score):
-                self._field_score_sums[current_path] += float(score)
-                self._field_score_counts[current_path] += 1
+            if "threshold_applied_score" in field_data:
+                score = field_data["threshold_applied_score"]
+                if self._is_valid_score(score):
+                    self._field_score_sums[current_path] += float(score)
+                    self._field_score_counts[current_path] += 1
+                elif self.verbose:
+                    logger.debug(
+                        "Skipping non-finite threshold_applied_score=%r at %s",
+                        score,
+                        current_path,
+                    )
 
             if isinstance(field_data.get("fields"), dict):
                 self._accumulate_field_scores_recursive(
@@ -532,21 +549,26 @@ class BulkStructuredModelEvaluator:
             else 0.0
         )
 
-        # Calculate derived metrics for each field
+        # Union of cm paths and score paths surfaces fields seen via the
+        # minimal-input contract of update_from_comparison_result.
         field_metrics = {}
-        for field_path, field_cm in self._confusion_matrix["fields"].items():
-            field_cm_dict = dict(field_cm)
+        field_paths = set(self._confusion_matrix["fields"].keys())
+        field_paths.update(self._field_score_sums.keys())
+        for field_path in field_paths:
+            field_cm_dict = dict(self._confusion_matrix["fields"].get(field_path, {}))
             field_derived = self._calculate_derived_metrics(field_cm_dict)
             field_metrics[field_path] = {**field_cm_dict, **field_derived}
 
             # .get() (not []) avoids resurrecting zero entries in the
-            # defaultdict on every compute() call.
+            # defaultdict on every compute() call. mean_score is only
+            # emitted when a finite threshold_applied_score was observed at
+            # this path in at least one document — omitting the key keeps
+            # "no data" distinguishable from "every observation was 0.0".
             count = self._field_score_counts.get(field_path, 0)
-            field_metrics[field_path]["mean_score"] = (
-                self._field_score_sums.get(field_path, 0.0) / count
-                if count > 0
-                else 0.0
-            )
+            if count > 0:
+                field_metrics[field_path]["mean_score"] = (
+                    self._field_score_sums.get(field_path, 0.0) / count
+                )
 
         total_time = time.time() - self._start_time
 
@@ -673,12 +695,16 @@ class BulkStructuredModelEvaluator:
                 precision = field_metrics.get("cm_precision", 0.0)
                 recall = field_metrics.get("cm_recall", 0.0)
                 f1 = field_metrics.get("cm_f1", 0.0)
-                mean_score = field_metrics.get("mean_score", 0.0)
+                mean_score = field_metrics.get("mean_score")
+                mean_cell = f"{mean_score:.3f}" if mean_score is not None else "  n/a"
 
                 # Only show fields with some activity
                 if tp + fp + fn > 0:
+                    display_path = (
+                        field_path if len(field_path) <= 30 else field_path[:27] + "..."
+                    )
                     print(
-                        f"  {field_path:30} Mean: {mean_score:.3f} | P: {precision:.3f} | R: {recall:.3f} | F1: {f1:.3f} | TP: {tp:,} | FP: {fp:,} | FN: {fn:,}"
+                        f"  {display_path:30} Mean: {mean_cell} | P: {precision:.3f} | R: {recall:.3f} | F1: {f1:.3f} | TP: {tp:,} | FP: {fp:,} | FN: {fn:,}"
                     )
 
         # Error summary

--- a/tests/structured_object_evaluator/test_bulk_evaluator_parity.py
+++ b/tests/structured_object_evaluator/test_bulk_evaluator_parity.py
@@ -911,3 +911,51 @@ class TestMultiDocumentAggregation:
             f"Expected 50 processed documents, got {bulk_evaluator._processed_count}"
         )
 
+
+class TestWeightedOverallScoreParity:
+    """Issue #122 — bulk weighted_overall_score matches per-doc mean."""
+
+    def test_weighted_overall_score_parity_vs_compare_with_mean(self):
+        """Bulk weighted_overall_score equals mean of compare_with overall_scores."""
+        from stickler.comparators.levenshtein import LevenshteinComparator
+        from stickler.comparators.numeric import NumericComparator
+
+        class WeightedInvoice(StructuredModel):
+            invoice_id: str = ComparableField(
+                comparator=LevenshteinComparator(), weight=10.0
+            )
+            note: str = ComparableField(comparator=LevenshteinComparator(), weight=0.1)
+            total: float = ComparableField(comparator=NumericComparator(), weight=5.0)
+
+        import random
+
+        random.seed(42)
+        pairs = []
+        for i in range(25):
+            gt = WeightedInvoice(
+                invoice_id=f"INV-{i}",
+                note=random.choice(["a", "b", "c"]),
+                total=float(i * 10),
+            )
+            pred = WeightedInvoice(
+                invoice_id=f"INV-{i}" if random.random() < 0.6 else f"INV-X{i}",
+                note=random.choice(["a", "b", "c", "d"]),
+                total=float(i * 10) if random.random() < 0.7 else float(i * 10 + 1),
+            )
+            pairs.append((gt, pred))
+
+        per_doc_scores = [
+            gt.compare_with(pred, include_confusion_matrix=True)["overall_score"]
+            for gt, pred in pairs
+        ]
+        expected_mean = sum(per_doc_scores) / len(per_doc_scores)
+
+        evaluator = BulkStructuredModelEvaluator(target_schema=WeightedInvoice)
+        for gt, pred in pairs:
+            evaluator.update(gt, pred)
+        result = evaluator.compute()
+
+        assert abs(result.metrics["weighted_overall_score"] - expected_mean) < 1e-9, (
+            f"bulk weighted_overall_score {result.metrics['weighted_overall_score']}"
+            f" != per-doc mean {expected_mean}"
+        )

--- a/tests/structured_object_evaluator/test_bulk_evaluator_parity.py
+++ b/tests/structured_object_evaluator/test_bulk_evaluator_parity.py
@@ -913,7 +913,7 @@ class TestMultiDocumentAggregation:
 
 
 class TestWeightedOverallScoreParity:
-    """Issue #122 — bulk weighted_overall_score matches per-doc mean."""
+    """Bulk weighted_overall_score matches per-doc mean."""
 
     def test_weighted_overall_score_parity_vs_compare_with_mean(self):
         """Bulk weighted_overall_score equals mean of compare_with overall_scores."""

--- a/tests/structured_object_evaluator/test_bulk_evaluator_parity.py
+++ b/tests/structured_object_evaluator/test_bulk_evaluator_parity.py
@@ -929,18 +929,18 @@ class TestWeightedOverallScoreParity:
 
         import random
 
-        random.seed(42)
+        rng = random.Random(42)
         pairs = []
         for i in range(25):
             gt = WeightedInvoice(
                 invoice_id=f"INV-{i}",
-                note=random.choice(["a", "b", "c"]),
+                note=rng.choice(["a", "b", "c"]),
                 total=float(i * 10),
             )
             pred = WeightedInvoice(
-                invoice_id=f"INV-{i}" if random.random() < 0.6 else f"INV-X{i}",
-                note=random.choice(["a", "b", "c", "d"]),
-                total=float(i * 10) if random.random() < 0.7 else float(i * 10 + 1),
+                invoice_id=f"INV-{i}" if rng.random() < 0.6 else f"INV-X{i}",
+                note=rng.choice(["a", "b", "c", "d"]),
+                total=float(i * 10) if rng.random() < 0.7 else float(i * 10 + 1),
             )
             pairs.append((gt, pred))
 

--- a/tests/structured_object_evaluator/test_bulk_structured_model_evaluator.py
+++ b/tests/structured_object_evaluator/test_bulk_structured_model_evaluator.py
@@ -9,6 +9,7 @@ capabilities of the new BulkStructuredModelEvaluator.
 """
 
 import json
+import math
 from typing import List, Optional
 
 import pandas as pd
@@ -796,20 +797,18 @@ class TestUpdateFromComparisonResult:
         assert evaluator._processed_count == 2
 
 
-# Issue #122 fixtures/models live at module scope so Pydantic can resolve
-# forward references inside the test class below.
+# Fixture model lives at module scope so Pydantic can resolve forward refs
+# inside the test class below.
 
 
 class _Issue122Invoice(StructuredModel):
-    """Exact repro model from issue #122."""
-
     invoice_id: str = ComparableField(comparator=LevenshteinComparator(), weight=10.0)
     note: str = ComparableField(comparator=LevenshteinComparator(), weight=0.1)
     total: float = ComparableField(comparator=NumericComparator(), weight=5.0)
 
 
 class TestWeightedOverallScore:
-    """Issue #122 — weight-aware aggregate score in bulk evaluation."""
+    """Weight-aware aggregate score in bulk evaluation."""
 
     def _make_invoice_pair(self, gt_kwargs, pred_kwargs):
         return (
@@ -917,7 +916,7 @@ class TestWeightedOverallScore:
         )
 
     def test_load_state_tolerates_old_state_without_score_keys(self):
-        """Pre-#122 state dicts must load without error, score is 0.0."""
+        """Old state dicts without score keys must load, score defaults to 0.0."""
         evaluator = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
         # Simulate an old state dict with no score_* keys.
         old_state = {
@@ -979,7 +978,7 @@ class TestWeightedOverallScore:
 
         score = result.metrics["weighted_overall_score"]
         assert score == 0.0
-        assert not isinstance(score, float) or score == score  # not NaN
+        assert not math.isnan(score)
 
     def test_merge_state_sums_weighted_score_accumulators(self):
         a_pair = self._make_invoice_pair(
@@ -1009,7 +1008,7 @@ class TestWeightedOverallScore:
         )
 
     def test_merge_state_tolerates_old_peer_without_score_keys(self):
-        """Merging an old state dict (pre-#122) must not raise."""
+        """Merging an old state dict (no score keys) must not raise."""
         pair = self._make_invoice_pair(
             {"invoice_id": "INV-1", "note": "hi", "total": 10.0},
             {"invoice_id": "INV-9", "note": "hi", "total": 10.0},

--- a/tests/structured_object_evaluator/test_bulk_structured_model_evaluator.py
+++ b/tests/structured_object_evaluator/test_bulk_structured_model_evaluator.py
@@ -1053,3 +1053,57 @@ class TestWeightedOverallScore:
         result = evaluator.compute()
         assert evaluator._overall_score_count == 1
         assert result.metrics["weighted_overall_score"] == pytest.approx(good_score)
+
+    def test_list_of_structured_model_mean_score_at_list_path(self):
+        """List[StructuredModel] fields emit mean_score at the list node."""
+        from typing import List as _List
+
+        class _Line(StructuredModel):
+            name: str = ComparableField(comparator=LevenshteinComparator(), weight=2.0)
+            qty: int = ComparableField(comparator=NumericComparator(), weight=1.0)
+
+        class _Order(StructuredModel):
+            order_id: str = ComparableField(
+                comparator=LevenshteinComparator(), weight=5.0
+            )
+            items: _List[_Line] = ComparableField(weight=3.0)
+
+        gt = _Order(
+            order_id="O-1",
+            items=[_Line(name="apple", qty=1), _Line(name="banana", qty=2)],
+        )
+        pred = _Order(
+            order_id="O-1",
+            items=[_Line(name="apple", qty=1), _Line(name="banana", qty=3)],
+        )
+
+        per_doc = gt.compare_with(pred, include_confusion_matrix=True)
+        expected_items_score = per_doc["confusion_matrix"]["fields"]["items"][
+            "threshold_applied_score"
+        ]
+
+        evaluator = BulkStructuredModelEvaluator(target_schema=_Order)
+        evaluator.update(gt, pred)
+        result = evaluator.compute()
+
+        assert "items" in result.field_metrics
+        assert result.field_metrics["items"]["mean_score"] == pytest.approx(
+            expected_items_score
+        )
+        assert result.field_metrics["order_id"]["mean_score"] == pytest.approx(1.0)
+
+    def test_build_process_evaluation_does_not_mutate_score_accumulators(self):
+        """Reading mean_score for cm-only paths must not create defaultdict entries."""
+        evaluator = BulkStructuredModelEvaluator()
+        # Seed a cm-only path via update_from_comparison_result (no score data).
+        evaluator.update_from_comparison_result(
+            {"confusion_matrix": {"overall": {"tp": 1}, "fields": {"foo": {"tp": 1}}}},
+            doc_id="doc1",
+        )
+
+        evaluator.compute()
+
+        # Sums/counts must still be empty — compute() should not have materialized
+        # a zero-sum entry just by reading it.
+        assert dict(evaluator._field_score_sums) == {}
+        assert dict(evaluator._field_score_counts) == {}

--- a/tests/structured_object_evaluator/test_bulk_structured_model_evaluator.py
+++ b/tests/structured_object_evaluator/test_bulk_structured_model_evaluator.py
@@ -859,8 +859,13 @@ class TestWeightedOverallScore:
 
         assert result.metrics["weighted_overall_score"] == pytest.approx(expected)
 
-    def test_non_uniform_weights_issue_122_repro(self):
-        """Exact repro from the issue body."""
+    def test_non_uniform_weights_diverge_from_cm_f1(self):
+        """Weighted score reflects per-field weights; cm_f1 treats fields equally.
+
+        With invoice_id (w=10) near-matching, note (w=0.1) matching, and total
+        (w=5) matching, cm_f1 sees "3 true positives" uniformly while the
+        weighted score is dominated by the heavy invoice_id similarity.
+        """
         gt = _WeightedInvoice(invoice_id="INV-1", note="short", total=100.0)
         pred = _WeightedInvoice(invoice_id="INV-9", note="short", total=100.0)
 
@@ -873,12 +878,12 @@ class TestWeightedOverallScore:
         assert result.metrics["weighted_overall_score"] == pytest.approx(
             per_doc["overall_score"]
         )
-        # The two fields that matched exactly account for 5.1 / 15.1 of the
-        # weight; weighted score is ~0.337. cm_f1 sees 2/3 field matches
-        # equally and comes out higher, confirming the weighting gap.
-        assert result.metrics["weighted_overall_score"] != pytest.approx(
-            result.metrics["cm_f1"]
+        # Pin the exact value so a math regression (e.g., divisor swap)
+        # can't pass by just happening to stay different from cm_f1.
+        assert result.metrics["weighted_overall_score"] == pytest.approx(
+            0.8675, abs=1e-3
         )
+        assert result.metrics["cm_f1"] == pytest.approx(1.0)
 
     def test_state_roundtrip_preserves_weighted_score(self):
         pairs = [
@@ -1217,3 +1222,179 @@ class TestWeightedOverallScore:
             assert result.metrics["weighted_overall_score"] == pytest.approx(1.0)
             # Both docs counted toward _processed_count / CM.
             assert result.document_count == 2
+
+    def test_reset_clears_weighted_score_accumulators(self):
+        """reset() must zero weighted score and per-field score accumulators."""
+        gt, pred = self._make_invoice_pair(
+            {"invoice_id": "INV-1", "note": "hi", "total": 10.0},
+            {"invoice_id": "INV-9", "note": "hi", "total": 10.0},
+        )
+        evaluator = BulkStructuredModelEvaluator(target_schema=_WeightedInvoice)
+        evaluator.update(gt, pred)
+        assert evaluator._overall_score_count == 1
+        assert len(evaluator._field_score_sums) > 0
+
+        evaluator.reset()
+
+        assert evaluator._overall_score_sum == 0.0
+        assert evaluator._overall_score_count == 0
+        assert dict(evaluator._field_score_sums) == {}
+        assert dict(evaluator._field_score_counts) == {}
+
+        result = evaluator.compute()
+        assert result.metrics["weighted_overall_score"] == 0.0
+        assert result.field_metrics == {}
+
+    def test_get_current_metrics_reflects_partial_weighted_score(self):
+        """Mid-stream polling via get_current_metrics() sees partial aggregate."""
+        pairs = [
+            self._make_invoice_pair(
+                {"invoice_id": "INV-1", "note": "hi", "total": 10.0},
+                {"invoice_id": "INV-9", "note": "hi", "total": 10.0},
+            ),
+            self._make_invoice_pair(
+                {"invoice_id": "INV-2", "note": "hi", "total": 20.0},
+                {"invoice_id": "INV-2", "note": "hi", "total": 20.0},
+            ),
+        ]
+
+        evaluator = BulkStructuredModelEvaluator(target_schema=_WeightedInvoice)
+        evaluator.update(*pairs[0])
+
+        mid = evaluator.get_current_metrics()
+        first_doc_score = pairs[0][0].compare_with(
+            pairs[0][1], include_confusion_matrix=True
+        )["overall_score"]
+        assert mid.metrics["weighted_overall_score"] == pytest.approx(first_doc_score)
+        # State must not have been cleared by the polling call.
+        assert evaluator._overall_score_count == 1
+
+        evaluator.update(*pairs[1])
+        final = evaluator.compute()
+        expected_mean = (
+            first_doc_score
+            + pairs[1][0].compare_with(pairs[1][1], include_confusion_matrix=True)[
+                "overall_score"
+            ]
+        ) / 2
+        assert final.metrics["weighted_overall_score"] == pytest.approx(expected_mean)
+
+    def test_update_batch_accumulates_weighted_score(self):
+        """update_batch() must feed the weighted score path like update() does."""
+        pairs = [
+            self._make_invoice_pair(
+                {"invoice_id": "INV-1", "note": "hi", "total": 10.0},
+                {"invoice_id": "INV-9", "note": "hi", "total": 10.0},
+            ),
+            self._make_invoice_pair(
+                {"invoice_id": "INV-2", "note": "hi", "total": 20.0},
+                {"invoice_id": "INV-2", "note": "hi", "total": 20.0},
+            ),
+        ]
+        batch = [(gt, pred, f"doc_{i}") for i, (gt, pred) in enumerate(pairs)]
+
+        evaluator = BulkStructuredModelEvaluator(target_schema=_WeightedInvoice)
+        evaluator.update_batch(batch)
+        result = evaluator.compute()
+
+        expected = sum(
+            gt.compare_with(pred, include_confusion_matrix=True)["overall_score"]
+            for gt, pred in pairs
+        ) / len(pairs)
+        assert result.metrics["weighted_overall_score"] == pytest.approx(expected)
+        assert evaluator._overall_score_count == len(pairs)
+
+    def test_aggregate_from_comparisons_exposes_weighted_score(self):
+        """The module-level helper must surface weighted_overall_score."""
+        from stickler.structured_object_evaluator.bulk_structured_model_evaluator import (  # noqa: E501
+            aggregate_from_comparisons,
+        )
+
+        gt, pred = self._make_invoice_pair(
+            {"invoice_id": "INV-1", "note": "hi", "total": 10.0},
+            {"invoice_id": "INV-9", "note": "hi", "total": 10.0},
+        )
+        comparison = gt.compare_with(pred, include_confusion_matrix=True)
+
+        result = aggregate_from_comparisons([comparison])
+
+        assert "weighted_overall_score" in result.metrics
+        assert result.metrics["weighted_overall_score"] == pytest.approx(
+            comparison["overall_score"]
+        )
+
+    def test_per_path_mean_score_averages_only_observing_docs(self):
+        """mean_score denominator at each path = docs that actually scored that path.
+
+        Doc A records scores at paths {foo, bar}; doc B only at {foo}. foo's
+        mean must average across 2 docs, bar's across 1.
+        """
+        evaluator = BulkStructuredModelEvaluator()
+        evaluator.update_from_comparison_result(
+            {
+                "confusion_matrix": {
+                    "overall": {"tp": 2},
+                    "fields": {
+                        "foo": {"tp": 1, "threshold_applied_score": 0.8},
+                        "bar": {"tp": 1, "threshold_applied_score": 0.4},
+                    },
+                }
+            },
+            doc_id="a",
+        )
+        evaluator.update_from_comparison_result(
+            {
+                "confusion_matrix": {
+                    "overall": {"tp": 1},
+                    "fields": {"foo": {"tp": 1, "threshold_applied_score": 0.2}},
+                }
+            },
+            doc_id="b",
+        )
+
+        result = evaluator.compute()
+
+        assert result.field_metrics["foo"]["mean_score"] == pytest.approx(0.5)
+        assert result.field_metrics["bar"]["mean_score"] == pytest.approx(0.4)
+        assert evaluator._field_score_counts["foo"] == 2
+        assert evaluator._field_score_counts["bar"] == 1
+
+    def test_merge_state_across_disjoint_worker_field_sets(self):
+        """Workers seeing different field subsets must merge into correct union.
+
+        Models the distributed case: one worker only scored path X, another
+        only path Y. After merge, both paths appear with their own per-path
+        denominators.
+        """
+        worker_a = BulkStructuredModelEvaluator()
+        worker_a.update_from_comparison_result(
+            {
+                "confusion_matrix": {
+                    "overall": {"tp": 1},
+                    "fields": {"only_a": {"tp": 1, "threshold_applied_score": 0.7}},
+                }
+            },
+            doc_id="a",
+        )
+
+        worker_b = BulkStructuredModelEvaluator()
+        worker_b.update_from_comparison_result(
+            {
+                "confusion_matrix": {
+                    "overall": {"tp": 1},
+                    "fields": {"only_b": {"tp": 1, "threshold_applied_score": 0.3}},
+                }
+            },
+            doc_id="b",
+        )
+
+        worker_a.merge_state(worker_b.get_state())
+        result = worker_a.compute()
+
+        assert "only_a" in result.field_metrics
+        assert result.field_metrics["only_a"]["mean_score"] == pytest.approx(0.7)
+        assert "only_b" in result.field_metrics
+        assert result.field_metrics["only_b"]["mean_score"] == pytest.approx(0.3)
+        # Overall aggregate spans both docs.
+        assert worker_a._overall_score_count == 0  # no top-level overall_score set
+        assert result.document_count == 2

--- a/tests/structured_object_evaluator/test_bulk_structured_model_evaluator.py
+++ b/tests/structured_object_evaluator/test_bulk_structured_model_evaluator.py
@@ -801,7 +801,7 @@ class TestUpdateFromComparisonResult:
 # inside the test class below.
 
 
-class _Issue122Invoice(StructuredModel):
+class _WeightedInvoice(StructuredModel):
     invoice_id: str = ComparableField(comparator=LevenshteinComparator(), weight=10.0)
     note: str = ComparableField(comparator=LevenshteinComparator(), weight=0.1)
     total: float = ComparableField(comparator=NumericComparator(), weight=5.0)
@@ -812,8 +812,8 @@ class TestWeightedOverallScore:
 
     def _make_invoice_pair(self, gt_kwargs, pred_kwargs):
         return (
-            _Issue122Invoice(**gt_kwargs),
-            _Issue122Invoice(**pred_kwargs),
+            _WeightedInvoice(**gt_kwargs),
+            _WeightedInvoice(**pred_kwargs),
         )
 
     def test_single_doc_weighted_overall_matches_compare_with(self):
@@ -824,7 +824,7 @@ class TestWeightedOverallScore:
 
         expected = gt.compare_with(pred, include_confusion_matrix=True)["overall_score"]
 
-        evaluator = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        evaluator = BulkStructuredModelEvaluator(target_schema=_WeightedInvoice)
         evaluator.update(gt, pred)
         result = evaluator.compute()
 
@@ -852,7 +852,7 @@ class TestWeightedOverallScore:
         ]
         expected = sum(per_doc) / len(per_doc)
 
-        evaluator = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        evaluator = BulkStructuredModelEvaluator(target_schema=_WeightedInvoice)
         for gt, pred in pairs:
             evaluator.update(gt, pred)
         result = evaluator.compute()
@@ -861,12 +861,12 @@ class TestWeightedOverallScore:
 
     def test_non_uniform_weights_issue_122_repro(self):
         """Exact repro from the issue body."""
-        gt = _Issue122Invoice(invoice_id="INV-1", note="short", total=100.0)
-        pred = _Issue122Invoice(invoice_id="INV-9", note="short", total=100.0)
+        gt = _WeightedInvoice(invoice_id="INV-1", note="short", total=100.0)
+        pred = _WeightedInvoice(invoice_id="INV-9", note="short", total=100.0)
 
         per_doc = gt.compare_with(pred, include_confusion_matrix=True)
 
-        evaluator = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        evaluator = BulkStructuredModelEvaluator(target_schema=_WeightedInvoice)
         evaluator.update(gt, pred)
         result = evaluator.compute()
 
@@ -896,17 +896,17 @@ class TestWeightedOverallScore:
             ),
         ]
 
-        first = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        first = BulkStructuredModelEvaluator(target_schema=_WeightedInvoice)
         for gt, pred in pairs[:2]:
             first.update(gt, pred)
         state = first.get_state()
 
-        resumed = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        resumed = BulkStructuredModelEvaluator(target_schema=_WeightedInvoice)
         resumed.load_state(state)
         resumed.update(*pairs[2])
         resumed_result = resumed.compute()
 
-        direct = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        direct = BulkStructuredModelEvaluator(target_schema=_WeightedInvoice)
         for gt, pred in pairs:
             direct.update(gt, pred)
         direct_result = direct.compute()
@@ -917,14 +917,14 @@ class TestWeightedOverallScore:
 
     def test_load_state_tolerates_old_state_without_score_keys(self):
         """Old state dicts without score keys must load, score defaults to 0.0."""
-        evaluator = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        evaluator = BulkStructuredModelEvaluator(target_schema=_WeightedInvoice)
         # Simulate an old state dict with no score_* keys.
         old_state = {
             "confusion_matrix": {"overall": {}, "fields": {}},
             "errors": [],
             "processed_count": 0,
             "start_time": 0.0,
-            "target_schema": "_Issue122Invoice",
+            "target_schema": "_WeightedInvoice",
             "elide_errors": False,
         }
 
@@ -973,7 +973,7 @@ class TestWeightedOverallScore:
 
     def test_zero_docs_weighted_overall_is_zero(self):
         """Empty evaluator returns 0.0 (not NaN)."""
-        evaluator = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        evaluator = BulkStructuredModelEvaluator(target_schema=_WeightedInvoice)
         result = evaluator.compute()
 
         score = result.metrics["weighted_overall_score"]
@@ -990,15 +990,15 @@ class TestWeightedOverallScore:
             {"invoice_id": "INV-2", "note": "hi", "total": 20.0},
         )
 
-        a = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        a = BulkStructuredModelEvaluator(target_schema=_WeightedInvoice)
         a.update(*a_pair)
-        b = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        b = BulkStructuredModelEvaluator(target_schema=_WeightedInvoice)
         b.update(*b_pair)
 
         a.merge_state(b.get_state())
         merged_result = a.compute()
 
-        direct = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        direct = BulkStructuredModelEvaluator(target_schema=_WeightedInvoice)
         direct.update(*a_pair)
         direct.update(*b_pair)
         direct_result = direct.compute()
@@ -1014,7 +1014,7 @@ class TestWeightedOverallScore:
             {"invoice_id": "INV-9", "note": "hi", "total": 10.0},
         )
 
-        a = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        a = BulkStructuredModelEvaluator(target_schema=_WeightedInvoice)
         a.update(*pair)
 
         old_peer_state = {
@@ -1022,7 +1022,7 @@ class TestWeightedOverallScore:
             "errors": [],
             "processed_count": 0,
             "start_time": 0.0,
-            "target_schema": "_Issue122Invoice",
+            "target_schema": "_WeightedInvoice",
             "elide_errors": False,
         }
 
@@ -1033,13 +1033,17 @@ class TestWeightedOverallScore:
         assert a._overall_score_count == 1
 
     def test_error_doc_excluded_from_weighted_score_mean(self):
-        """Docs that raise during compare_with are excluded from denominator."""
+        """Docs that raise during compare_with are excluded from denominator.
+
+        The CM still absorbs the error (fn bump) so error-rate shows up in
+        cm_* metrics, but weighted_overall_score only counts successful docs.
+        """
         good_pair = self._make_invoice_pair(
             {"invoice_id": "INV-1", "note": "hi", "total": 10.0},
             {"invoice_id": "INV-9", "note": "hi", "total": 10.0},
         )
 
-        evaluator = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        evaluator = BulkStructuredModelEvaluator(target_schema=_WeightedInvoice)
         evaluator.update(*good_pair, doc_id="good")
 
         # Induce a comparison error via a malformed comparison_result dict.
@@ -1052,6 +1056,9 @@ class TestWeightedOverallScore:
         result = evaluator.compute()
         assert evaluator._overall_score_count == 1
         assert result.metrics["weighted_overall_score"] == pytest.approx(good_score)
+        # CM absorbs the error via fn bump; weighted score does not.
+        assert result.metrics["fn"] >= 1
+        assert len(result.errors) == 1
 
     def test_list_of_structured_model_mean_score_at_list_path(self):
         """List[StructuredModel] fields emit mean_score at the list node."""
@@ -1106,3 +1113,107 @@ class TestWeightedOverallScore:
         # a zero-sum entry just by reading it.
         assert dict(evaluator._field_score_sums) == {}
         assert dict(evaluator._field_score_counts) == {}
+
+    def test_cm_only_path_omits_mean_score_key(self):
+        """Paths with CM counts but no score data must not emit mean_score=0.0."""
+        evaluator = BulkStructuredModelEvaluator()
+        evaluator.update_from_comparison_result(
+            {"confusion_matrix": {"overall": {"tp": 1}, "fields": {"foo": {"tp": 1}}}},
+            doc_id="doc1",
+        )
+
+        result = evaluator.compute()
+
+        assert "foo" in result.field_metrics
+        # The distinguishing contract: no mean_score key means "not scored",
+        # which is distinct from "scored and got 0.0".
+        assert "mean_score" not in result.field_metrics["foo"]
+
+    def test_score_only_path_surfaces_in_field_metrics(self):
+        """Paths with score data but no CM counts must still appear in output."""
+        evaluator = BulkStructuredModelEvaluator()
+        evaluator.update_from_comparison_result(
+            {
+                "confusion_matrix": {
+                    "overall": {"tp": 1},
+                    "fields": {"bar": {"threshold_applied_score": 0.8}},
+                }
+            },
+            doc_id="doc1",
+        )
+
+        result = evaluator.compute()
+
+        assert "bar" in result.field_metrics
+        assert result.field_metrics["bar"]["mean_score"] == pytest.approx(0.8)
+        # CM counts default to absent — derived metrics still compute cleanly.
+        assert result.field_metrics["bar"].get("tp", 0) == 0
+
+    def test_list_of_model_leaf_omits_mean_score_key(self):
+        """Leaves inside List[StructuredModel] get CM counts but no mean_score.
+
+        compare_with() only emits threshold_applied_score at the list parent,
+        so nested leaves never accumulate a score. The key is omitted rather
+        than reported as a misleading 0.0.
+        """
+        from typing import List as _List
+
+        class _Line(StructuredModel):
+            name: str = ComparableField(comparator=LevenshteinComparator(), weight=2.0)
+            qty: int = ComparableField(comparator=NumericComparator(), weight=1.0)
+
+        class _Order(StructuredModel):
+            order_id: str = ComparableField(
+                comparator=LevenshteinComparator(), weight=5.0
+            )
+            items: _List[_Line] = ComparableField(weight=3.0)
+
+        gt = _Order(order_id="O-1", items=[_Line(name="apple", qty=1)])
+        pred = _Order(order_id="O-1", items=[_Line(name="apple", qty=1)])
+
+        evaluator = BulkStructuredModelEvaluator(target_schema=_Order)
+        evaluator.update(gt, pred)
+        evaluator.update(gt, pred)
+        result = evaluator.compute()
+
+        # Nested leaves get CM counts bubbled up...
+        assert "items.name" in result.field_metrics
+        assert result.field_metrics["items.name"].get("tp", 0) > 0
+        # ...but no mean_score because compare_with emits it only at the parent.
+        assert "mean_score" not in result.field_metrics["items.name"]
+        assert "mean_score" not in result.field_metrics["items.qty"]
+        # List parent and sibling leaves do surface mean_score.
+        assert "mean_score" in result.field_metrics["items"]
+        assert "mean_score" in result.field_metrics["order_id"]
+
+    def test_invalid_overall_score_skipped(self):
+        """Non-numeric, non-finite, and bool overall_score are silently dropped.
+
+        bool is a subclass of int in Python, so ``_is_valid_score`` rejects
+        it explicitly to avoid silently counting ``True`` as ``1.0``.
+        """
+        for bad in (float("nan"), float("inf"), float("-inf"), None, True, "0.5"):
+            evaluator = BulkStructuredModelEvaluator()
+            evaluator.update_from_comparison_result(
+                {
+                    "confusion_matrix": {"overall": {"tp": 1}, "fields": {}},
+                    "overall_score": bad,
+                },
+                doc_id="doc1",
+            )
+            evaluator.update_from_comparison_result(
+                {
+                    "confusion_matrix": {"overall": {"tp": 1}, "fields": {}},
+                    "overall_score": 1.0,
+                },
+                doc_id="doc2",
+            )
+
+            result = evaluator.compute()
+            # Only the valid doc counted in the denominator.
+            assert evaluator._overall_score_count == 1, (
+                f"expected non-finite {bad!r} to be skipped"
+            )
+            assert result.metrics["weighted_overall_score"] == pytest.approx(1.0)
+            # Both docs counted toward _processed_count / CM.
+            assert result.document_count == 2

--- a/tests/structured_object_evaluator/test_bulk_structured_model_evaluator.py
+++ b/tests/structured_object_evaluator/test_bulk_structured_model_evaluator.py
@@ -15,6 +15,8 @@ import pandas as pd
 import pytest
 
 from stickler.comparators.exact import ExactComparator
+from stickler.comparators.levenshtein import LevenshteinComparator
+from stickler.comparators.numeric import NumericComparator
 from stickler.structured_object_evaluator.bulk_structured_model_evaluator import (
     BulkStructuredModelEvaluator,
 )
@@ -792,3 +794,262 @@ class TestUpdateFromComparisonResult:
 
         assert second_tp == first_tp * 2
         assert evaluator._processed_count == 2
+
+
+# Issue #122 fixtures/models live at module scope so Pydantic can resolve
+# forward references inside the test class below.
+
+
+class _Issue122Invoice(StructuredModel):
+    """Exact repro model from issue #122."""
+
+    invoice_id: str = ComparableField(comparator=LevenshteinComparator(), weight=10.0)
+    note: str = ComparableField(comparator=LevenshteinComparator(), weight=0.1)
+    total: float = ComparableField(comparator=NumericComparator(), weight=5.0)
+
+
+class TestWeightedOverallScore:
+    """Issue #122 — weight-aware aggregate score in bulk evaluation."""
+
+    def _make_invoice_pair(self, gt_kwargs, pred_kwargs):
+        return (
+            _Issue122Invoice(**gt_kwargs),
+            _Issue122Invoice(**pred_kwargs),
+        )
+
+    def test_single_doc_weighted_overall_matches_compare_with(self):
+        gt, pred = self._make_invoice_pair(
+            {"invoice_id": "INV-1", "note": "hi", "total": 10.0},
+            {"invoice_id": "INV-9", "note": "hi", "total": 10.0},
+        )
+
+        expected = gt.compare_with(pred, include_confusion_matrix=True)["overall_score"]
+
+        evaluator = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        evaluator.update(gt, pred)
+        result = evaluator.compute()
+
+        assert result.metrics["weighted_overall_score"] == pytest.approx(expected)
+
+    def test_multi_doc_weighted_overall_is_arithmetic_mean(self):
+        pairs = [
+            self._make_invoice_pair(
+                {"invoice_id": "INV-1", "note": "hi", "total": 10.0},
+                {"invoice_id": "INV-9", "note": "hi", "total": 10.0},
+            ),
+            self._make_invoice_pair(
+                {"invoice_id": "INV-2", "note": "hi", "total": 20.0},
+                {"invoice_id": "INV-2", "note": "hi", "total": 20.0},
+            ),
+            self._make_invoice_pair(
+                {"invoice_id": "INV-3", "note": "hi", "total": 30.0},
+                {"invoice_id": "INV-3", "note": "bye", "total": 30.0},
+            ),
+        ]
+
+        per_doc = [
+            gt.compare_with(pred, include_confusion_matrix=True)["overall_score"]
+            for gt, pred in pairs
+        ]
+        expected = sum(per_doc) / len(per_doc)
+
+        evaluator = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        for gt, pred in pairs:
+            evaluator.update(gt, pred)
+        result = evaluator.compute()
+
+        assert result.metrics["weighted_overall_score"] == pytest.approx(expected)
+
+    def test_non_uniform_weights_issue_122_repro(self):
+        """Exact repro from the issue body."""
+        gt = _Issue122Invoice(invoice_id="INV-1", note="short", total=100.0)
+        pred = _Issue122Invoice(invoice_id="INV-9", note="short", total=100.0)
+
+        per_doc = gt.compare_with(pred, include_confusion_matrix=True)
+
+        evaluator = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        evaluator.update(gt, pred)
+        result = evaluator.compute()
+
+        assert result.metrics["weighted_overall_score"] == pytest.approx(
+            per_doc["overall_score"]
+        )
+        # The two fields that matched exactly account for 5.1 / 15.1 of the
+        # weight; weighted score is ~0.337. cm_f1 sees 2/3 field matches
+        # equally and comes out higher, confirming the weighting gap.
+        assert result.metrics["weighted_overall_score"] != pytest.approx(
+            result.metrics["cm_f1"]
+        )
+
+    def test_state_roundtrip_preserves_weighted_score(self):
+        pairs = [
+            self._make_invoice_pair(
+                {"invoice_id": "INV-1", "note": "hi", "total": 10.0},
+                {"invoice_id": "INV-9", "note": "hi", "total": 10.0},
+            ),
+            self._make_invoice_pair(
+                {"invoice_id": "INV-2", "note": "hi", "total": 20.0},
+                {"invoice_id": "INV-2", "note": "hi", "total": 20.0},
+            ),
+            self._make_invoice_pair(
+                {"invoice_id": "INV-3", "note": "hi", "total": 30.0},
+                {"invoice_id": "INV-3", "note": "bye", "total": 30.0},
+            ),
+        ]
+
+        first = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        for gt, pred in pairs[:2]:
+            first.update(gt, pred)
+        state = first.get_state()
+
+        resumed = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        resumed.load_state(state)
+        resumed.update(*pairs[2])
+        resumed_result = resumed.compute()
+
+        direct = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        for gt, pred in pairs:
+            direct.update(gt, pred)
+        direct_result = direct.compute()
+
+        assert resumed_result.metrics["weighted_overall_score"] == pytest.approx(
+            direct_result.metrics["weighted_overall_score"]
+        )
+
+    def test_load_state_tolerates_old_state_without_score_keys(self):
+        """Pre-#122 state dicts must load without error, score is 0.0."""
+        evaluator = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        # Simulate an old state dict with no score_* keys.
+        old_state = {
+            "confusion_matrix": {"overall": {}, "fields": {}},
+            "errors": [],
+            "processed_count": 0,
+            "start_time": 0.0,
+            "target_schema": "_Issue122Invoice",
+            "elide_errors": False,
+        }
+
+        evaluator.load_state(old_state)
+        result = evaluator.compute()
+
+        assert result.metrics["weighted_overall_score"] == 0.0
+        assert evaluator._overall_score_count == 0
+
+    def test_per_field_mean_score_at_nested_paths(self):
+        """Nested paths like contact.phone should emit their own mean_score."""
+        matching = {
+            "accountNumber": "1234567890",
+            "contact": {"phone": "555-123-4567", "email": "test@example.com"},
+            "transactions": [{"date": "2023-01-01", "description": "x", "amount": 1.0}],
+        }
+        wrong_phone = dict(matching)
+        wrong_phone["contact"] = {
+            "phone": "555-999-9999",
+            "email": "test@example.com",
+        }
+
+        evaluator = BulkStructuredModelEvaluator(target_schema=BankStatement)
+        evaluator.update(BankStatement(**matching), BankStatement(**matching))
+        evaluator.update(BankStatement(**matching), BankStatement(**wrong_phone))
+        result = evaluator.compute()
+
+        # contact.phone: 1.0 (match) + 0.0 (mismatch) = mean 0.5.
+        assert "contact.phone" in result.field_metrics
+        assert result.field_metrics["contact.phone"]["mean_score"] == pytest.approx(0.5)
+
+        # accountNumber matched twice: mean 1.0.
+        assert result.field_metrics["accountNumber"]["mean_score"] == pytest.approx(1.0)
+
+    def test_update_from_comparison_result_tolerates_missing_score_keys(self):
+        """Minimal dict without overall_score / fields must not raise."""
+        evaluator = BulkStructuredModelEvaluator()
+        evaluator.update_from_comparison_result(
+            {"confusion_matrix": {"overall": {"tp": 1}, "fields": {}}}, "doc1"
+        )
+
+        assert evaluator._processed_count == 1
+        assert evaluator._overall_score_count == 0
+        result = evaluator.compute()
+        assert result.metrics["weighted_overall_score"] == 0.0
+
+    def test_zero_docs_weighted_overall_is_zero(self):
+        """Empty evaluator returns 0.0 (not NaN)."""
+        evaluator = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        result = evaluator.compute()
+
+        score = result.metrics["weighted_overall_score"]
+        assert score == 0.0
+        assert not isinstance(score, float) or score == score  # not NaN
+
+    def test_merge_state_sums_weighted_score_accumulators(self):
+        a_pair = self._make_invoice_pair(
+            {"invoice_id": "INV-1", "note": "hi", "total": 10.0},
+            {"invoice_id": "INV-9", "note": "hi", "total": 10.0},
+        )
+        b_pair = self._make_invoice_pair(
+            {"invoice_id": "INV-2", "note": "hi", "total": 20.0},
+            {"invoice_id": "INV-2", "note": "hi", "total": 20.0},
+        )
+
+        a = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        a.update(*a_pair)
+        b = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        b.update(*b_pair)
+
+        a.merge_state(b.get_state())
+        merged_result = a.compute()
+
+        direct = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        direct.update(*a_pair)
+        direct.update(*b_pair)
+        direct_result = direct.compute()
+
+        assert merged_result.metrics["weighted_overall_score"] == pytest.approx(
+            direct_result.metrics["weighted_overall_score"]
+        )
+
+    def test_merge_state_tolerates_old_peer_without_score_keys(self):
+        """Merging an old state dict (pre-#122) must not raise."""
+        pair = self._make_invoice_pair(
+            {"invoice_id": "INV-1", "note": "hi", "total": 10.0},
+            {"invoice_id": "INV-9", "note": "hi", "total": 10.0},
+        )
+
+        a = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        a.update(*pair)
+
+        old_peer_state = {
+            "confusion_matrix": {"overall": {}, "fields": {}},
+            "errors": [],
+            "processed_count": 0,
+            "start_time": 0.0,
+            "target_schema": "_Issue122Invoice",
+            "elide_errors": False,
+        }
+
+        a.merge_state(old_peer_state)
+        result = a.compute()
+
+        assert result.metrics["weighted_overall_score"] > 0.0
+        assert a._overall_score_count == 1
+
+    def test_error_doc_excluded_from_weighted_score_mean(self):
+        """Docs that raise during compare_with are excluded from denominator."""
+        good_pair = self._make_invoice_pair(
+            {"invoice_id": "INV-1", "note": "hi", "total": 10.0},
+            {"invoice_id": "INV-9", "note": "hi", "total": 10.0},
+        )
+
+        evaluator = BulkStructuredModelEvaluator(target_schema=_Issue122Invoice)
+        evaluator.update(*good_pair, doc_id="good")
+
+        # Induce a comparison error via a malformed comparison_result dict.
+        evaluator.update_from_comparison_result({}, doc_id="bad")
+
+        good_score = good_pair[0].compare_with(
+            good_pair[1], include_confusion_matrix=True
+        )["overall_score"]
+
+        result = evaluator.compute()
+        assert evaluator._overall_score_count == 1
+        assert result.metrics["weighted_overall_score"] == pytest.approx(good_score)


### PR DESCRIPTION
# Pull Request

## Issue Reference
Fixes #122

## Description of Changes

`BulkStructuredModelEvaluator.compute()` aggregates confusion-matrix counts across docs but silently drops the weight-aware `overall_score` each per-doc `compare_with()` returns. users with non-uniform `ComparableField(weight=...)` values get misleading dataset-level headline numbers: `cm_f1` treats every field-match equally regardless of weight. this PR exposes a weight-aware aggregate.

### Changes Made
- `metrics["weighted_overall_score"]` in `ProcessEvaluation`: arithmetic mean of per-doc `comparison_result["overall_score"]` across successful docs. since each per-doc `overall_score = Σ_f(score × weight) / Σ_f(weight)` already divides by the schema-constant total weight, the mean-of-per-doc-overalls equals the `(doc, field)`-weighted aggregate, one key suffices.
- `field_metrics[path]["mean_score"]`: arithmetic mean of per-doc `threshold_applied_score` at that nested path, recorded at every leaf and object/list aggregate node that exposes the key.
- `get_state` / `load_state` / `merge_state` participate: new accumulators are persisted and mergeable, with `.get(..., default)` so pre-#122 state dicts still load cleanly.
- `pretty_print_metrics()` renders `Weighted Overall Score` under derived metrics and `Mean:` per field.
- score accumulation is best-effort: missing `overall_score` or `fields` in a `comparison_result` is skipped rather than raised, preserving the minimal-input contract of `update_from_comparison_result`. error docs (exception during `compare_with`) are excluded from the denominator, consistent with `_processed_count` semantics.
- docs: `docs/docs/Guides/Evaluation/bulk-evaluation.md` output-fields table now lists the new keys, with a `### Weighted Overall Score` subsection explaining when to prefer it over `cm_f1`.

### Why These Changes Are Needed

weighted scoring is a documented core feature of the library. teams running dataset-level evaluation via `BulkStructuredModelEvaluator` either don't realize weights aren't reflected in aggregate metrics and draw wrong conclusions, or roll their own aggregation from `per_doc.jsonl` to get a weight-aware headline number. see #122 for the repro and impact discussion.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

added `TestWeightedOverallScore` (11 tests) in `tests/structured_object_evaluator/test_bulk_structured_model_evaluator.py` covering:

- single-doc parity with `compare_with` (`test_single_doc_weighted_overall_matches_compare_with`)
- multi-doc arithmetic mean (`test_multi_doc_weighted_overall_is_arithmetic_mean`)
- exact issue #122 repro with non-uniform weights, asserting `weighted_overall_score != cm_f1` (`test_non_uniform_weights_issue_122_repro`)
- state roundtrip (`test_state_roundtrip_preserves_weighted_score`)
- backwards-compat: `load_state` / `merge_state` tolerate old state dicts without the score keys (`test_load_state_tolerates_old_state_without_score_keys`, `test_merge_state_tolerates_old_peer_without_score_keys`)
- per-field `mean_score` at nested paths (`test_per_field_mean_score_at_nested_paths`)
- minimal-input contract preserved (`test_update_from_comparison_result_tolerates_missing_score_keys`)
- zero-docs returns `0.0` not NaN (`test_zero_docs_weighted_overall_is_zero`)
- `merge_state` sums accumulators (`test_merge_state_sums_weighted_score_accumulators`)
- error docs excluded from denominator (`test_error_doc_excluded_from_weighted_score_mean`)

plus `TestWeightedOverallScoreParity::test_weighted_overall_score_parity_vs_compare_with_mean` in `test_bulk_evaluator_parity.py` over 25 randomized pairs.

local verification:

- `uv run pytest tests/` → 913 passed, 10 skipped, 1 pre-existing warning
- `uv run ruff check` / `ruff format --check` on touched files → clean
- issue repro snippet end-to-end: `weighted_overall_score` matches per-doc `overall_score` exactly and differs from `cm_f1`

## Reviewers
@sromoam

## Checklist
- [x] Code follows the project's coding standards
- [x] Self-review of code completed
- [x] Documentation updated (if applicable)
- [x] Tests added/updated for new functionality
- [ ] All CI checks are passing
- [x] Ready for review

## Additional Notes

backwards-compatible: pre-#122 state dicts load without raising and merge without raising; new keys default to `0.0` / `0` when absent. no breaking changes to `ProcessEvaluation` (`metrics` is `Dict[str, Any]`) or to the `update_from_comparison_result` minimal-input contract.