### PR TITLE
ci: fix security scan comment failing on fork PRs

### DIFF
--- a/.github/workflows/security-pr-comment.yaml
+++ b/.github/workflows/security-pr-comment.yaml
@@ -1,0 +1,78 @@
+name: Security Scan PR Comment
+
+on:
+  workflow_run:
+    workflows: ["Security Scan"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Download security-reports artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: security-reports
+          path: security-reports
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Post ASH summary to PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+
+            const prNumberPath = 'security-reports/pr-number.txt';
+            const reportPath = 'security-reports/.ash/ash_output/reports/ash.summary.md';
+
+            if (!fs.existsSync(prNumberPath)) {
+              core.info('No pr-number.txt in artifact; nothing to comment on.');
+              return;
+            }
+            const prNumber = parseInt(fs.readFileSync(prNumberPath, 'utf8').trim(), 10);
+            if (!Number.isFinite(prNumber)) {
+              core.setFailed(`Invalid PR number: ${prNumber}`);
+              return;
+            }
+
+            if (!fs.existsSync(reportPath)) {
+              core.info('ASH summary report not found; skipping comment.');
+              return;
+            }
+            const reportContent = fs.readFileSync(reportPath, 'utf8');
+            const marker = '<!-- ash-security-scan-report -->';
+            const body = `${marker}\n## Security Scan Results\n\n${reportContent}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated existing comment ${existing.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+              core.info('Created new comment');
+            }

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -4,15 +4,12 @@ on: [push, pull_request]
 
 permissions:
   contents: read
-  actions: read
 
 jobs:
   security:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      actions: write
-      pull-requests: write
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -36,6 +33,9 @@ jobs:
         continue-on-error: true
         run: |
           ash --mode local
+      - name: Save PR number
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
       - name: Upload Security Reports
         uses: actions/upload-artifact@v4
         if: always()
@@ -44,24 +44,4 @@ jobs:
           path: |
             bandit-report.json
             .ash/ash_output/
-      - name: Add Security Report to PR
-        uses: actions/github-script@v7
-        if: always() && github.event_name == 'pull_request'
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const reportPath = '.ash/ash_output/reports/ash.summary.md';
-
-            if (fs.existsSync(reportPath)) {
-              const reportContent = fs.readFileSync(reportPath, 'utf8');
-
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: '## Security Scan Results\n\n' + reportContent
-              });
-            } else {
-              console.log('ASH summary report not found');
-            }
+            pr-number.txt


### PR DESCRIPTION
## Summary
- split the ASH PR-comment step into a separate `workflow_run`-triggered workflow so it runs in base-repo context with `pull-requests: write`, which fixes the 403 seen on fork-originated PRs (e.g. #124)
- drop write permissions from `security.yaml`; it only scans and uploads artifacts now
- the new `security-pr-comment.yaml` upserts a single comment via an HTML marker so repeated pushes update in place instead of stacking comments

## Why
`pull_request` events triggered from forks receive a read-only `GITHUB_TOKEN` regardless of the `permissions:` block in the workflow, so `createComment` fails with `Resource not accessible by integration`. The `workflow_run` trigger executes in the base repository, where the token can be granted write scope safely.

## Validation note
`workflow_run` workflows execute the version of the workflow file on the **base branch**, not the PR branch. That means `security-pr-comment.yaml` will not run against this PR itself — the commenter workflow doesn't exist on `dev` yet. The `security.yaml` changes (artifact upload + `pr-number.txt`) will run from this PR, but end-to-end validation of the comment posting has to come from the **next** fork PR opened after this one merges into `dev`.

## Test plan
- [ ] on this PR: `Security Scan` uploads `pr-number.txt` alongside existing artifacts
- [ ] after merge: next fork PR triggers `Security Scan PR Comment` after `Security Scan` completes
- [ ] next fork PR: ASH summary comment posts successfully
- [ ] next fork PR: re-running the scan updates the existing comment rather than creating a new one
- [ ] push-triggered (non-PR) runs don't attempt to comment