### PR TITLE
docs: fix v0.4.0 release doc bugs flagged on PR #131

### DIFF
--- a/docs/docs/Advanced/confidence-metrics.md
+++ b/docs/docs/Advanced/confidence-metrics.md
@@ -196,7 +196,7 @@ results = evaluator.compute()
 ecab = results.confidence_metrics["overall"]["error_capture_at_budget"]
 
 for budget, data in ecab["budgets"].items():
-    print(f"Review {budget:.0%} of data: catch {data['pct_errors_caught']:.0%} of errors "
+    print(f"Review {float(budget):.0%} of data: catch {data['pct_errors_caught']:.0%} of errors "
           f"({data['gain']:.1f}x vs random)")
 ```
 

--- a/docs/docs/Advanced/rich-value-pattern.md
+++ b/docs/docs/Advanced/rich-value-pattern.md
@@ -156,7 +156,7 @@ present for the shim to fire — a plain dict like
 `{"currency": "USD", "value": 100}` is treated as user data, not a rich
 value. When the shim does fire, a `DeprecationWarning` names the
 offending field path and the value is unwrapped the same way as the new
-form. The legacy shape will be removed in 0.4.0 — migrate payloads to
+form. The legacy shape will be removed in 0.5.0 — migrate payloads to
 `_value`/`_confidence` as soon as you can.
 
 ## Integration with Confidence Evaluation

--- a/docs/docs/Guides/Evaluation/confidence-evaluation.md
+++ b/docs/docs/Guides/Evaluation/confidence-evaluation.md
@@ -34,7 +34,7 @@ print(results.confidence_metrics["overall"]["auroc"]["value"])
 # Practical: how useful?
 ecab = results.confidence_metrics["overall"]["error_capture_at_budget"]
 for budget, data in ecab["budgets"].items():
-    print(f"Review {budget:.0%} of data: catch {data['pct_errors_caught']:.0%} of errors "
+    print(f"Review {float(budget):.0%} of data: catch {data['pct_errors_caught']:.0%} of errors "
           f"({data['gain']:.1f}x vs random)")
 
 # How much data has confidence?


### PR DESCRIPTION
## Summary

Three docs-only fixes for issues flagged on the v0.4.0 release PR (#131). Lands on `dev` so they flow into #131 before tagging.

- **`docs/Advanced/rich-value-pattern.md`**: legacy `{"value", "confidence"}` shape removal is **0.5.0**, not 0.4.0. 0.4.0 introduces the deprecation shim; the shim is removed in 0.5.0. This matches `rich_value_helper.py` and the PR #131 commit `chore: pin deprecation removal to 0.5.0`.
- **`docs/Guides/Evaluation/confidence-evaluation.md`** and **`docs/Advanced/confidence-metrics.md`**: cast `budget` to `float` before formatting with `:.0%`. `ErrorCaptureAtBudgetMetric._budget_key` returns strings (`"0.10"`) so results JSON round-trip; without the cast, the snippet `f"{budget:.0%}"` raises `TypeError: unsupported format string passed to str.__format__` when copy-pasted.

3 files, 1-line change each.

## Test plan

- [ ] mkdocs builds clean (no broken refs)
- [ ] copy-paste the ECARB snippet from each guide into a Python REPL — should print without TypeError