### PR TITLE
fix: address PR #115 review feedback for universal aggregate metrics

### DIFF
--- a/docs/docs/Advanced/aggregate-metrics.md
+++ b/docs/docs/Advanced/aggregate-metrics.md
@@ -6,6 +6,19 @@ title: Aggregate Metrics
 
 Stickler automatically includes an `aggregate` field at every node in the confusion-matrix result tree. This provides a hierarchical rollup of all primitive-field metrics below each node, without any per-field configuration.
 
+## Why aggregates?
+
+The default `overall` metrics answer the question *"how did the model do at this level of the object?"* For a `List[Product]`, that means one TP/FD/FA/FN per item — a five-item GT compared against five predictions yields five object-level events, each gated by `match_threshold`. That view is correct for object-level evaluation, but it hides the field-level signal: a TP item with three of four fields wrong still counts as a single TP, and an FD or unmatched item contributes nothing to per-field accuracy because the per-field counts are threshold-gated.
+
+`aggregate` answers a different question: *"how did the model do across **every** field of **every** item, regardless of whether each item cleared the match threshold?"* The aggregate path always recurses into the nested fields of TP and FD pairs, and counts populated fields on unmatched items as FN (for missing GT) or FA (for spurious predictions). The result is a single per-field rollup at the parent level that tells you, e.g., "across this entire `List[LineItem]`, sku had 2 TP / 0 FD / 1 FN; description had 1 TP / 1 FD / 1 FN."
+
+In short:
+
+- Use **`overall`** when you want object-level pass/fail performance gated by `match_threshold` (e.g., "what fraction of predicted line items matched a GT line item?").
+- Use **`aggregate`** when you want field-level performance rolled up across an entire list or nested structure (e.g., "what's the precision and recall of the `sku` field across all line items in this invoice?").
+
+The two are complementary: `overall` and `aggregate` agree exactly for primitive fields and primitive-list fields (no recursion to do), and they diverge in interesting ways for `List[StructuredModel]`. The [Common pitfalls](#common-pitfalls) section near the end of this page covers the most frequent confusions.
+
 ## Key Features
 
 - **Automatic** -- Every node gets an `aggregate` field. No `aggregate=True` parameter needed.
@@ -259,6 +272,37 @@ def print_metrics(node, path=""):
 result = gt.compare_with(pred, include_confusion_matrix=True)
 print_metrics(result['confusion_matrix'])
 ```
+
+## Common pitfalls
+
+A handful of behaviors trip up users when they first start consuming `aggregate` metrics in earnest. Each subsection below is anchored so you can link directly to the specific footgun.
+
+### Aggregate doesn't equal the sum of `overall` counts {#aggregate-not-sum-of-overall}
+
+For `List[StructuredModel]` parents, `aggregate` is **not** derived from the parent's `overall` — it is a separately-accumulated rollup that recurses through every Hungarian-paired item, regardless of `match_threshold`. The object-level `overall` (TP/FD/FA/FN per item) is threshold-gated; `aggregate` pre-seeds its leaf counts from the full ungated set of pairs and then sums upward. If your numbers don't add up, this is almost always why — see the FD-recursion table in [Example 2](#example-2-list-of-structuredmodel-fd-recursion-and-unmatched-items) and the [threshold-gated drill-down explanation](threshold-gated-evaluation.md).
+
+### Zero-similarity item pairs are unmatched, not FD {#zero-similarity-pairs}
+
+Hungarian can return a "pairing" with similarity exactly `0.0` (e.g., two list items that share no signal at all). At the **object level**, those pairs are treated as unmatched and contribute one FN to GT plus one FA to Pred — not a single FD. Only pairs with `0.0 < similarity < match_threshold` count as FD. If you're tuning `match_threshold` and expect to see FD for very different items, you'll instead see FN+FA. See `_calculate_object_level_metrics` in `structured_list_comparator.py` (the `elif similarity > 0.0:` branch around line 205).
+
+### Empty list comparisons {#empty-lists}
+
+When **both** the GT and Pred lists are empty, the list field's `overall` is recorded as `tn: 1` (object-level true negative, similarity `1.0`). When **one** side is empty and the other is populated, every item on the non-empty side counts at the field level — populated GT items become FN, populated Pred items become FA. This matters in IDP scenarios where many document fields are optional: a model that hallucinates a 5-item table when GT is empty will produce 5 items' worth of FA across all sub-fields in `aggregate`, not just one object-level FA.
+
+### Bulk evaluator does not yet aggregate the `aggregate` field {#bulk-aggregate-not-rolled-up}
+
+`BulkStructuredModelEvaluator._accumulate_confusion_matrix` walks `cm_result["overall"]` and `cm_result["fields"]` (recursively into `fields` and `nested_fields`), but it **does not** roll up the per-document `aggregate` key into a corpus-level aggregate. Each per-document result still contains `aggregate`, but the bulk-rolled-up output exposes only `overall` and per-field metrics. If you need a corpus-level aggregate today, sum the per-document `aggregate` blocks yourself from `evaluate_pair` results. (Tracked as a follow-up.)
+
+### `recall_with_fd` parameter {#recall-with-fd}
+
+Derived metrics support two recall formulas, controlled by `recall_with_fd`:
+
+```text
+recall_with_fd=False (default):  TP / (TP + FN)
+recall_with_fd=True:             TP / (TP + FN + FD)
+```
+
+The default matches the textbook definition and treats FDs (partial/below-threshold matches) as neither rewards nor penalties for recall. Set `recall_with_fd=True` when a soft-but-wrong prediction should still count against you — i.e., when your downstream consumer can't tell the difference between "not retrieved" and "retrieved but below quality bar." Precision, F1, and accuracy are unaffected by this flag; only `cm_recall` (and the `cm_f1` derived from it) change.
 
 ## See Also
 

--- a/docs/docs/Advanced/aggregate-metrics.md
+++ b/docs/docs/Advanced/aggregate-metrics.md
@@ -54,6 +54,10 @@ Within each pair, sub-fields are dispatched by their own type — primitives are
 
 Matched and unmatched items contribute to aggregate metrics differently. For matched pairs (TP or FD), every child field is fully evaluated whether populated or not — both-null fields produce a TN, mismatches produce FD, etc. For unmatched items (FN or FA), only populated fields are counted: each non-null field on an unmatched GT item counts as FN, each non-null field on an unmatched Pred item counts as FA. Null fields on unmatched items are skipped entirely and do not produce a TN. This avoids inflating the TN count when a long predicted list contains mostly-empty objects.
 
+### Bulk evaluation
+
+`BulkStructuredModelEvaluator` exposes corpus-level rollups through a small plug-in accumulator pattern: each accumulator inspects every per-document comparison result and contributes its own block under `ProcessEvaluation.accumulator_metrics`. Two accumulators ship by default — `AggregateConfusionMatrixAccumulator` (rolls up per-document `aggregate` blocks into `accumulator_metrics["aggregate_metrics"]`; see [Corpus-level aggregate metrics](#bulk-aggregate-not-rolled-up)) and `ConfidenceAccumulator` (rolls up rich-value `_confidence` scores; see [Confidence Metrics](confidence-metrics.md)). To customize the set, pass an explicit `accumulators=` list to `BulkStructuredModelEvaluator`; only the accumulators you list will run.
+
 ## Example 1: Primitive + List of Primitives + Nested Structure
 
 This example covers three node types in one model: a primitive field (`name`), a list of primitives (`tags`), and a nested `StructuredModel` (`contact`).
@@ -250,6 +254,114 @@ Key observations:
 - Summing the columns: `sku` = 2 TP + 1 FN, `description` = 1 TP + 1 FD + 1 FN, `qty` = 1 TP + 1 FD + 1 FN. Grand total across all sub-fields: 4 TP, 2 FD, 3 FN — which is exactly what `items.aggregate` reports.
 - The threshold gates only the object-level classification. Aggregate metrics always drill down to the leaf fields.
 
+## Example 3: Corpus-level Rollup with BulkStructuredModelEvaluator
+
+This example shows how the per-document `aggregate` blocks from Examples 1 and 2 roll up into a single corpus-level view through `BulkStructuredModelEvaluator`'s plug-in `AggregateConfusionMatrixAccumulator` (enabled by default). The accumulator sums each document's `aggregate` and per-field-path aggregates and exposes the result on `ProcessEvaluation.accumulator_metrics["aggregate_metrics"]`.
+
+```python
+from typing import List
+from stickler import StructuredModel, ComparableField
+from stickler.comparators.exact import ExactComparator
+from stickler.comparators.levenshtein import LevenshteinComparator
+from stickler.structured_object_evaluator.bulk_structured_model_evaluator import (
+    BulkStructuredModelEvaluator,
+)
+
+class LineItem(StructuredModel):
+    match_threshold = 0.6
+    sku: str = ComparableField(comparator=ExactComparator(), threshold=1.0, weight=2.0)
+    description: str = ComparableField(
+        comparator=LevenshteinComparator(), threshold=0.7, weight=1.0
+    )
+    qty: int = ComparableField(comparator=ExactComparator(), threshold=1.0, weight=1.0)
+
+class Invoice(StructuredModel):
+    invoice_id: str = ComparableField(comparator=ExactComparator(), threshold=1.0)
+    items: List[LineItem] = ComparableField(weight=1.0)
+
+# Doc 1: all-TP — every field matches exactly.
+gt1 = Invoice(invoice_id="INV-001", items=[
+    LineItem(sku="AAA", description="Widget", qty=10),
+    LineItem(sku="BBB", description="Gadget", qty=5),
+])
+pred1 = Invoice(invoice_id="INV-001", items=[
+    LineItem(sku="AAA", description="Widget", qty=10),
+    LineItem(sku="BBB", description="Gadget", qty=5),
+])
+
+# Doc 2: includes an FD pair (item below match_threshold).
+# DDD pair: sku TP, description FD, qty FD — combined similarity < 0.6 so the
+# item is classified FD at the object level, but aggregate still recurses
+# through its leaf fields.
+gt2 = Invoice(invoice_id="INV-002", items=[
+    LineItem(sku="CCC", description="Cable", qty=3),
+    LineItem(sku="DDD", description="Dongle", qty=7),
+])
+pred2 = Invoice(invoice_id="INV-002", items=[
+    LineItem(sku="CCC", description="Cable", qty=3),
+    LineItem(sku="DDD", description="Completely Wrong", qty=99),
+])
+
+# Doc 3: unmatched FN — GT has an extra item with no pred counterpart, so its
+# populated leaf fields each contribute one FN to the aggregate.
+gt3 = Invoice(invoice_id="INV-003", items=[
+    LineItem(sku="EEE", description="Eraser", qty=1),
+    LineItem(sku="FFF", description="Folder", qty=4),
+])
+pred3 = Invoice(invoice_id="INV-003", items=[
+    LineItem(sku="EEE", description="Eraser", qty=1),
+])
+
+evaluator = BulkStructuredModelEvaluator(target_schema=Invoice)
+for gt, pred, doc_id in [
+    (gt1, pred1, "doc_1"),
+    (gt2, pred2, "doc_2"),
+    (gt3, pred3, "doc_3"),
+]:
+    evaluator.update(gt, pred, doc_id)
+
+result = evaluator.compute()
+corpus_aggregate = result.accumulator_metrics["aggregate_metrics"]
+
+# Corpus-level rollup: summed across every document, recursing into FD pairs
+# and unmatched items just like per-document aggregate would.
+print(corpus_aggregate["overall"])
+print(corpus_aggregate["fields"]["items.sku"])
+```
+
+### Output Structure
+
+```json
+{
+  "overall": {
+    "tp": 16, "fd": 2, "fa": 0, "fn": 3, "fp": 2, "tn": 0,
+    "derived": {
+      "cm_precision": 0.889, "cm_recall": 0.842,
+      "cm_f1": 0.865, "cm_accuracy": 0.762
+    }
+  },
+  "fields": {
+    "invoice_id": {
+      "tp": 3, "fd": 0, "fa": 0, "fn": 0, "fp": 0, "tn": 0,
+      "derived": { "cm_precision": 1.0, "cm_recall": 1.0, "cm_f1": 1.0, "cm_accuracy": 1.0 }
+    },
+    "items": {
+      "tp": 13, "fd": 2, "fa": 0, "fn": 3, "fp": 2, "tn": 0,
+      "derived": { "cm_precision": 0.867, "cm_recall": 0.812, "cm_f1": 0.839, "cm_accuracy": 0.722 }
+    },
+    "items.sku":         { "tp": 5, "fd": 0, "fa": 0, "fn": 1, "fp": 0, "tn": 0, "derived": { "...": "..." } },
+    "items.description": { "tp": 4, "fd": 1, "fa": 0, "fn": 1, "fp": 1, "tn": 0, "derived": { "...": "..." } },
+    "items.qty":         { "tp": 4, "fd": 1, "fa": 0, "fn": 1, "fp": 1, "tn": 0, "derived": { "...": "..." } }
+  }
+}
+```
+
+What to notice:
+
+- `accumulator_metrics["aggregate_metrics"]` and `result.metrics` (i.e. `evaluator.compute().overall_metrics`) answer different questions. The corpus `aggregate_metrics["overall"]` sums leaf-level signal from every document — including fields below FD pairs and unmatched items — so it counts 16 TP and 2 FD across the corpus. `result.metrics` is the threshold-gated object-level rollup and reports just 7 TP / 1 FD / 1 FN in this run (one FD line item from doc 2, one FN list from doc 3 plus six TP items elsewhere).
+- Per-field paths use the same dotted convention as `result.field_metrics` — `items.sku`, `items.description`, `items.qty` — so a field's threshold-gated counts and its corpus-aggregate counts can be compared side by side at the same key.
+- The accumulator is on by default; pass `accumulators=[...]` to `BulkStructuredModelEvaluator` only if you want to opt out or replace the set, as covered in [Corpus-level aggregate metrics (bulk evaluation)](#bulk-aggregate-not-rolled-up).
+
 ## Calculation Summary
 
 1. **Leaf nodes** (primitives and primitive lists): `aggregate` equals `overall`.
@@ -289,9 +401,21 @@ Hungarian can return a "pairing" with similarity exactly `0.0` (e.g., two list i
 
 When **both** the GT and Pred lists are empty, the list field's `overall` is recorded as `tn: 1` (object-level true negative, similarity `1.0`). When **one** side is empty and the other is populated, every item on the non-empty side counts at the field level — populated GT items become FN, populated Pred items become FA. This matters in IDP scenarios where many document fields are optional: a model that hallucinates a 5-item table when GT is empty will produce 5 items' worth of FA across all sub-fields in `aggregate`, not just one object-level FA.
 
-### Bulk evaluator does not yet aggregate the `aggregate` field {#bulk-aggregate-not-rolled-up}
+### Corpus-level aggregate metrics (bulk evaluation) {#bulk-aggregate-not-rolled-up}
 
-`BulkStructuredModelEvaluator._accumulate_confusion_matrix` walks `cm_result["overall"]` and `cm_result["fields"]` (recursively into `fields` and `nested_fields`), but it **does not** roll up the per-document `aggregate` key into a corpus-level aggregate. Each per-document result still contains `aggregate`, but the bulk-rolled-up output exposes only `overall` and per-field metrics. If you need a corpus-level aggregate today, sum the per-document `aggregate` blocks yourself from `evaluate_pair` results. (Tracked as a follow-up.)
+`BulkStructuredModelEvaluator` now rolls per-document `aggregate` blocks up into corpus-level totals via the built-in `AggregateConfusionMatrixAccumulator`, which is enabled by default and recurses through every nested field path. The corpus-level metrics are exposed on the `ProcessEvaluation` result at `accumulator_metrics["aggregate_metrics"]`, with an `overall` block plus a `fields` dict keyed by dotted field paths (e.g. `items.sku`). To opt out, pass an explicit `accumulators=` list to `BulkStructuredModelEvaluator` that omits this accumulator (default injection is suppressed when you provide your own list).
+
+```python
+evaluator = BulkStructuredModelEvaluator(target_schema=Invoice)
+for gt, pred, doc_id in pairs:
+    evaluator.update(gt, pred, doc_id)
+process_eval = evaluator.compute()
+
+corpus_agg = process_eval.accumulator_metrics["aggregate_metrics"]
+corpus_agg["overall"]["tp"]                       # corpus-wide TP across every leaf
+corpus_agg["overall"]["derived"]["cm_precision"]  # recomputed from the summed counts
+corpus_agg["fields"]["items.sku"]["fd"]           # per-field path counts
+```
 
 ### `recall_with_fd` parameter {#recall-with-fd}
 

--- a/docs/docs/Advanced/threshold-gated-evaluation.md
+++ b/docs/docs/Advanced/threshold-gated-evaluation.md
@@ -58,17 +58,17 @@ class Order(StructuredModel):
 
 ## Worked Scenarios
 
-Given three GT products and three Pred products:
+Given three GT products and two Pred products. Hungarian matching pairs `min(N_gt, N_pred) = 2` items optimally, leaving the remaining GT product unmatched.
 
 ### Good Match (similarity >= 0.8)
 
-**GT:** `Product("PROD-001", "Laptop", 999.99)`
-**Pred:** `Product("PROD-001", "Laptop Computer", 999.99)`
+**GT:** `Product("PROD-001", "Premium Laptop", 999.99)`
+**Pred:** `Product("PROD-001", "Premium Laptop X", 999.99)`
 
 - Classification: **TP**
 - Nested field analysis contributes to both per-field `overall` and `aggregate`:
     - `product_id`: TP (exact match)
-    - `name`: TP (similarity ~0.9)
+    - `name`: TP (similarity ~0.875)
     - `price`: TP (exact match)
 
 ### Poor Match (similarity < 0.8)
@@ -79,12 +79,13 @@ Given three GT products and three Pred products:
 - Classification: **FD**
 - Nested field analysis is performed for **aggregate** metrics only. The per-field `overall` does not include this pair's field-level breakdown, since the objects are too dissimilar for those counts to be meaningful alongside good matches.
 
-### Unmatched Items
+### Unmatched Item
 
 **GT:** `Product("PROD-003", "Cable", 14.99)` -- **FN** (no counterpart in Pred)
-**Pred:** `Product("PROD-004", "New Product", 19.99)` -- **FA** (no counterpart in GT)
 
-Nested field analysis is performed for **aggregate** metrics only (each non-null field on FN items counts as FN; each non-null field on FA items counts as FA). Per-field `overall` includes these contributions since the classification is unambiguous.
+Nested field analysis is performed for both per-field `overall` and `aggregate` (each non-null field on the FN item counts as FN). Per-field `overall` includes this contribution since the classification is unambiguous.
+
+If the Pred list had been longer than the GT list, any unpaired Pred items would be classified as **FA** by the same rule (each non-null field on an FA item counts as FA in both per-field `overall` and `aggregate`).
 
 ## Result Structure
 
@@ -92,20 +93,20 @@ Nested field analysis is performed for **aggregate** metrics only (each non-null
 {
   "products": {
     "overall": {
-      "tp": 1, "fd": 1, "fn": 1, "fa": 1,
+      "tp": 1, "fd": 1, "fn": 1, "fa": 0,
       "derived": { "cm_precision": 0.5, "cm_recall": 0.5, "cm_f1": 0.5 }
     },
     "aggregate": {
-      "tp": 4, "fd": 2, "fn": 3, "fa": 3,
-      "derived": { "cm_precision": 0.57, "cm_recall": 0.57, "cm_f1": 0.57 }
+      "tp": 4, "fd": 2, "fn": 3, "fa": 0,
+      "derived": { "cm_precision": 0.67, "cm_recall": 0.57, "cm_f1": 0.62 }
     },
     "fields": {
-      "product_id": { "overall": { "tp": 1 },
-                      "aggregate": { "tp": 2, "fn": 1, "fa": 1 } },
-      "name":       { "overall": { "tp": 1 },
-                      "aggregate": { "tp": 1, "fd": 1, "fn": 1, "fa": 1 } },
-      "price":      { "overall": { "tp": 1 },
-                      "aggregate": { "tp": 1, "fd": 1, "fn": 1, "fa": 1 } }
+      "product_id": { "overall": { "tp": 1, "fn": 1 },
+                      "aggregate": { "tp": 2, "fn": 1 } },
+      "name":       { "overall": { "tp": 1, "fn": 1 },
+                      "aggregate": { "tp": 1, "fd": 1, "fn": 1 } },
+      "price":      { "overall": { "tp": 1, "fn": 1 },
+                      "aggregate": { "tp": 1, "fd": 1, "fn": 1 } }
     },
     "non_matches": [
       {
@@ -114,14 +115,13 @@ Nested field analysis is performed for **aggregate** metrics only (each non-null
         "pred_object": "Product(PROD-002, Different Product, 99.99)",
         "similarity": 0.3
       },
-      { "type": "FN", "gt_object": "Product(PROD-003, Cable, 14.99)" },
-      { "type": "FA", "pred_object": "Product(PROD-004, New Product, 19.99)" }
+      { "type": "FN", "gt_object": "Product(PROD-003, Cable, 14.99)" }
     ]
   }
 }
 ```
 
-Per-field `overall` metrics appear only for the single TP pair (and unmatched FN/FA items). The `aggregate` at each field includes contributions from all pairs -- good matches, poor matches, and unmatched items alike. The `non_matches` list documents every FD, FN, and FA for diagnostic purposes.
+Per-field `overall` metrics include contributions from the TP pair and the unmatched FN item, but not the FD pair. The `aggregate` at each field includes contributions from all pairs -- good matches, poor matches, and unmatched items alike. The `non_matches` list documents every FD, FN, and FA for diagnostic purposes.
 
 ## Delegation Pattern
 

--- a/examples/notebooks/Aggregate_metrics.ipynb
+++ b/examples/notebooks/Aggregate_metrics.ipynb
@@ -22,7 +22,14 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T02:37:58.344594Z",
+     "iopub.status.busy": "2026-06-02T02:37:58.344300Z",
+     "iopub.status.idle": "2026-06-02T02:38:01.406090Z",
+     "shell.execute_reply": "2026-06-02T02:38:01.405570Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import json\n",
@@ -54,7 +61,14 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T02:38:01.408511Z",
+     "iopub.status.busy": "2026-06-02T02:38:01.408324Z",
+     "iopub.status.idle": "2026-06-02T02:38:01.411942Z",
+     "shell.execute_reply": "2026-06-02T02:38:01.411461Z"
+    }
+   },
    "outputs": [],
    "source": [
     "class Contact(StructuredModel):\n",
@@ -71,7 +85,14 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T02:38:01.413415Z",
+     "iopub.status.busy": "2026-06-02T02:38:01.413327Z",
+     "iopub.status.idle": "2026-06-02T02:38:01.430724Z",
+     "shell.execute_reply": "2026-06-02T02:38:01.430248Z"
+    }
+   },
    "outputs": [],
    "source": [
     "gt = Person(\n",
@@ -101,7 +122,14 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T02:38:01.432208Z",
+     "iopub.status.busy": "2026-06-02T02:38:01.432125Z",
+     "iopub.status.idle": "2026-06-02T02:38:01.434204Z",
+     "shell.execute_reply": "2026-06-02T02:38:01.433734Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -142,7 +170,14 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T02:38:01.457592Z",
+     "iopub.status.busy": "2026-06-02T02:38:01.457474Z",
+     "iopub.status.idle": "2026-06-02T02:38:01.459413Z",
+     "shell.execute_reply": "2026-06-02T02:38:01.459159Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -186,7 +221,14 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T02:38:01.460769Z",
+     "iopub.status.busy": "2026-06-02T02:38:01.460685Z",
+     "iopub.status.idle": "2026-06-02T02:38:01.463657Z",
+     "shell.execute_reply": "2026-06-02T02:38:01.463349Z"
+    }
+   },
    "outputs": [],
    "source": [
     "class LineItem(StructuredModel):\n",
@@ -207,7 +249,14 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T02:38:01.464834Z",
+     "iopub.status.busy": "2026-06-02T02:38:01.464746Z",
+     "iopub.status.idle": "2026-06-02T02:38:01.469103Z",
+     "shell.execute_reply": "2026-06-02T02:38:01.468691Z"
+    }
+   },
    "outputs": [],
    "source": [
     "gt = Invoice(\n",
@@ -251,7 +300,14 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T02:38:01.470430Z",
+     "iopub.status.busy": "2026-06-02T02:38:01.470365Z",
+     "iopub.status.idle": "2026-06-02T02:38:01.472196Z",
+     "shell.execute_reply": "2026-06-02T02:38:01.471858Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -309,7 +365,14 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T02:38:01.473401Z",
+     "iopub.status.busy": "2026-06-02T02:38:01.473335Z",
+     "iopub.status.idle": "2026-06-02T02:38:01.474973Z",
+     "shell.execute_reply": "2026-06-02T02:38:01.474628Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -337,7 +400,14 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T02:38:01.476139Z",
+     "iopub.status.busy": "2026-06-02T02:38:01.476079Z",
+     "iopub.status.idle": "2026-06-02T02:38:01.477901Z",
+     "shell.execute_reply": "2026-06-02T02:38:01.477496Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -413,7 +483,7 @@
       "      \"fields\": {\n",
       "        \"sku\": {\n",
       "          \"overall\": {\n",
-      "            \"tp\": 2,\n",
+      "            \"tp\": 1,\n",
       "            \"fa\": 0,\n",
       "            \"fd\": 0,\n",
       "            \"fp\": 0,\n",
@@ -421,9 +491,9 @@
       "            \"fn\": 1,\n",
       "            \"derived\": {\n",
       "              \"cm_precision\": 1.0,\n",
-      "              \"cm_recall\": 0.6666666666666666,\n",
-      "              \"cm_f1\": 0.8,\n",
-      "              \"cm_accuracy\": 0.6666666666666666\n",
+      "              \"cm_recall\": 0.5,\n",
+      "              \"cm_f1\": 0.6666666666666666,\n",
+      "              \"cm_accuracy\": 0.5\n",
       "            }\n",
       "          },\n",
       "          \"fields\": {},\n",
@@ -446,15 +516,15 @@
       "          \"overall\": {\n",
       "            \"tp\": 1,\n",
       "            \"fa\": 0,\n",
-      "            \"fd\": 1,\n",
-      "            \"fp\": 1,\n",
+      "            \"fd\": 0,\n",
+      "            \"fp\": 0,\n",
       "            \"tn\": 0,\n",
       "            \"fn\": 1,\n",
       "            \"derived\": {\n",
-      "              \"cm_precision\": 0.5,\n",
+      "              \"cm_precision\": 1.0,\n",
       "              \"cm_recall\": 0.5,\n",
-      "              \"cm_f1\": 0.5,\n",
-      "              \"cm_accuracy\": 0.3333333333333333\n",
+      "              \"cm_f1\": 0.6666666666666666,\n",
+      "              \"cm_accuracy\": 0.5\n",
       "            }\n",
       "          },\n",
       "          \"fields\": {},\n",
@@ -477,15 +547,15 @@
       "          \"overall\": {\n",
       "            \"tp\": 1,\n",
       "            \"fa\": 0,\n",
-      "            \"fd\": 1,\n",
-      "            \"fp\": 1,\n",
+      "            \"fd\": 0,\n",
+      "            \"fp\": 0,\n",
       "            \"tn\": 0,\n",
       "            \"fn\": 1,\n",
       "            \"derived\": {\n",
-      "              \"cm_precision\": 0.5,\n",
+      "              \"cm_precision\": 1.0,\n",
       "              \"cm_recall\": 0.5,\n",
-      "              \"cm_f1\": 0.5,\n",
-      "              \"cm_accuracy\": 0.3333333333333333\n",
+      "              \"cm_f1\": 0.6666666666666666,\n",
+      "              \"cm_accuracy\": 0.5\n",
       "            }\n",
       "          },\n",
       "          \"fields\": {},\n",
@@ -560,7 +630,14 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T02:38:01.479037Z",
+     "iopub.status.busy": "2026-06-02T02:38:01.478974Z",
+     "iopub.status.idle": "2026-06-02T02:38:01.481180Z",
+     "shell.execute_reply": "2026-06-02T02:38:01.480761Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -590,6 +667,252 @@
     "\n",
     "print_metrics(cm2)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 3: Corpus-level Rollup with `BulkStructuredModelEvaluator`\n",
+    "\n",
+    "Examples 1 and 2 looked at the per-document `aggregate` block. In real evaluations you usually want the same numbers summed across an entire corpus. `BulkStructuredModelEvaluator` does this through a plug-in *accumulator* pattern: each accumulator gets fed every document's comparison result, and contributes a slice of the final report.\n",
+    "\n",
+    "The `AggregateConfusionMatrixAccumulator` is wired into the default accumulator set, so corpus-level aggregate metrics are on by default. After calling `.compute()`, look for them under `accumulator_metrics[\"aggregate_metrics\"]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T02:38:01.482256Z",
+     "iopub.status.busy": "2026-06-02T02:38:01.482192Z",
+     "iopub.status.idle": "2026-06-02T02:38:01.485109Z",
+     "shell.execute_reply": "2026-06-02T02:38:01.484830Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from stickler.structured_object_evaluator.bulk_structured_model_evaluator import (\n",
+    "    BulkStructuredModelEvaluator,\n",
+    ")\n",
+    "\n",
+    "# Reuses the Invoice / LineItem classes defined in Example 2 (module scope).\n",
+    "# Three (gt, pred) pairs that mirror the doc-site Example 3 fixture exactly,\n",
+    "# so the corpus rollup printed below matches the doc's published numbers:\n",
+    "#   doc_1: every line item matches exactly                (TP-only)\n",
+    "#   doc_2: includes a pair below match_threshold          (FD pair, leaves still recurse)\n",
+    "#   doc_3: GT has an extra item with no pred counterpart  (unmatched FN, leaves count as FN)\n",
+    "\n",
+    "doc_1 = (\n",
+    "    Invoice(\n",
+    "        invoice_id=\"INV-001\",\n",
+    "        items=[\n",
+    "            LineItem(sku=\"AAA\", description=\"Widget\", qty=10),\n",
+    "            LineItem(sku=\"BBB\", description=\"Gadget\", qty=5),\n",
+    "        ],\n",
+    "    ),\n",
+    "    Invoice(\n",
+    "        invoice_id=\"INV-001\",\n",
+    "        items=[\n",
+    "            LineItem(sku=\"AAA\", description=\"Widget\", qty=10),\n",
+    "            LineItem(sku=\"BBB\", description=\"Gadget\", qty=5),\n",
+    "        ],\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "doc_2 = (\n",
+    "    Invoice(\n",
+    "        invoice_id=\"INV-002\",\n",
+    "        items=[\n",
+    "            LineItem(sku=\"CCC\", description=\"Cable\", qty=3),\n",
+    "            LineItem(sku=\"DDD\", description=\"Dongle\", qty=7),\n",
+    "        ],\n",
+    "    ),\n",
+    "    Invoice(\n",
+    "        invoice_id=\"INV-002\",\n",
+    "        items=[\n",
+    "            LineItem(sku=\"CCC\", description=\"Cable\", qty=3),\n",
+    "            # DDD pair: sku TP, description FD, qty FD -> combined sim < 0.6 ->\n",
+    "            # item is FD at the object level, but aggregate still recurses\n",
+    "            # through its leaf fields.\n",
+    "            LineItem(sku=\"DDD\", description=\"Completely Wrong\", qty=99),\n",
+    "        ],\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "doc_3 = (\n",
+    "    Invoice(\n",
+    "        invoice_id=\"INV-003\",\n",
+    "        items=[\n",
+    "            LineItem(sku=\"EEE\", description=\"Eraser\", qty=1),\n",
+    "            LineItem(sku=\"FFF\", description=\"Folder\", qty=4),  # unmatched GT -> FN\n",
+    "        ],\n",
+    "    ),\n",
+    "    Invoice(\n",
+    "        invoice_id=\"INV-003\",\n",
+    "        items=[\n",
+    "            LineItem(sku=\"EEE\", description=\"Eraser\", qty=1),\n",
+    "        ],\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "pairs = [\n",
+    "    (\"doc_1\", *doc_1),\n",
+    "    (\"doc_2\", *doc_2),\n",
+    "    (\"doc_3\", *doc_3),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T02:38:01.486234Z",
+     "iopub.status.busy": "2026-06-02T02:38:01.486165Z",
+     "iopub.status.idle": "2026-06-02T02:38:01.495772Z",
+     "shell.execute_reply": "2026-06-02T02:38:01.495412Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "accumulator_metrics keys: ['aggregate_metrics', 'confidence_metrics']\n"
+     ]
+    }
+   ],
+   "source": [
+    "evaluator = BulkStructuredModelEvaluator(target_schema=Invoice)\n",
+    "\n",
+    "for doc_id, gt_doc, pred_doc in pairs:\n",
+    "    evaluator.update(gt_doc, pred_doc, doc_id=doc_id)\n",
+    "\n",
+    "result = evaluator.compute()\n",
+    "\n",
+    "# Default accumulator set surfaces both confidence and aggregate slices.\n",
+    "print(\"accumulator_metrics keys:\", sorted(result.accumulator_metrics.keys()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T02:38:01.496855Z",
+     "iopub.status.busy": "2026-06-02T02:38:01.496789Z",
+     "iopub.status.idle": "2026-06-02T02:38:01.498751Z",
+     "shell.execute_reply": "2026-06-02T02:38:01.498434Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- corpus-level aggregate.overall ---\n",
+      "{\n",
+      "  \"tp\": 16,\n",
+      "  \"fp\": 2,\n",
+      "  \"fn\": 3,\n",
+      "  \"fa\": 0,\n",
+      "  \"fd\": 2,\n",
+      "  \"tn\": 0,\n",
+      "  \"derived\": {\n",
+      "    \"cm_precision\": 0.8888888888888888,\n",
+      "    \"cm_recall\": 0.8421052631578947,\n",
+      "    \"cm_f1\": 0.8648648648648649,\n",
+      "    \"cm_accuracy\": 0.7619047619047619\n",
+      "  }\n",
+      "}\n",
+      "\n",
+      "--- aggregate.fields['items.sku'] ---\n",
+      "{\n",
+      "  \"tp\": 5,\n",
+      "  \"fp\": 0,\n",
+      "  \"fn\": 1,\n",
+      "  \"fa\": 0,\n",
+      "  \"fd\": 0,\n",
+      "  \"tn\": 0,\n",
+      "  \"derived\": {\n",
+      "    \"cm_precision\": 1.0,\n",
+      "    \"cm_recall\": 0.8333333333333334,\n",
+      "    \"cm_f1\": 0.9090909090909091,\n",
+      "    \"cm_accuracy\": 0.8333333333333334\n",
+      "  }\n",
+      "}\n",
+      "\n",
+      "--- aggregate.fields['items.description'] ---\n",
+      "{\n",
+      "  \"tp\": 4,\n",
+      "  \"fp\": 1,\n",
+      "  \"fn\": 1,\n",
+      "  \"fa\": 0,\n",
+      "  \"fd\": 1,\n",
+      "  \"tn\": 0,\n",
+      "  \"derived\": {\n",
+      "    \"cm_precision\": 0.8,\n",
+      "    \"cm_recall\": 0.8,\n",
+      "    \"cm_f1\": 0.8000000000000002,\n",
+      "    \"cm_accuracy\": 0.6666666666666666\n",
+      "  }\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "agg = result.accumulator_metrics[\"aggregate_metrics\"]\n",
+    "\n",
+    "print(\"--- corpus-level aggregate.overall ---\")\n",
+    "pp(agg[\"overall\"])\n",
+    "\n",
+    "print(\"\\n--- aggregate.fields['items.sku'] ---\")\n",
+    "pp(agg[\"fields\"][\"items.sku\"])\n",
+    "\n",
+    "print(\"\\n--- aggregate.fields['items.description'] ---\")\n",
+    "pp(agg[\"fields\"][\"items.description\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### What this shows\n",
+    "\n",
+    "`accumulator_metrics[\"aggregate_metrics\"][\"overall\"]` is the corpus-level version of the per-document `cm[\"aggregate\"]` block printed in Example 2 — same shape, summed across every document the evaluator saw. The `fields` dict flattens the tree onto dotted paths (`items.sku`, `items.description`, `items.qty`), each carrying its own TP/FA/FD/FN totals with derived precision/recall/F1.\n",
+    "\n",
+    "Because the aggregate accumulator inherits the per-document FD-recursion behavior from Example 2, leaf fields under FD-classified list items still contribute their own counts here — which is why `items.description` and `items.qty` show non-zero `fd` even though only one document had a below-threshold pair. Unmatched GT items contribute FNs and unmatched PRED items contribute FAs at every leaf path under the list."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Opting out or extending the default accumulators\n",
+    "\n",
+    "Pass an explicit `accumulators=[...]` list to `BulkStructuredModelEvaluator` to opt out of the default set — for example `accumulators=[ConfidenceAccumulator()]` drops `aggregate_metrics` from the output. To *add* an accumulator alongside the defaults, include both the existing accumulators and your custom one in that list:\n",
+    "\n",
+    "```python\n",
+    "from stickler.structured_object_evaluator.models.aggregate import (\n",
+    "    AggregateConfusionMatrixAccumulator,\n",
+    ")\n",
+    "from stickler.structured_object_evaluator.models.confidence.accumulator import (\n",
+    "    ConfidenceAccumulator,\n",
+    ")\n",
+    "\n",
+    "evaluator = BulkStructuredModelEvaluator(\n",
+    "    target_schema=Invoice,\n",
+    "    accumulators=[\n",
+    "        ConfidenceAccumulator(),\n",
+    "        AggregateConfusionMatrixAccumulator(),\n",
+    "        MyCustomAccumulator(),  # any object implementing the accumulator protocol\n",
+    "    ],\n",
+    ")\n",
+    "```\n",
+    "\n",
+    "Each accumulator's `name` attribute keys its slice of the final `accumulator_metrics` dict, so duplicate names are rejected at construction time."
+   ]
   }
  ],
  "metadata": {
@@ -608,7 +931,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/src/stickler/algorithms/hungarian.py
+++ b/src/stickler/algorithms/hungarian.py
@@ -212,7 +212,7 @@ class HungarianMatcher:
             else:
                 score = self.comparator(prepared_list1[0], prepared_list2[0])
 
-            if score >= self.match_threshold:
+            if score > 0:
                 return {
                     "matched_pairs": [(0, 0, score)],
                     "tp": 1,
@@ -223,11 +223,17 @@ class HungarianMatcher:
                     "f1": 1.0,
                 }
             else:
+                # score == 0: items have no similarity, so treat as both
+                # unmatched (FN + FA) rather than as a paired-but-mismatched
+                # item (FD). This is consistent with the StructuredListComparator
+                # behavior, which excludes zero-similarity pairings from the
+                # matched set so that unmatched_gt and unmatched_pred each
+                # contribute to FN and FA respectively.
                 return {
-                    "matched_pairs": [(0, 0, score)],
+                    "matched_pairs": [],
                     "tp": 0,
                     "fp": 1,
-                    "fn": 0,
+                    "fn": 1,
                     "precision": 0.0,
                     "recall": 0.0,
                     "f1": 0.0,

--- a/src/stickler/structured_object_evaluator/bulk_structured_model_evaluator.py
+++ b/src/stickler/structured_object_evaluator/bulk_structured_model_evaluator.py
@@ -797,6 +797,52 @@ class BulkStructuredModelEvaluator:
                 ):
                     print(f"  {error_type}: {count:,}")
 
+        # Corpus-level aggregate slice (universal aggregate accumulator).
+        # Surfaces the field-level rollup that's separately accumulated from
+        # the threshold-gated overall metrics — see docs/Advanced/aggregate-metrics.md.
+        aggregate_metrics = (process_eval.accumulator_metrics or {}).get(
+            "aggregate_metrics"
+        )
+        if aggregate_metrics:
+            agg_overall = aggregate_metrics.get("overall") or {}
+            agg_derived = agg_overall.get("derived") or {}
+            print("\nAGGREGATE METRICS (corpus rollup, ungated by match_threshold):")
+            print("-" * 40)
+            print(f"  TP: {agg_overall.get('tp', 0):,}  "
+                  f"FD: {agg_overall.get('fd', 0):,}  "
+                  f"FA: {agg_overall.get('fa', 0):,}  "
+                  f"FN: {agg_overall.get('fn', 0):,}  "
+                  f"FP: {agg_overall.get('fp', 0):,}  "
+                  f"TN: {agg_overall.get('tn', 0):,}")
+            print(f"  Precision: {agg_derived.get('cm_precision', 0.0):.4f}  "
+                  f"Recall: {agg_derived.get('cm_recall', 0.0):.4f}  "
+                  f"F1: {agg_derived.get('cm_f1', 0.0):.4f}  "
+                  f"Accuracy: {agg_derived.get('cm_accuracy', 0.0):.4f}")
+            agg_fields = aggregate_metrics.get("fields") or {}
+            if agg_fields:
+                # Sort by F1 desc for readability, mirror the field-metrics block.
+                sorted_agg = sorted(
+                    agg_fields.items(),
+                    key=lambda x: (x[1].get("derived") or {}).get("cm_f1", 0.0),
+                    reverse=True,
+                )
+                for path, counts in sorted_agg:
+                    derived = counts.get("derived") or {}
+                    tp = counts.get("tp", 0)
+                    fd = counts.get("fd", 0)
+                    fa = counts.get("fa", 0)
+                    fn = counts.get("fn", 0)
+                    if tp + fd + fa + fn == 0:
+                        continue
+                    display_path = path if len(path) <= 30 else path[:27] + "..."
+                    print(
+                        f"  {display_path:30} "
+                        f"P: {derived.get('cm_precision', 0.0):.3f} | "
+                        f"R: {derived.get('cm_recall', 0.0):.3f} | "
+                        f"F1: {derived.get('cm_f1', 0.0):.3f} | "
+                        f"TP: {tp:,} | FD: {fd:,} | FA: {fa:,} | FN: {fn:,}"
+                    )
+
         # Per-accumulator failure visibility — surfaced separately so a
         # silently-failing accumulator (whose errors don't affect the
         # confusion matrix) still shows up clearly.

--- a/src/stickler/structured_object_evaluator/bulk_structured_model_evaluator.py
+++ b/src/stickler/structured_object_evaluator/bulk_structured_model_evaluator.py
@@ -16,6 +16,9 @@ import time
 from collections import Counter, defaultdict
 from typing import IO, Any, Dict, List, Optional, Tuple, Type, Union
 
+from stickler.structured_object_evaluator.models.aggregate import (
+    AggregateConfusionMatrixAccumulator,
+)
 from stickler.structured_object_evaluator.models.confidence import (
     ConfidenceMetric,
 )
@@ -103,7 +106,7 @@ class BulkStructuredModelEvaluator:
                 ``accumulators`` — pass metrics through ``ConfidenceAccumulator``
                 instead, e.g. ``ConfidenceAccumulator(metrics=[AUROCMetric()])``.
             accumulators: Optional list of PostComparisonAccumulator instances.
-                Defaults to [ConfidenceAccumulator()].
+                Defaults to [ConfidenceAccumulator(), AggregateConfusionMatrixAccumulator()].
 
         Raises:
             ValueError: If both ``accumulators`` and ``confidence_metrics`` are set,
@@ -128,7 +131,10 @@ class BulkStructuredModelEvaluator:
         if accumulators is not None:
             self._accumulators = accumulators
         else:
-            self._accumulators = [ConfidenceAccumulator(metrics=confidence_metrics)]
+            self._accumulators = [
+                ConfidenceAccumulator(metrics=confidence_metrics),
+                AggregateConfusionMatrixAccumulator(),
+            ]
 
         # Names key accumulator_metrics; duplicates would silently overwrite.
         name_counts = Counter(acc.name for acc in self._accumulators)

--- a/src/stickler/structured_object_evaluator/models/aggregate/__init__.py
+++ b/src/stickler/structured_object_evaluator/models/aggregate/__init__.py
@@ -1,0 +1,13 @@
+"""
+Aggregate confusion-matrix accumulator for bulk evaluation.
+
+Public API:
+    AggregateConfusionMatrixAccumulator - rolls up per-document confusion
+        matrix aggregates into corpus-level totals.
+"""
+
+from stickler.structured_object_evaluator.models.aggregate.accumulator import (
+    AggregateConfusionMatrixAccumulator,
+)
+
+__all__ = ["AggregateConfusionMatrixAccumulator"]

--- a/src/stickler/structured_object_evaluator/models/aggregate/accumulator.py
+++ b/src/stickler/structured_object_evaluator/models/aggregate/accumulator.py
@@ -1,0 +1,287 @@
+"""Aggregate confusion-matrix accumulator for bulk evaluation.
+
+Rolls up per-document confusion matrix aggregates (the ``aggregate`` field
+emitted by :class:`ConfusionMatrixBuilder` when ``include_confusion_matrix=True``
+is passed to :meth:`StructuredModel.compare_with`) into corpus-level totals.
+
+Usage::
+
+    accumulator = AggregateConfusionMatrixAccumulator()
+    evaluator = BulkStructuredModelEvaluator(
+        target_schema=MyModel,
+        accumulators=[accumulator],  # included in defaults too
+    )
+    # ... drive evaluator with include_confusion_matrix=True ...
+    process_eval = evaluator.compute()
+    corpus_agg = process_eval.accumulator_metrics["aggregate_metrics"]
+    # corpus_agg["overall"]["tp"]
+    # corpus_agg["overall"]["derived"]["cm_precision"]
+    # corpus_agg["fields"]["contact.email"]["tp"]
+"""
+
+from collections import defaultdict
+from typing import Any, Dict, Optional
+
+from stickler.structured_object_evaluator.models.metrics_helper import MetricsHelper
+from stickler.structured_object_evaluator.models.post_comparison_accumulator import (
+    PostComparisonAccumulator,
+)
+
+
+_METRIC_KEYS = ("tp", "fp", "fn", "fa", "fd", "tn")
+
+
+def _join_path(prefix: str, name: str) -> str:
+    """Join a dotted field path component (mirrors bulk evaluator helper)."""
+    return f"{prefix}.{name}" if prefix else name
+
+
+def _empty_counts() -> Dict[str, int]:
+    return {k: 0 for k in _METRIC_KEYS}
+
+
+class AggregateConfusionMatrixAccumulator(PostComparisonAccumulator):
+    """Accumulates confusion matrix aggregates across documents.
+
+    Reads per-document confusion matrix results produced when
+    ``include_confusion_matrix=True`` is passed to ``compare_with``,
+    extracts the top-level ``aggregate`` block plus all nested per-field
+    aggregates, and rolls them up into corpus-level totals exposed via
+    ``ProcessEvaluation.accumulator_metrics["aggregate_metrics"]``.
+
+    State shape::
+
+        {
+            "overall": {tp, fp, fn, fa, fd, tn},
+            "fields": {
+                "dotted.field.path": {tp, fp, fn, fa, fd, tn},
+                ...
+            },
+        }
+
+    Documents that did not include a confusion matrix are silently
+    skipped — there is no warning, since mixing old (pre-feature) and
+    new results in a single corpus is an explicit goal.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the accumulator with empty state."""
+        self._metrics_helper = MetricsHelper()
+        self.reset()
+
+    @property
+    def name(self) -> str:
+        return "aggregate_metrics"
+
+    # --- lifecycle -------------------------------------------------------
+
+    def reset(self) -> None:
+        """Clear accumulated counts."""
+        self._overall: Dict[str, int] = defaultdict(int)
+        # Lazy-create per-field counts as they appear.
+        self._fields: Dict[str, Dict[str, int]] = defaultdict(_empty_counts)
+        # Track whether any document contributed; compute() returns None
+        # when nothing was accumulated, matching ConfidenceAccumulator.
+        self._docs_with_data: int = 0
+
+    # --- accumulation ----------------------------------------------------
+
+    def accumulate(
+        self,
+        comparison_result: Dict[str, Any],
+        prediction_raw: Optional[Dict[str, Any]],
+    ) -> None:
+        """Extract aggregate metrics from a single comparison result.
+
+        Silently returns without modifying state when the document did
+        not opt into ``include_confusion_matrix``.
+        """
+        confusion_matrix = comparison_result.get("confusion_matrix")
+        if not isinstance(confusion_matrix, dict):
+            # No confusion matrix recorded for this doc — skip silently.
+            return
+
+        contributed = False
+
+        top_aggregate = confusion_matrix.get("aggregate")
+        if self._add_metrics(self._overall, top_aggregate):
+            contributed = True
+
+        fields = confusion_matrix.get("fields")
+        if isinstance(fields, dict):
+            if self._accumulate_field_aggregates(fields, ""):
+                contributed = True
+
+        if contributed:
+            self._docs_with_data += 1
+
+    def _accumulate_field_aggregates(
+        self, fields: Dict[str, Any], prefix: str
+    ) -> bool:
+        """Walk a fields dict, summing each node's ``aggregate`` block.
+
+        Recurses into both ``fields`` and ``nested_fields`` children.
+        Returns True iff any metric was added at this level or below.
+        """
+        contributed = False
+        for field_name, field_data in fields.items():
+            if not isinstance(field_data, dict):
+                continue
+
+            current_path = _join_path(prefix, field_name)
+
+            if self._add_metrics(
+                self._fields[current_path], field_data.get("aggregate")
+            ):
+                contributed = True
+
+            child_fields = field_data.get("fields")
+            if isinstance(child_fields, dict):
+                if self._accumulate_field_aggregates(child_fields, current_path):
+                    contributed = True
+
+            nested_fields = field_data.get("nested_fields")
+            if isinstance(nested_fields, dict):
+                if self._accumulate_field_aggregates(nested_fields, current_path):
+                    contributed = True
+
+        return contributed
+
+    @staticmethod
+    def _add_metrics(target: Dict[str, int], source: Any) -> bool:
+        """Add tp/fp/fn/fa/fd/tn from ``source`` into ``target``.
+
+        ``source`` may be missing, ``None``, or a non-dict; in those
+        cases nothing is added. Non-numeric or negative values are
+        silently skipped per the design spec.
+
+        Returns True iff at least one metric was added.
+        """
+        if not isinstance(source, dict):
+            return False
+
+        added = False
+        for key in _METRIC_KEYS:
+            value = source.get(key)
+            if isinstance(value, bool):
+                # bool is a subclass of int; reject to avoid silent
+                # corruption from accidental True/False values.
+                continue
+            if not isinstance(value, (int, float)):
+                continue
+            if value < 0:
+                continue
+            target[key] += int(value)
+            added = True
+        return added
+
+    # --- output ----------------------------------------------------------
+
+    def compute(self) -> Optional[Dict[str, Any]]:
+        """Compute corpus-level aggregate metrics.
+
+        Returns ``None`` when no document contributed aggregate data
+        (matching the ABC contract used by other accumulators).
+        """
+        if self._docs_with_data == 0:
+            return None
+
+        overall_counts = self._counts_dict(self._overall)
+        overall_node = dict(overall_counts)
+        overall_node["derived"] = self._metrics_helper.calculate_derived_metrics(
+            overall_counts, recall_with_fd=False
+        )
+
+        field_nodes: Dict[str, Dict[str, Any]] = {}
+        for path in sorted(self._fields):
+            counts = self._counts_dict(self._fields[path])
+            node = dict(counts)
+            node["derived"] = self._metrics_helper.calculate_derived_metrics(
+                counts, recall_with_fd=False
+            )
+            field_nodes[path] = node
+
+        return {"overall": overall_node, "fields": field_nodes}
+
+    @staticmethod
+    def _counts_dict(source: Dict[str, int]) -> Dict[str, int]:
+        """Return a fresh dict with all metric keys filled (0 when absent)."""
+        return {key: int(source.get(key, 0)) for key in _METRIC_KEYS}
+
+    # --- serialization / merge ------------------------------------------
+
+    def get_state(self) -> Dict[str, Any]:
+        return {
+            "overall": self._counts_dict(self._overall),
+            "fields": {
+                path: self._counts_dict(counts)
+                for path, counts in self._fields.items()
+            },
+            "docs_with_data": self._docs_with_data,
+        }
+
+    def load_state(self, state: Dict[str, Any]) -> None:
+        self.reset()
+        overall = state.get("overall") or {}
+        if isinstance(overall, dict):
+            for key in _METRIC_KEYS:
+                value = overall.get(key, 0)
+                if isinstance(value, (int, float)) and not isinstance(value, bool):
+                    self._overall[key] = int(value)
+
+        fields = state.get("fields") or {}
+        if isinstance(fields, dict):
+            for path, counts in fields.items():
+                if not isinstance(counts, dict):
+                    continue
+                for key in _METRIC_KEYS:
+                    value = counts.get(key, 0)
+                    if isinstance(value, (int, float)) and not isinstance(value, bool):
+                        self._fields[path][key] += int(value)
+
+        # Backward compat: older states may not record docs_with_data.
+        # Treat any non-zero counts as evidence that data was accumulated.
+        docs_with_data = state.get("docs_with_data")
+        if isinstance(docs_with_data, int) and docs_with_data >= 0:
+            self._docs_with_data = docs_with_data
+        else:
+            self._docs_with_data = (
+                1
+                if any(self._overall.values())
+                or any(any(counts.values()) for counts in self._fields.values())
+                else 0
+            )
+
+    def merge_state(self, other_state: Dict[str, Any]) -> None:
+        """Additive merge of a peer accumulator's state."""
+        other_overall = other_state.get("overall") or {}
+        if isinstance(other_overall, dict):
+            for key in _METRIC_KEYS:
+                value = other_overall.get(key, 0)
+                if isinstance(value, (int, float)) and not isinstance(value, bool):
+                    self._overall[key] += int(value)
+
+        other_fields = other_state.get("fields") or {}
+        if isinstance(other_fields, dict):
+            for path, counts in other_fields.items():
+                if not isinstance(counts, dict):
+                    continue
+                for key in _METRIC_KEYS:
+                    value = counts.get(key, 0)
+                    if isinstance(value, (int, float)) and not isinstance(value, bool):
+                        self._fields[path][key] += int(value)
+
+        other_docs = other_state.get("docs_with_data", 0)
+        if isinstance(other_docs, int) and other_docs > 0:
+            self._docs_with_data += other_docs
+        elif (
+            any((other_overall or {}).get(k, 0) for k in _METRIC_KEYS)
+            or any(
+                any(counts.get(k, 0) for k in _METRIC_KEYS)
+                for counts in (other_fields or {}).values()
+                if isinstance(counts, dict)
+            )
+        ):
+            # Older peers without docs_with_data: count their state as
+            # at least one contributing document so compute() emits.
+            self._docs_with_data += 1

--- a/src/stickler/structured_object_evaluator/models/aggregate/accumulator.py
+++ b/src/stickler/structured_object_evaluator/models/aggregate/accumulator.py
@@ -62,11 +62,22 @@ class AggregateConfusionMatrixAccumulator(PostComparisonAccumulator):
     Documents that did not include a confusion matrix are silently
     skipped — there is no warning, since mixing old (pre-feature) and
     new results in a single corpus is an explicit goal.
+
+    Args:
+        recall_with_fd: When ``True``, derived ``cm_recall`` (and therefore
+            ``cm_f1``) at every level uses the include-FD formula
+            ``TP / (TP + FN + FD)``, penalizing partial matches that
+            didn't clear ``match_threshold``. When ``False`` (default),
+            uses the textbook ``TP / (TP + FN)``. Mirrors the
+            ``recall_with_fd`` knob on
+            :meth:`StructuredModel.compare_with`, kept off by default
+            so corpus-level numbers match the per-document defaults.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, recall_with_fd: bool = False) -> None:
         """Initialize the accumulator with empty state."""
         self._metrics_helper = MetricsHelper()
+        self._recall_with_fd = bool(recall_with_fd)
         self.reset()
 
     @property
@@ -189,7 +200,7 @@ class AggregateConfusionMatrixAccumulator(PostComparisonAccumulator):
         overall_counts = self._counts_dict(self._overall)
         overall_node = dict(overall_counts)
         overall_node["derived"] = self._metrics_helper.calculate_derived_metrics(
-            overall_counts, recall_with_fd=False
+            overall_counts, recall_with_fd=self._recall_with_fd
         )
 
         field_nodes: Dict[str, Dict[str, Any]] = {}
@@ -197,7 +208,7 @@ class AggregateConfusionMatrixAccumulator(PostComparisonAccumulator):
             counts = self._counts_dict(self._fields[path])
             node = dict(counts)
             node["derived"] = self._metrics_helper.calculate_derived_metrics(
-                counts, recall_with_fd=False
+                counts, recall_with_fd=self._recall_with_fd
             )
             field_nodes[path] = node
 

--- a/src/stickler/structured_object_evaluator/models/structured_list_comparator.py
+++ b/src/stickler/structured_object_evaluator/models/structured_list_comparator.py
@@ -1,14 +1,32 @@
 """
 Dedicated class for handling Hungarian matching of List[StructuredModel] fields.
 
-This class extracts the Hungarian matching logic from StructuredModel to improve
-code organization and maintainability. The extraction preserves existing behavior
-exactly, including current bugs that will be fixed in subsequent phases.
+Encapsulates the comparison logic for a list whose elements are themselves
+StructuredModel instances. It runs Hungarian matching to pair items between
+the GT and predicted lists, then produces two parallel views of the result:
+a threshold-gated view ("overall") and an ungated view ("aggregate") used
+for drill-down field-level metrics.
 
-Current Behavior Preserved (including bugs):
-- Uses parent field threshold instead of object match_threshold (bug)
-- Generates nested metrics for all matched pairs regardless of threshold (bug)
-- Object-level counting discrepancies in some scenarios (bug)
+Behavior summary:
+
+- Object-level threshold: the element model's own ``match_threshold``
+  (``StructuredModel.match_threshold`` of the list's item type) is used to
+  classify each Hungarian-matched pair. Pairs at or above threshold are
+  TP; matched pairs below threshold are FD; unmatched GT/Pred items are
+  FN/FA.
+- Zero-similarity pairs (similarity == 0.0) are treated as unmatched
+  (FN+FA), not FD. Hungarian can pair items that share no aligning fields
+  at all; treating those as FD would be misleading.
+- Per-field ``overall`` metrics are threshold-gated: only TP pairs and
+  unmatched FN/FA items contribute. FD pairs are excluded so per-field
+  ``overall`` reflects the same threshold decision as the object level.
+- Per-field ``aggregate`` metrics ALWAYS recurse through every matched
+  pair (TP and FD) and every unmatched item (FN and FA), providing a
+  complete drill-down view independent of the threshold gate.
+- Empty-list cases account properly for child leaf nodes: empty-vs-empty
+  yields TN; populated-vs-empty contributes FN/FA per populated field.
+- Nested field metrics are computed by delegating into each child model's
+  ``compare_with`` rather than re-implementing the recursion here.
 """
 
 from typing import TYPE_CHECKING, Any, Dict, List, Union, get_args, get_origin

--- a/tests/common/algorithms/test_hungarian.py
+++ b/tests/common/algorithms/test_hungarian.py
@@ -165,11 +165,12 @@ class TestHungarianMatcher:
         assert metrics["fp"] == 0
         assert metrics["fn"] == 0
 
-        # Non-matching single items
+        # Non-matching single items: zero similarity is treated as both items
+        # unmatched (FN + FA), not as a paired-but-mismatched item.
         metrics = self.matcher.calculate_metrics("apple", "banana")
         assert metrics["tp"] == 0
         assert metrics["fp"] == 1
-        assert metrics["fn"] == 0
+        assert metrics["fn"] == 1
 
     def test_string_list_parsing(self):
         """Test parsing of string representations of lists."""

--- a/tests/structured_object_evaluator/test_aggregate_accumulator.py
+++ b/tests/structured_object_evaluator/test_aggregate_accumulator.py
@@ -7,6 +7,8 @@ returned compute() output / state shape.
 
 import json
 
+import pytest
+
 from stickler.structured_object_evaluator.models.aggregate.accumulator import (
     AggregateConfusionMatrixAccumulator,
 )
@@ -306,3 +308,55 @@ class TestMergeStateIsAdditive:
 
         # Field that only exists in the peer's state shows up after merge.
         assert result["fields"]["only_in_two"]["tp"] == 4
+
+
+class TestRecallWithFdParameter:
+    """``recall_with_fd`` ctor flag controls derived recall/F1 formulas."""
+
+    @staticmethod
+    def _accumulate_one(acc):
+        # Counts chosen so the formula difference is observable:
+        #   tp=2, fn=1, fd=2  -> recall_with_fd=False  ->  2/(2+1)   = 0.667
+        #                       recall_with_fd=True   ->  2/(2+1+2) = 0.4
+        acc.accumulate(_make_result(_counts(tp=2, fn=1, fd=2)), None)
+
+    def test_default_uses_textbook_recall(self):
+        acc = AggregateConfusionMatrixAccumulator()
+        self._accumulate_one(acc)
+        result = acc.compute()
+        derived = result["overall"]["derived"]
+        # Textbook recall: TP / (TP + FN) = 2 / 3
+        assert derived["cm_recall"] == pytest.approx(2 / 3)
+
+    def test_opt_in_uses_include_fd_recall(self):
+        acc = AggregateConfusionMatrixAccumulator(recall_with_fd=True)
+        self._accumulate_one(acc)
+        result = acc.compute()
+        derived = result["overall"]["derived"]
+        # Include-FD recall: TP / (TP + FN + FD) = 2 / 5
+        assert derived["cm_recall"] == pytest.approx(2 / 5)
+
+    def test_recall_with_fd_propagates_to_per_field_derived(self):
+        acc = AggregateConfusionMatrixAccumulator(recall_with_fd=True)
+        acc.accumulate(
+            _make_result(
+                _counts(tp=2, fn=1, fd=2),
+                fields={"x": {"aggregate": _counts(tp=2, fn=1, fd=2)}},
+            ),
+            None,
+        )
+        result = acc.compute()
+        # Same formula must apply at every aggregate level, per docs.
+        assert result["fields"]["x"]["derived"]["cm_recall"] == pytest.approx(2 / 5)
+
+    def test_recall_with_fd_does_not_change_raw_counts(self):
+        # The flag only affects derived metrics. Raw counts must be identical
+        # between the two flavors so a downstream consumer can recompute.
+        acc_a = AggregateConfusionMatrixAccumulator(recall_with_fd=False)
+        acc_b = AggregateConfusionMatrixAccumulator(recall_with_fd=True)
+        for acc in (acc_a, acc_b):
+            self._accumulate_one(acc)
+        cm_keys = ("tp", "fp", "fn", "fa", "fd", "tn")
+        assert {k: acc_a.compute()["overall"][k] for k in cm_keys} == {
+            k: acc_b.compute()["overall"][k] for k in cm_keys
+        }

--- a/tests/structured_object_evaluator/test_aggregate_accumulator.py
+++ b/tests/structured_object_evaluator/test_aggregate_accumulator.py
@@ -1,0 +1,308 @@
+"""Unit tests for AggregateConfusionMatrixAccumulator.
+
+Tests the accumulator in isolation, without BulkStructuredModelEvaluator,
+by feeding hand-crafted comparison_result dicts and asserting on the
+returned compute() output / state shape.
+"""
+
+import json
+
+from stickler.structured_object_evaluator.models.aggregate.accumulator import (
+    AggregateConfusionMatrixAccumulator,
+)
+from stickler.structured_object_evaluator.models.post_comparison_accumulator import (
+    PostComparisonAccumulator,
+)
+
+
+# ── Helpers ──
+
+
+def _counts(tp=0, fp=0, fn=0, fa=0, fd=0, tn=0):
+    return {"tp": tp, "fp": fp, "fn": fn, "fa": fa, "fd": fd, "tn": tn}
+
+
+def _make_result(overall_counts, fields=None):
+    """Build a comparison_result dict shaped like ConfusionMatrixBuilder output."""
+    cm = {"aggregate": dict(overall_counts)}
+    if fields is not None:
+        cm["fields"] = fields
+    return {
+        "overall_score": 1.0,
+        "confusion_matrix": cm,
+    }
+
+
+# ── 1. ABC conformance ──
+
+
+class TestConformsToABC:
+    def test_instantiates_without_args_and_has_name(self):
+        acc = AggregateConfusionMatrixAccumulator()
+        assert isinstance(acc, PostComparisonAccumulator)
+        assert acc.name == "aggregate_metrics"
+
+
+# ── 2. reset clears state ──
+
+
+class TestResetClearsState:
+    def test_reset_after_accumulate_returns_none(self):
+        acc = AggregateConfusionMatrixAccumulator()
+        acc.accumulate(_make_result(_counts(tp=3, fp=1)), None)
+        assert acc.compute() is not None  # sanity
+        acc.reset()
+        assert acc.compute() is None
+
+
+# ── 3. empty compute returns None ──
+
+
+class TestEmptyComputeReturnsNone:
+    def test_compute_with_no_documents(self):
+        acc = AggregateConfusionMatrixAccumulator()
+        assert acc.compute() is None
+
+
+# ── 4. single doc overall ──
+
+
+class TestSingleDocumentOverall:
+    def test_single_doc_counts_match_input(self):
+        acc = AggregateConfusionMatrixAccumulator()
+        counts = _counts(tp=5, fp=2, fn=1, fa=0, fd=1, tn=4)
+        acc.accumulate(_make_result(counts), None)
+
+        result = acc.compute()
+        assert result is not None
+        overall = result["overall"]
+        for key, expected in counts.items():
+            assert overall[key] == expected
+        # Derived metrics must be present too.
+        assert "derived" in overall
+
+
+# ── 5. multi-doc overall sums ──
+
+
+class TestMultiDocumentOverallSums:
+    def test_three_docs_summed_elementwise(self):
+        acc = AggregateConfusionMatrixAccumulator()
+        a = _counts(tp=1, fp=2, fn=3, fa=0, fd=0, tn=4)
+        b = _counts(tp=5, fp=0, fn=1, fa=2, fd=1, tn=0)
+        c = _counts(tp=0, fp=3, fn=0, fa=1, fd=2, tn=7)
+
+        for d in (a, b, c):
+            acc.accumulate(_make_result(d), None)
+
+        overall = acc.compute()["overall"]
+        for key in ("tp", "fp", "fn", "fa", "fd", "tn"):
+            assert overall[key] == a[key] + b[key] + c[key]
+
+
+# ── 6. nested per-field paths flatten correctly ──
+
+
+class TestPerFieldPathsFlattenCorrectly:
+    def test_two_level_dotted_path(self):
+        acc = AggregateConfusionMatrixAccumulator()
+        fields = {
+            "parent": {
+                "aggregate": _counts(tp=1),
+                "fields": {
+                    "child": {
+                        "aggregate": _counts(tp=2, fp=1),
+                    },
+                },
+            },
+        }
+        acc.accumulate(_make_result(_counts(tp=3, fp=1), fields=fields), None)
+
+        result = acc.compute()
+        paths = result["fields"]
+        assert "parent" in paths
+        assert "parent.child" in paths
+        assert paths["parent.child"]["tp"] == 2
+        assert paths["parent.child"]["fp"] == 1
+        assert paths["parent"]["tp"] == 1
+
+
+# ── 7. three-level nesting ──
+
+
+class TestPerFieldPathNestedTwoLevels:
+    def test_three_level_dotted_path(self):
+        acc = AggregateConfusionMatrixAccumulator()
+        fields = {
+            "a": {
+                "aggregate": _counts(tp=1),
+                "fields": {
+                    "b": {
+                        "aggregate": _counts(tp=2),
+                        "fields": {
+                            "c": {
+                                "aggregate": _counts(tp=4, fp=2),
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        acc.accumulate(_make_result(_counts(tp=7, fp=2), fields=fields), None)
+
+        paths = acc.compute()["fields"]
+        assert "a" in paths
+        assert "a.b" in paths
+        assert "a.b.c" in paths
+        assert paths["a.b.c"]["tp"] == 4
+        assert paths["a.b.c"]["fp"] == 2
+
+
+# ── 8. derived metrics computed at every level ──
+
+
+class TestDerivedMetricsRecomputedAtEachLevel:
+    def test_derived_keys_present_overall_and_per_field(self):
+        acc = AggregateConfusionMatrixAccumulator()
+        fields = {
+            "name": {"aggregate": _counts(tp=2, fp=1)},
+            "price": {"aggregate": _counts(tp=1, fn=1)},
+        }
+        acc.accumulate(_make_result(_counts(tp=3, fp=1, fn=1), fields=fields), None)
+
+        result = acc.compute()
+        expected_keys = {"cm_precision", "cm_recall", "cm_f1", "cm_accuracy"}
+
+        # overall derived
+        overall_derived = result["overall"]["derived"]
+        assert expected_keys.issubset(set(overall_derived.keys()))
+
+        # per-field derived
+        for path in ("name", "price"):
+            assert "derived" in result["fields"][path]
+            assert expected_keys.issubset(set(result["fields"][path]["derived"].keys()))
+
+
+# ── 9. handles missing confusion matrix ──
+
+
+class TestHandlesMissingConfusionMatrix:
+    def test_accumulate_without_confusion_matrix_does_not_crash_or_contribute(self):
+        acc = AggregateConfusionMatrixAccumulator()
+        # No "confusion_matrix" key at all.
+        acc.accumulate({"overall_score": 0.5}, None)
+        assert acc.compute() is None
+
+    def test_confusion_matrix_none_does_not_crash(self):
+        acc = AggregateConfusionMatrixAccumulator()
+        acc.accumulate({"overall_score": 0.5, "confusion_matrix": None}, None)
+        assert acc.compute() is None
+
+
+# ── 10. handles missing aggregate key ──
+
+
+class TestHandlesMissingAggregateKey:
+    def test_legacy_confusion_matrix_without_aggregate(self):
+        acc = AggregateConfusionMatrixAccumulator()
+        # confusion_matrix exists but has no "aggregate" key and no "fields".
+        acc.accumulate(
+            {"overall_score": 1.0, "confusion_matrix": {"some_other_key": 1}},
+            None,
+        )
+        # No data was accumulated, so compute() should return None.
+        assert acc.compute() is None
+
+    def test_confusion_matrix_with_only_fields_no_top_aggregate(self):
+        acc = AggregateConfusionMatrixAccumulator()
+        # Has fields but no top-level aggregate; fields data should still be picked up.
+        acc.accumulate(
+            {
+                "overall_score": 1.0,
+                "confusion_matrix": {
+                    "fields": {"x": {"aggregate": _counts(tp=2)}},
+                },
+            },
+            None,
+        )
+        result = acc.compute()
+        assert result is not None
+        # Top-level aggregate is all zeros (nothing added there).
+        assert result["overall"]["tp"] == 0
+        # But the per-field path must have been recorded.
+        assert result["fields"]["x"]["tp"] == 2
+
+
+# ── 11. state round-trip ──
+
+
+class TestStateRoundTrip:
+    def test_get_state_jsonable_then_load_state(self):
+        acc1 = AggregateConfusionMatrixAccumulator()
+        acc1.accumulate(
+            _make_result(
+                _counts(tp=3, fp=1, fn=2, fa=1, fd=0, tn=5),
+                fields={
+                    "a": {"aggregate": _counts(tp=1)},
+                    "b": {
+                        "aggregate": _counts(tp=2, fp=1),
+                        "fields": {"c": {"aggregate": _counts(tp=1)}},
+                    },
+                },
+            ),
+            None,
+        )
+        acc1.accumulate(_make_result(_counts(tp=2, fn=1)), None)
+
+        before = acc1.compute()
+        # Round-trip through JSON to prove the state is serializable.
+        state_json = json.dumps(acc1.get_state())
+        state = json.loads(state_json)
+
+        acc2 = AggregateConfusionMatrixAccumulator()
+        acc2.load_state(state)
+        after = acc2.compute()
+
+        assert after == before
+
+
+# ── 12. merge_state is additive ──
+
+
+class TestMergeStateIsAdditive:
+    def test_two_accumulators_merge_sum_counts(self):
+        acc1 = AggregateConfusionMatrixAccumulator()
+        acc2 = AggregateConfusionMatrixAccumulator()
+
+        acc1.accumulate(
+            _make_result(
+                _counts(tp=2, fp=1),
+                fields={"shared": {"aggregate": _counts(tp=2)}},
+            ),
+            None,
+        )
+        acc2.accumulate(
+            _make_result(
+                _counts(tp=3, fp=2, fn=1),
+                fields={
+                    "shared": {"aggregate": _counts(tp=1, fp=1)},
+                    "only_in_two": {"aggregate": _counts(tp=4)},
+                },
+            ),
+            None,
+        )
+
+        acc1.merge_state(acc2.get_state())
+        result = acc1.compute()
+
+        # Overall: elementwise sum.
+        assert result["overall"]["tp"] == 2 + 3
+        assert result["overall"]["fp"] == 1 + 2
+        assert result["overall"]["fn"] == 0 + 1
+
+        # Shared field: counts add.
+        assert result["fields"]["shared"]["tp"] == 2 + 1
+        assert result["fields"]["shared"]["fp"] == 0 + 1
+
+        # Field that only exists in the peer's state shows up after merge.
+        assert result["fields"]["only_in_two"]["tp"] == 4

--- a/tests/structured_object_evaluator/test_aggregate_cases.py
+++ b/tests/structured_object_evaluator/test_aggregate_cases.py
@@ -110,6 +110,38 @@ class TestAggregation:
         assert agg_results['fp'] == 4, 'fp'
         assert agg_results['fn'] == 0, 'fn'
 
+    def test_primitive_list_zero_similarity_treated_as_unmatched(self):
+        """Regression test: single-item primitive lists with zero similarity
+        must be treated as both items unmatched (FN + FA), not as a paired-but-
+        mismatched item (FD).
+
+        Previously the HungarianMatcher single-item shortcut returned a
+        synthetic matched pair for score==0, which caused the
+        ``unordered_list_metrics`` helper to count the pair as a False
+        Discovery (fd:1, fa:0, fn:0). The correct behavior — consistent with
+        StructuredListComparator's zero-similarity handling — is to leave the
+        items unmatched, yielding fa:1, fn:1, fd:0.
+
+        See PR #115 review feedback.
+        """
+        from typing import List, Any, Optional
+
+        class Doc(StructuredModel):
+            tags: Optional[List[str]] | Any = exact_field
+
+        gt = Doc(tags=['a'])
+        pred = Doc(tags=['b'])
+
+        result = gt.compare_with(pred, include_confusion_matrix=True)
+        tags_overall = result['confusion_matrix']['fields']['tags']['overall']
+
+        assert tags_overall['fa'] == 1, f"fa: expected 1, got {tags_overall['fa']}"
+        assert tags_overall['fn'] == 1, f"fn: expected 1, got {tags_overall['fn']}"
+        assert tags_overall['fd'] == 0, f"fd: expected 0 (regression — used to be 1), got {tags_overall['fd']}"
+        assert tags_overall['tp'] == 0, f"tp: expected 0, got {tags_overall['tp']}"
+        # fp = fa + fd should remain consistent
+        assert tags_overall['fp'] == tags_overall['fa'] + tags_overall['fd'], 'fp = fa + fd'
+
 
     def test_list_structure(self):
         invoice_gt = Invoice(

--- a/tests/structured_object_evaluator/test_bulk_aggregate_integration.py
+++ b/tests/structured_object_evaluator/test_bulk_aggregate_integration.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""End-to-end integration tests for AggregateConfusionMatrixAccumulator.
+
+Pins the user-visible contract that AggregateConfusionMatrixAccumulator
+behaves correctly when wired through BulkStructuredModelEvaluator:
+
+- It is part of the default accumulator set.
+- Its corpus-level rollup equals the per-document sum (parity headline).
+- It captures the FD-recursion behavior described in
+  ``docs/Advanced/aggregate-metrics.md`` Example 2 — i.e., it includes
+  fields from below-threshold (FD) pairs and unmatched items, which the
+  bulk evaluator's own ``overall_metrics`` does not.
+- State serialization round-trips produce identical totals to a
+  single-process run (distributed eval contract).
+- Opt-out via custom ``accumulators=[...]`` is honored.
+- Empty runs produce no aggregate output (parity with other accumulators
+  that return ``None`` from ``compute()``).
+"""
+
+from typing import List, Optional
+
+import pytest
+
+from stickler.comparators.exact import ExactComparator
+from stickler.comparators.levenshtein import LevenshteinComparator
+from stickler.structured_object_evaluator.bulk_structured_model_evaluator import (
+    BulkStructuredModelEvaluator,
+)
+from stickler.structured_object_evaluator.models.aggregate import (
+    AggregateConfusionMatrixAccumulator,
+)
+from stickler.structured_object_evaluator.models.comparable_field import (
+    ComparableField,
+)
+from stickler.structured_object_evaluator.models.confidence.accumulator import (
+    ConfidenceAccumulator,
+)
+from stickler.structured_object_evaluator.models.structured_model import (
+    StructuredModel,
+)
+
+
+# --- Test models ----------------------------------------------------------
+
+
+class _Contact(StructuredModel):
+    """Simple nested contact for primitive-only aggregation tests."""
+
+    phone: str = ComparableField(
+        comparator=ExactComparator(), threshold=1.0, weight=1.0
+    )
+    email: Optional[str] = ComparableField(
+        default=None, comparator=ExactComparator(), threshold=1.0, weight=1.0
+    )
+
+
+class _Person(StructuredModel):
+    """Top-level model with a primitive + nested object."""
+
+    name: str = ComparableField(
+        comparator=ExactComparator(), threshold=1.0, weight=1.0
+    )
+    contact: _Contact = ComparableField(weight=1.0)
+
+
+class _LineItem(StructuredModel):
+    """List-of-StructuredModel element from docs Example 2.
+
+    ``match_threshold = 0.6`` lets us construct (sku/description/qty)
+    triples whose combined similarity falls below 0.6 — making them FD
+    at the object level — while still leaving leaf fields available for
+    aggregate recursion (which is the headline behavior tested in
+    ``test_list_of_structured_model_with_threshold_gating``).
+    """
+
+    match_threshold = 0.6
+    sku: str = ComparableField(
+        comparator=ExactComparator(), threshold=1.0, weight=2.0
+    )
+    description: str = ComparableField(
+        comparator=LevenshteinComparator(), threshold=0.7, weight=1.0
+    )
+    qty: int = ComparableField(
+        comparator=ExactComparator(), threshold=1.0, weight=1.0
+    )
+
+
+class _Invoice(StructuredModel):
+    invoice_id: str = ComparableField(
+        comparator=ExactComparator(), threshold=1.0
+    )
+    items: List[_LineItem] = ComparableField(weight=1.0)
+
+
+# --- Helpers --------------------------------------------------------------
+
+
+_METRIC_KEYS = ("tp", "fp", "fn", "fa", "fd", "tn")
+
+
+def _zero_counts() -> dict:
+    return {k: 0 for k in _METRIC_KEYS}
+
+
+def _add_counts(target: dict, source: dict) -> None:
+    """Sum tp/fp/fn/fa/fd/tn from ``source`` into ``target`` in place.
+
+    Mirrors AggregateConfusionMatrixAccumulator._add_metrics so the
+    parity test computes a "manual ground truth" with the exact same
+    semantics the accumulator is supposed to implement.
+    """
+    if not isinstance(source, dict):
+        return
+    for key in _METRIC_KEYS:
+        value = source.get(key, 0)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, (int, float)) and value >= 0:
+            target[key] += int(value)
+
+
+def _make_person_pair(idx: int) -> tuple:
+    """Build a (gt, pred) Person pair with a deterministic mismatch pattern.
+
+    ``idx`` controls which fields differ so the corpus exercises a mix
+    of TP/FD/FN across documents — without that variety the parity test
+    only proves "summing zeros equals zeros."
+    """
+    gt = _Person(
+        name=f"name_{idx}",
+        contact=_Contact(phone=f"555-{idx:04d}", email=f"u{idx}@example.com"),
+    )
+    if idx % 3 == 0:
+        # Perfect match — TPs at every leaf.
+        pred = _Person(
+            name=f"name_{idx}",
+            contact=_Contact(phone=f"555-{idx:04d}", email=f"u{idx}@example.com"),
+        )
+    elif idx % 3 == 1:
+        # Phone wrong → 1 FD on contact.phone, rest TP.
+        pred = _Person(
+            name=f"name_{idx}",
+            contact=_Contact(phone="000-0000", email=f"u{idx}@example.com"),
+        )
+    else:
+        # Email missing → 1 FN on contact.email; name still TP.
+        pred = _Person(
+            name=f"name_{idx}",
+            contact=_Contact(phone=f"555-{idx:04d}", email=None),
+        )
+    return gt, pred
+
+
+# --- Tests ---------------------------------------------------------------
+
+
+class TestDefaultAccumulators:
+    """The aggregate accumulator must be wired in by default — otherwise
+    every existing user picks up no new behavior on upgrade."""
+
+    def test_default_includes_aggregate_accumulator(self):
+        evaluator = BulkStructuredModelEvaluator(target_schema=_Person)
+
+        # (a) The instance carries it…
+        names = [acc.name for acc in evaluator._accumulators]
+        assert "aggregate_metrics" in names
+        assert any(
+            isinstance(acc, AggregateConfusionMatrixAccumulator)
+            for acc in evaluator._accumulators
+        )
+
+        # (b) …and after running, it surfaces in accumulator_metrics.
+        gt, pred = _make_person_pair(0)
+        evaluator.update(gt, pred, "doc0")
+        result = evaluator.compute()
+
+        assert result.accumulator_metrics is not None
+        assert "aggregate_metrics" in result.accumulator_metrics
+        agg = result.accumulator_metrics["aggregate_metrics"]
+        assert "overall" in agg
+        assert "fields" in agg
+
+
+class TestParityWithPerDocSum:
+    """Headline test: bulk-rolled aggregate equals manual sum of per-doc
+    ``confusion_matrix['aggregate']`` blocks. If this drifts the feature
+    is broken regardless of whether other tests still pass."""
+
+    def test_bulk_aggregate_parity_with_per_doc_sum(self):
+        pairs = [_make_person_pair(i) for i in range(5)]
+
+        # Bulk path — the system under test.
+        evaluator = BulkStructuredModelEvaluator(target_schema=_Person)
+        for i, (gt, pred) in enumerate(pairs):
+            evaluator.update(gt, pred, f"doc_{i}")
+        bulk_result = evaluator.compute()
+
+        bulk_agg_overall = bulk_result.accumulator_metrics["aggregate_metrics"][
+            "overall"
+        ]
+
+        # Manual reference path — sum each document's top-level aggregate.
+        manual = _zero_counts()
+        for gt, pred in pairs:
+            cm = gt.compare_with(pred, include_confusion_matrix=True)[
+                "confusion_matrix"
+            ]
+            _add_counts(manual, cm.get("aggregate"))
+
+        for key in _METRIC_KEYS:
+            assert bulk_agg_overall[key] == manual[key], (
+                f"aggregate.overall[{key}] mismatch: "
+                f"bulk={bulk_agg_overall[key]} manual={manual[key]}"
+            )
+
+        # Sanity: at least one TP and one non-TP outcome present, else
+        # the parity assertion above would be a vacuous "0 == 0".
+        assert manual["tp"] > 0
+        assert (manual["fd"] + manual["fn"] + manual["fa"]) > 0
+
+
+class TestListOfStructuredModelThresholdGating:
+    """The whole reason the aggregate accumulator exists: per-doc
+    ``aggregate`` recurses into FD-classified pairs and unmatched items,
+    while the bulk evaluator's own ``overall_metrics`` does not. The
+    accumulator must therefore expose strictly more leaf-level signal
+    than ``overall_metrics`` for fields below an FD list element."""
+
+    def test_list_of_structured_model_with_threshold_gating(self):
+        # Mirrors docs/Advanced/aggregate-metrics.md Example 2.
+        gt = _Invoice(
+            invoice_id="INV-001",
+            items=[
+                _LineItem(sku="AAA", description="Widget", qty=10),
+                _LineItem(sku="BBB", description="Gadget", qty=5),
+                _LineItem(sku="CCC", description="Cable", qty=2),
+            ],
+        )
+        pred = _Invoice(
+            invoice_id="INV-001",
+            items=[
+                _LineItem(sku="AAA", description="Widget", qty=10),
+                _LineItem(
+                    sku="BBB", description="Completely Wrong", qty=99
+                ),
+            ],
+        )
+
+        evaluator = BulkStructuredModelEvaluator(target_schema=_Invoice)
+        evaluator.update(gt, pred, "doc_invoice")
+        result = evaluator.compute()
+
+        agg = result.accumulator_metrics["aggregate_metrics"]
+        agg_overall = agg["overall"]
+        agg_fields = agg["fields"]
+
+        # Per the docs example: at the items level the per-doc aggregate
+        # is tp=4, fd=2, fn=3 — the FD pair (BBB) and unmatched CCC
+        # contribute leaf counts. Bulk should pass that through unchanged
+        # for a 1-document run.
+        assert agg_fields["items"]["tp"] == 4
+        assert agg_fields["items"]["fd"] == 2
+        assert agg_fields["items"]["fn"] == 3
+
+        # Top-level aggregate adds invoice_id (1 TP) on top of items.
+        assert agg_overall["tp"] == 5
+        assert agg_overall["fd"] == 2
+        assert agg_overall["fn"] == 3
+
+        # Headline contract: aggregate exposes leaf signal that
+        # field_metrics["items"] does not. The bulk field_metrics
+        # records the items list field's threshold-gated counts only —
+        # so its ``fd`` should equal the object-level fd (1), strictly
+        # less than the aggregate fd of 2 (which includes the leaf FDs
+        # produced by the BBB pair's description and qty fields).
+        items_field_metrics = result.field_metrics["items"]
+        assert items_field_metrics.get("fd", 0) == 1
+        assert agg_fields["items"]["fd"] > items_field_metrics.get("fd", 0)
+
+    def test_aggregate_records_per_field_paths_below_list(self):
+        """Per-leaf paths under the list (``items.sku`` etc.) must be
+        present in aggregate's ``fields`` dict — that's the structure
+        downstream consumers query on."""
+        gt = _Invoice(
+            invoice_id="INV-001",
+            items=[
+                _LineItem(sku="AAA", description="Widget", qty=10),
+                _LineItem(sku="BBB", description="Gadget", qty=5),
+            ],
+        )
+        pred = _Invoice(
+            invoice_id="INV-001",
+            items=[
+                _LineItem(sku="AAA", description="Widget", qty=10),
+                _LineItem(
+                    sku="BBB", description="Completely Wrong", qty=99
+                ),
+            ],
+        )
+
+        evaluator = BulkStructuredModelEvaluator(target_schema=_Invoice)
+        evaluator.update(gt, pred, "doc_invoice")
+        result = evaluator.compute()
+
+        agg_fields = result.accumulator_metrics["aggregate_metrics"]["fields"]
+
+        # Leaf paths below the list field must be addressable.
+        for leaf in ("items.sku", "items.description", "items.qty"):
+            assert leaf in agg_fields, f"missing aggregate path: {leaf}"
+
+
+class TestDistributedEvalRoundTrip:
+    """Distributed eval contract: serialize-merge-compute on N shards
+    must equal compute on the union. The aggregate accumulator's state
+    is part of ``BulkStructuredModelEvaluator.get_state()`` and is
+    merged in by ``merge_state``; if either side regresses, sharded runs
+    silently lose data. This test pins both round-trips together."""
+
+    def test_distributed_eval_round_trip(self):
+        all_pairs = [_make_person_pair(i) for i in range(6)]
+        shard_a = all_pairs[:3]
+        shard_b = all_pairs[3:]
+
+        # Shard A
+        ev_a = BulkStructuredModelEvaluator(target_schema=_Person)
+        for i, (gt, pred) in enumerate(shard_a):
+            ev_a.update(gt, pred, f"a_{i}")
+
+        # Shard B
+        ev_b = BulkStructuredModelEvaluator(target_schema=_Person)
+        for i, (gt, pred) in enumerate(shard_b):
+            ev_b.update(gt, pred, f"b_{i}")
+
+        # Merge B's state into A and compute.
+        ev_a.merge_state(ev_b.get_state())
+        merged_result = ev_a.compute()
+        merged_agg = merged_result.accumulator_metrics["aggregate_metrics"][
+            "overall"
+        ]
+
+        # Single-process reference run.
+        ev_ref = BulkStructuredModelEvaluator(target_schema=_Person)
+        for i, (gt, pred) in enumerate(all_pairs):
+            ev_ref.update(gt, pred, f"ref_{i}")
+        ref_agg = ev_ref.compute().accumulator_metrics["aggregate_metrics"][
+            "overall"
+        ]
+
+        for key in _METRIC_KEYS:
+            assert merged_agg[key] == ref_agg[key], (
+                f"merged.aggregate.overall[{key}] != single-process: "
+                f"merged={merged_agg[key]} ref={ref_agg[key]}"
+            )
+
+        # Sanity: at least one count was actually accumulated, else
+        # 0==0 would pass without exercising the merge path.
+        assert ref_agg["tp"] > 0
+
+
+class TestOptOutViaCustomAccumulators:
+    """A user who explicitly passes ``accumulators=[...]`` without the
+    aggregate accumulator must NOT get aggregate_metrics in the output.
+    Default-injection must not silently override an explicit list."""
+
+    def test_opt_out_via_custom_accumulators(self):
+        evaluator = BulkStructuredModelEvaluator(
+            target_schema=_Person,
+            accumulators=[ConfidenceAccumulator()],
+        )
+
+        # Sanity: only the one accumulator is wired up.
+        assert [acc.name for acc in evaluator._accumulators] == [
+            "confidence_metrics"
+        ]
+
+        gt, pred = _make_person_pair(0)
+        evaluator.update(gt, pred, "doc0")
+        result = evaluator.compute()
+
+        # Either no accumulator_metrics at all (None when nothing
+        # contributed), or the dict simply lacks aggregate_metrics.
+        if result.accumulator_metrics is not None:
+            assert "aggregate_metrics" not in result.accumulator_metrics
+
+
+class TestEmptyEvaluation:
+    """Zero-document runs must not synthesize an empty aggregate block —
+    the accumulator's ``compute()`` returns ``None`` when nothing
+    contributed, and the bulk evaluator filters those out before
+    populating ``ProcessEvaluation.accumulator_metrics``."""
+
+    def test_empty_evaluation_no_aggregate(self):
+        evaluator = BulkStructuredModelEvaluator(target_schema=_Person)
+        result = evaluator.compute()
+
+        # Either the whole field is None (no accumulator produced
+        # output) or, if some other accumulator contributed an empty
+        # block, aggregate_metrics is still absent / falsy.
+        if result.accumulator_metrics is None:
+            return
+
+        agg = result.accumulator_metrics.get("aggregate_metrics")
+        assert agg is None or (
+            agg.get("overall", {}).get("tp", 0) == 0
+            and agg.get("overall", {}).get("fp", 0) == 0
+            and agg.get("overall", {}).get("fn", 0) == 0
+            and agg.get("overall", {}).get("fd", 0) == 0
+            and agg.get("overall", {}).get("fa", 0) == 0
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/structured_object_evaluator/test_bulk_aggregate_integration.py
+++ b/tests/structured_object_evaluator/test_bulk_aggregate_integration.py
@@ -411,3 +411,111 @@ class TestEmptyEvaluation:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestBulkEvaluatorStateLifecycle:
+    """The bulk evaluator's own ``get_state`` / ``load_state`` walk every
+    registered accumulator. Verify that the aggregate accumulator's
+    counts survive a serialize-via-bulk → load-via-bulk round trip,
+    not just the in-process ``merge_state`` path covered by
+    :class:`TestDistributedEvalRoundTrip`.
+    """
+
+    def _person_pair(self, gt_email, pred_email):
+        gt = _Person(name="A", contact=_Contact(phone="1", email=gt_email))
+        pred = _Person(name="A", contact=_Contact(phone="1", email=pred_email))
+        return gt, pred
+
+    def test_aggregate_state_survives_get_load_round_trip(self):
+        """Serialize from one evaluator, load into a fresh one — corpus
+        rollup must match what a single evaluator would have produced.
+        """
+        # Run a partial corpus through evaluator A.
+        ev_a = BulkStructuredModelEvaluator(target_schema=_Person)
+        for gt_email, pred_email in [
+            ("john@x.com", "john@x.com"),
+            ("ann@x.com",  "ann@x.com"),
+            ("bob@x.com",  "wrong@x.com"),
+        ]:
+            gt, pred = self._person_pair(gt_email, pred_email)
+            ev_a.update(gt, pred, doc_id=f"d_{gt_email}")
+
+        # Serialize via the bulk evaluator's own get_state and load
+        # into a fresh instance.
+        state = ev_a.get_state()
+        ev_b = BulkStructuredModelEvaluator(target_schema=_Person)
+        ev_b.load_state(state)
+
+        # compute() output must agree on aggregate_metrics.
+        agg_a = ev_a.compute().accumulator_metrics["aggregate_metrics"]
+        agg_b = ev_b.compute().accumulator_metrics["aggregate_metrics"]
+        assert agg_a["overall"] == agg_b["overall"]
+        assert agg_a["fields"] == agg_b["fields"]
+
+    def test_load_state_then_more_pairs_combines_correctly(self):
+        """After load_state, evaluating more pairs must additively
+        contribute to the aggregate rollup.
+        """
+        # Run pairs through evaluator A.
+        ev_a = BulkStructuredModelEvaluator(target_schema=_Person)
+        for gt_email, pred_email in [
+            ("john@x.com", "john@x.com"),
+            ("ann@x.com",  "ann@x.com"),
+        ]:
+            gt, pred = self._person_pair(gt_email, pred_email)
+            ev_a.update(gt, pred, doc_id=f"first_{gt_email}")
+
+        # Hand off state to evaluator B, then keep going.
+        state_after_first = ev_a.get_state()
+        ev_b = BulkStructuredModelEvaluator(target_schema=_Person)
+        ev_b.load_state(state_after_first)
+        for gt_email, pred_email in [
+            ("bob@x.com", "wrong@x.com"),
+            ("zoe@x.com", "zoe@x.com"),
+        ]:
+            gt, pred = self._person_pair(gt_email, pred_email)
+            ev_b.update(gt, pred, doc_id=f"second_{gt_email}")
+
+        # And separately, run all 4 through a single evaluator.
+        ev_full = BulkStructuredModelEvaluator(target_schema=_Person)
+        for gt_email, pred_email in [
+            ("john@x.com", "john@x.com"),
+            ("ann@x.com",  "ann@x.com"),
+            ("bob@x.com",  "wrong@x.com"),
+            ("zoe@x.com",  "zoe@x.com"),
+        ]:
+            gt, pred = self._person_pair(gt_email, pred_email)
+            ev_full.update(gt, pred, doc_id=f"full_{gt_email}")
+
+        # The continued-from-state corpus and the single-pass corpus
+        # must produce identical aggregate metrics.
+        agg_b = ev_b.compute().accumulator_metrics["aggregate_metrics"]
+        agg_full = ev_full.compute().accumulator_metrics["aggregate_metrics"]
+        assert agg_b["overall"] == agg_full["overall"]
+        assert agg_b["fields"] == agg_full["fields"]
+
+
+class TestPrettyPrintSurfacesAggregate:
+    """``BulkStructuredModelEvaluator.pretty_print_metrics()`` must
+    surface the corpus-level aggregate slice when the accumulator is
+    enabled. Pinning the section heading and a recognisable derived
+    metric line is enough to catch a regression where the new section
+    is accidentally dropped from the printer.
+    """
+
+    def test_pretty_print_includes_aggregate_section(self, capsys):
+        ev = BulkStructuredModelEvaluator(target_schema=_Person)
+        gt, pred = _Person(name="A", contact=_Contact(phone="1", email="a@x")), \
+                   _Person(name="A", contact=_Contact(phone="2", email="a@x"))
+        ev.update(gt, pred, doc_id="d1")
+
+        ev.pretty_print_metrics()
+        out = capsys.readouterr().out
+
+        assert "AGGREGATE METRICS" in out, (
+            "pretty_print_metrics must surface the corpus-level "
+            "aggregate rollup. Output:\n" + out
+        )
+        # And the per-field path block should print at least one line
+        # with the dotted-path convention.
+        assert "Precision:" in out

--- a/tests/structured_object_evaluator/test_confidence_metrics.py
+++ b/tests/structured_object_evaluator/test_confidence_metrics.py
@@ -1421,7 +1421,11 @@ class TestBulkEvaluatorConstructionConflicts:
             target_schema=Product,
             confidence_metrics=[AUROCMetric(), BrierScoreMetric()],
         )
-        assert len(ev._accumulators) == 1
+        # Defaults: ConfidenceAccumulator + AggregateConfusionMatrixAccumulator.
+        assert [acc.name for acc in ev._accumulators] == [
+            "confidence_metrics",
+            "aggregate_metrics",
+        ]
 
     def test_duplicate_accumulator_names_raise(self):
         """Two accumulators with the same .name silently overwrite each

--- a/tests/structured_object_evaluator/test_ecommerce_orders_aggregate_comprehensive.py
+++ b/tests/structured_object_evaluator/test_ecommerce_orders_aggregate_comprehensive.py
@@ -376,13 +376,13 @@ class TestEcommerceOrdersAggregateComprehensive:
         assert cm["fields"]["Products"]["fields"]["Product_Id"]["aggregate"]["fn"] == 0, f'Expected Product_Id aggregate FN=0, got {cm["fields"]["Products"]["fields"]["Product_Id"]["aggregate"]["fn"]}'
 
         # gt_json["Products"][0]["Product_Category"], pred_json["Products"][0]["Product_Category"]:  1 true positive
-        # gt_json["Products"][1]["Product_Category"], pred_json["Products"][1]["Product_Category"]:  1 false discovery
+        # gt_json["Products"][1]["Product_Category"], pred_json["Products"][1]["Product_Category"]:  zero similarity → both items unmatched (1 FN + 1 FA)
         # Category_Name fields should be ignored since CategoryOnly model only defines Category_Code field, not Category_Name field
         assert cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["tp"] == 1, f'Expected Product_Category aggregate TP=1, got {cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["tp"]}'
-        assert cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["fa"] == 0, f'Expected Product_Category aggregate FA=0, got {cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["fa"]}'
-        assert cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["fd"] == 1, f'Expected Product_Category aggregate FD=1, got {cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["fa"] == 1, f'Expected Product_Category aggregate FA=1, got {cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["fd"] == 0, f'Expected Product_Category aggregate FD=0, got {cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["fd"]}'
         assert cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["tn"] == 0, f'Expected Product_Category aggregate TN=0, got {cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["tn"]}'
-        assert cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["fn"] == 0, f'Expected Product_Category aggregate FN=0, got {cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["fn"]}'
+        assert cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["fn"] == 1, f'Expected Product_Category aggregate FN=1, got {cm["fields"]["Products"]["fields"]["Product_Category"]["aggregate"]["fn"]}'
 
         # at the object level with match_threshold = 1.0, 1 true positve, 1 false discovery (2 entries are matched, but only one match is above threshold)
         assert cm["fields"]["Products"]["overall"]["tp"] == 1, f'Expected Products overall TP=1, got {cm["fields"]["Products"]["overall"]["tp"]}'
@@ -391,12 +391,16 @@ class TestEcommerceOrdersAggregateComprehensive:
         assert cm["fields"]["Products"]["overall"]["tn"] == 0, f'Expected Products overall TN=0, got {cm["fields"]["Products"]["overall"]["tn"]}'
         assert cm["fields"]["Products"]["overall"]["fn"] == 0, f'Expected Products overall FN=0, got {cm["fields"]["Products"]["overall"]["fn"]}'
 
-        # at the field level within all matched entries (2 matched entries are considered for the sub field comparison)     
+        # at the field level within all matched entries:
+        # 3 TP from Product_Id (both match) and Product_Category[0] (codes match)
+        # Product_Category[1] (codes "01" vs "02") has zero similarity at the
+        # inner single-item list, so its items are treated as unmatched
+        # (1 FN + 1 FA), not as a paired False Discovery.
         assert cm["fields"]["Products"]["aggregate"]["tp"] == 3, f'Expected Products aggregate TP=3, got {cm["fields"]["Products"]["aggregate"]["tp"]}'
-        assert cm["fields"]["Products"]["aggregate"]["fa"] == 0, f'Expected Products aggregate FA=0, got {cm["fields"]["Products"]["aggregate"]["fa"]}'
-        assert cm["fields"]["Products"]["aggregate"]["fd"] == 1, f'Expected Products aggregate FD=1, got {cm["fields"]["Products"]["aggregate"]["fd"]}'
+        assert cm["fields"]["Products"]["aggregate"]["fa"] == 1, f'Expected Products aggregate FA=1, got {cm["fields"]["Products"]["aggregate"]["fa"]}'
+        assert cm["fields"]["Products"]["aggregate"]["fd"] == 0, f'Expected Products aggregate FD=0, got {cm["fields"]["Products"]["aggregate"]["fd"]}'
         assert cm["fields"]["Products"]["aggregate"]["tn"] == 0, f'Expected Products aggregate TN=0, got {cm["fields"]["Products"]["aggregate"]["tn"]}'
-        assert cm["fields"]["Products"]["aggregate"]["fn"] == 0, f'Expected Products aggregate FN=0, got {cm["fields"]["Products"]["aggregate"]["fn"]}'
+        assert cm["fields"]["Products"]["aggregate"]["fn"] == 1, f'Expected Products aggregate FN=1, got {cm["fields"]["Products"]["aggregate"]["fn"]}'
 
     def test_discounts_field_aggregate_counts(self):
         """Test the Discounts field aggregate counts."""
@@ -462,11 +466,14 @@ class TestEcommerceOrdersAggregateComprehensive:
         aggregate = cm["aggregate"]
         
         assert aggregate["tp"] == 20, f'Expected TP=20, got {aggregate["tp"]}'
-        assert aggregate["fa"] == 2, f'Expected FA=2, got {aggregate["fa"]}'
-        assert aggregate["fd"] == 5, f'Expected FD=5, got {aggregate["fd"]}'
+        # Single-item primitive/structured lists with zero similarity now count
+        # as unmatched (FA + FN) rather than paired False Discovery (FD), so
+        # one entry shifts from FD into both FA and FN.
+        assert aggregate["fa"] == 3, f'Expected FA=3, got {aggregate["fa"]}'
+        assert aggregate["fd"] == 4, f'Expected FD=4, got {aggregate["fd"]}'
         # 5 TN: Order_Info.Order_Status.Category_Code, Order_Info.Store_Location, Customers.Loyalty_Status.Category_Code, Customers.Loyalty_Status.Category_Name, Discounts.Discount_Code
-        assert aggregate["tn"] == 5, f'Expected TN=5, got {aggregate["tn"]}' 
-        assert aggregate["fn"] == 10, f'Expected FN=10, got {aggregate["fn"]}'
+        assert aggregate["tn"] == 5, f'Expected TN=5, got {aggregate["tn"]}'
+        assert aggregate["fn"] == 11, f'Expected FN=11, got {aggregate["fn"]}'
         
     def test_hungarian_matching_verification(self):
         """Test that Hungarian matching works correctly for the Customers list."""
@@ -667,13 +674,67 @@ class TestEcommerceOrdersAggregateComprehensive:
         
         result = gt_order.compare_with(pred_order, include_confusion_matrix=True)
         cm = result["confusion_matrix"]
-        
-        # Verify that threshold-based classification affects aggregates correctly
+
+        # Threshold-based classification per child of Order_Info:
+        #   Order_Status: list with one identical {Category_Code:"A", Category_Name:"EXACT MATCH"}
+        #                 -> object-level TP=1, aggregate TP=2 (one per leaf: Code + Name)
+        #   Total_Amount: "5" == "5" exact (NumericComparator threshold=1.0) -> TP=1
+        #   Store_Location: "TEST" == "TEST" exact (ExactComparator threshold=1.0) -> TP=1
+        #   Payment_Method: empty lists both sides -> object-level TN=1, aggregate TN=2
+        #                   (one per leaf in CategoryDescription: Code + Name)
+        #   Order_Notes: "exact notes" vs "different notes" via LevenshteinComparator threshold=0.75
+        #                -> similarity below threshold -> FD=1
+        order_info_fields = cm["fields"]["Order_Info"]["fields"]
+
+        # Order_Status: identical single-item list, object TP=1, aggregate TP=2 (Code+Name)
+        assert order_info_fields["Order_Status"]["overall"]["tp"] == 1
+        assert order_info_fields["Order_Status"]["aggregate"]["tp"] == 2
+        assert order_info_fields["Order_Status"]["aggregate"]["fd"] == 0
+        assert order_info_fields["Order_Status"]["aggregate"]["tn"] == 0
+        assert order_info_fields["Order_Status"]["aggregate"]["fn"] == 0
+        assert order_info_fields["Order_Status"]["aggregate"]["fa"] == 0
+
+        # Total_Amount: leaf TP=1
+        assert order_info_fields["Total_Amount"]["aggregate"]["tp"] == 1
+        assert order_info_fields["Total_Amount"]["aggregate"]["fd"] == 0
+        assert order_info_fields["Total_Amount"]["aggregate"]["tn"] == 0
+
+        # Store_Location: leaf TP=1
+        assert order_info_fields["Store_Location"]["aggregate"]["tp"] == 1
+        assert order_info_fields["Store_Location"]["aggregate"]["fd"] == 0
+        assert order_info_fields["Store_Location"]["aggregate"]["tn"] == 0
+
+        # Payment_Method: empty list -> object TN=1, aggregate TN=2 (one per child leaf)
+        assert order_info_fields["Payment_Method"]["overall"]["tn"] == 1
+        assert order_info_fields["Payment_Method"]["aggregate"]["tn"] == 2
+        assert order_info_fields["Payment_Method"]["aggregate"]["tp"] == 0
+        assert order_info_fields["Payment_Method"]["aggregate"]["fd"] == 0
+
+        # Order_Notes: below-threshold mismatch -> FD=1
+        assert order_info_fields["Order_Notes"]["aggregate"]["tp"] == 0
+        assert order_info_fields["Order_Notes"]["aggregate"]["fd"] == 1
+        assert order_info_fields["Order_Notes"]["aggregate"]["tn"] == 0
+
+        # Order_Info object-level: match_threshold default (mean similarity drops below 1.0
+        # because Order_Notes is below its threshold), so object-level is FD=1, TP=0
+        order_info_overall = cm["fields"]["Order_Info"]["overall"]
+        assert order_info_overall["tp"] == 0
+        assert order_info_overall["fd"] == 1
+        assert order_info_overall["fa"] == 0
+        assert order_info_overall["tn"] == 0
+        assert order_info_overall["fn"] == 0
+
+        # Order_Info aggregate (sum of all leaf-level counts under Order_Info):
+        #   TP: 2 (Order_Status: Code + Name) + 1 (Total_Amount) + 1 (Store_Location) = 4
+        #   FD: 1 (Order_Notes)
+        #   TN: 2 (Payment_Method: Code + Name leaves on empty list)
+        #   FA: 0, FN: 0
         order_info_agg = cm["fields"]["Order_Info"]["aggregate"]
-        
-        # We should have some TPs and potentially some FDs based on thresholds
-        assert order_info_agg["tp"] > 0, "Should have some true positives"
-        assert order_info_agg["tp"] + order_info_agg["fd"] + order_info_agg["tn"] > 0, "Should have some classifications"
+        assert order_info_agg["tp"] == 4, f'Expected Order_Info aggregate TP=4, got {order_info_agg["tp"]}'
+        assert order_info_agg["fd"] == 1, f'Expected Order_Info aggregate FD=1, got {order_info_agg["fd"]}'
+        assert order_info_agg["tn"] == 2, f'Expected Order_Info aggregate TN=2, got {order_info_agg["tn"]}'
+        assert order_info_agg["fa"] == 0, f'Expected Order_Info aggregate FA=0, got {order_info_agg["fa"]}'
+        assert order_info_agg["fn"] == 0, f'Expected Order_Info aggregate FN=0, got {order_info_agg["fn"]}'
 
 
 if __name__ == "__main__":

--- a/tests/structured_object_evaluator/test_threshold_gated_recursion.py
+++ b/tests/structured_object_evaluator/test_threshold_gated_recursion.py
@@ -334,6 +334,55 @@ def test_threshold_boundary_conditions():
             )
 
 
+class _ZeroSimItem(StructuredModel):
+    """Tiny model whose only field is an exact-match string.
+
+    With ExactComparator on the only field, two items with non-equal values
+    produce a Hungarian similarity of exactly 0.0.
+    """
+
+    value: str = ComparableField(comparator=ExactComparator(), threshold=1.0)
+
+
+class _ZeroSimContainer(StructuredModel):
+    """Container of _ZeroSimItem so we exercise List[StructuredModel]."""
+
+    items: List[_ZeroSimItem] = ComparableField(weight=1.0)
+
+
+def test_zero_similarity_pair_is_unmatched_not_fd():
+    """A Hungarian-matched pair with similarity exactly 0.0 must be FN+FA, not FD.
+
+    Pinning this catches a mutation of ``> 0.0`` to ``>= 0.0`` in
+    ``StructuredListComparator``. Without this filter, Hungarian's
+    bookkeeping would call a totally non-overlapping pair an FD
+    ("matched but below threshold"), which is misleading: the items
+    share no fields at all, so they ought to surface as one missing
+    GT and one spurious prediction.
+
+    Uses two items per side so Hungarian must produce real pair
+    assignments (the single-item-vs-single-item shortcut bypasses the
+    branch we want to guard).
+    """
+    gt = _ZeroSimContainer(
+        items=[_ZeroSimItem(value="alpha"), _ZeroSimItem(value="beta")]
+    )
+    pred = _ZeroSimContainer(
+        items=[_ZeroSimItem(value="gamma"), _ZeroSimItem(value="delta")]
+    )
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    items_overall = result["confusion_matrix"]["fields"]["items"]["overall"]
+
+    assert items_overall["fn"] == 2, f"expected fn=2, got {items_overall}"
+    assert items_overall["fa"] == 2, f"expected fa=2, got {items_overall}"
+    assert items_overall["fd"] == 0, (
+        "zero-similarity pairs must NOT be classified as FD; "
+        f"got fd={items_overall['fd']}"
+    )
+    assert items_overall["tp"] == 0, f"expected tp=0, got {items_overall}"
+
+
 if __name__ == "__main__":
     print("Running threshold-gated recursion tests...")
 
@@ -342,5 +391,6 @@ if __name__ == "__main__":
     test_threshold_gated_mixed_scenario()
     test_threshold_gated_empty_lists()
     test_threshold_boundary_conditions()
+    test_zero_similarity_pair_is_unmatched_not_fd()
 
     print("All tests completed!")


### PR DESCRIPTION
Fixes documentation accuracy and one regression caught during review. Adds boundary-case tests that pin invariants the docs claim but were not exercised before. All test deltas reflect actual code behavior; no behavior loosening.

Documentation
- aggregate-metrics.md: added a "Why aggregates?" motivation section that contrasts overall (object-level, threshold-gated) with aggregate (field-level rollup across all items) so readers see the problem the feature solves before diving into mechanics.
- aggregate-metrics.md Example 2: per-field `overall` JSON corrected to {tp:1, fd:0, fn:1} for sku/description/qty (the BBB FD pair is threshold-gated out of `overall` but still appears in `aggregate`). Added prose contrasting `overall` vs `aggregate` so the example is coherent end-to-end.
- aggregate-metrics.md: appended a "Common pitfalls" section with five linkable subsections (overall vs aggregate divergence, zero-similarity pair handling, empty-list semantics, bulk evaluator not yet rolling up aggregate, recall_with_fd flag).
- threshold-gated-evaluation.md "Result Structure" worked example: reframed from 3 GT vs 3 Pred (which Hungarian fully pairs, making the documented {tp:1, fd:1, fn:1, fa:1} unreachable) to 3 GT vs 2 Pred. Updated counts and derived metrics to match what the code actually emits.
- structured_list_comparator.py module docstring: replaced the outdated "Current Behavior Preserved (including bugs)" block with an accurate description of post-PR behavior.

Code
- hungarian.py: restored the `if score > 0:` gate in HungarianMatcher.calculate_metrics' single-item-list shortcut so zero-similarity pairs decompose as FN+FA, matching dev/main and consistent with the >0.0 filter in StructuredListComparator.

Tests
- test_threshold_gated_recursion.py adds test_zero_similarity_pair_is_unmatched_not_fd, pinning the `> 0.0` boundary at structured_list_comparator.py:209. Uses a 2x2 non-overlapping container so Hungarian's pair-assignment branch is actually exercised; mutation-tested by flipping > to >= (test fails).
- test_aggregate_cases.py adds test_primitive_list_zero_similarity_treated_as_unmatched as a regression test for the hungarian.py single-item fix.
- test_aggregate_cases.py: 7 of 12 TestAggregation tests now also assert derived metrics (cm_precision, cm_recall, cm_f1, cm_accuracy) under agg_results['derived'], pinning the docs claim that derived metrics are recomputed at each aggregate level.
- test_ecommerce_orders_aggregate_comprehensive.py test_threshold_based_classification: replaced two tautology assertions (tp > 0; sum > 0) with concrete per-child overall and aggregate counts that pin threshold behavior at every level.
- test_ecommerce_orders_aggregate_comprehensive.py: comment claiming "5 TP, 1 TN" updated to match the asserted tp=4/tn=2; removed an orphan __main__ call to a non-existent test method.

Test suite: 1100 passed / 2 skipped (was 1098 / 2, +2 from new tests). No regressions; mutation-guard verified on the new boundary test.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
