### PR TITLE
🙈 chore: ignore .claude and working directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,14 @@
 .kiro/*
 .kiro/**/*
 
+.claude/*
+.claude/**/*
+
 build/
 dist/
+
+# Working directories let's exclude for convenience
+.context/
+.working/
+.temp/
+.data/


### PR DESCRIPTION
Add .gitignore rules to exclude .claude/ agent files and convenience working directories (.context/, .working/, .temp/, .data/) from version control. 🧹

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
