### PR TITLE
fix(json-schema): annotate optional fields as Optional[T] so from_json accepts None

### DIFF
--- a/src/stickler/structured_object_evaluator/models/json_schema_field_converter.py
+++ b/src/stickler/structured_object_evaluator/models/json_schema_field_converter.py
@@ -4,7 +4,7 @@ This module provides utilities for converting JSON Schema properties to
 Pydantic Field instances with ComparableField functionality.
 """
 
-from typing import Any, Dict, List, Tuple, Type
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 from pydantic.fields import FieldInfo
 
@@ -147,7 +147,14 @@ class JsonSchemaFieldConverter:
         default = property_schema.get("default", ... if is_required else None)
         description = property_schema.get("description")
         examples = property_schema.get("examples")
-        
+
+        # Widen the annotation to Optional[...] for non-required fields so the
+        # None default is a valid value. See issue #149: the rich-value path
+        # round-trips through from_json(...).model_dump(), which materializes
+        # the None default and re-validates it against the annotation.
+        if not is_required:
+            field_type = Optional[field_type]
+
         # Call ComparableField() to create the Pydantic Field
         field = ComparableField(
             comparator=comparator,
@@ -158,7 +165,7 @@ class JsonSchemaFieldConverter:
             description=description,
             examples=examples
         )
-        
+
         return field_type, field
 
     def _map_json_type_to_python_type(self, json_type: str) -> Type:
@@ -353,8 +360,16 @@ class JsonSchemaFieldConverter:
             default=default,
             description=description
         )
-        
-        return NestedModel, field
+
+        # Widen the annotation to Optional[...] for non-required fields so the
+        # None default is a valid value. See issue #149: the rich-value path
+        # round-trips through from_json(...).model_dump(), which materializes
+        # the None default and re-validates it against the annotation.
+        field_type = NestedModel
+        if not is_required:
+            field_type = Optional[field_type]
+
+        return field_type, field
 
     def _handle_array_type(
         self, field_name: str, property_schema: Dict[str, Any], is_required: bool, field_path: str = None
@@ -413,7 +428,14 @@ class JsonSchemaFieldConverter:
         # Get default
         default = property_schema.get("default", ... if is_required else None)
         description = property_schema.get("description")
-        
+
+        # Widen the annotation to Optional[...] for non-required fields so the
+        # None default is a valid value. See issue #149: the rich-value path
+        # round-trips through from_json(...).model_dump(), which materializes
+        # the None default and re-validates it against the annotation.
+        if not is_required:
+            field_type = Optional[field_type]
+
         # Create ComparableField
         field = ComparableField(
             comparator=comparator,
@@ -423,7 +445,7 @@ class JsonSchemaFieldConverter:
             default=default,
             description=description
         )
-        
+
         return field_type, field
 
     

--- a/tests/structured_object_evaluator/test_json_schema_field_converter.py
+++ b/tests/structured_object_evaluator/test_json_schema_field_converter.py
@@ -1,6 +1,8 @@
 """Integration tests for JsonSchemaFieldConverter.convert_properties_to_fields()."""
 
 
+import typing
+
 import pytest
 
 from stickler.comparators.exact import ExactComparator
@@ -9,6 +11,21 @@ from stickler.comparators.numeric import NumericComparator
 from stickler.structured_object_evaluator.models.json_schema_field_converter import (
     JsonSchemaFieldConverter,
 )
+
+
+def _unwrap_optional(field_type):
+    """Strip ``Optional[...]`` (i.e. ``Union[X, None]``) down to the inner type.
+
+    Non-required JSON-Schema fields are annotated as ``Optional[T]`` so their
+    ``None`` default is valid (issue #149). Required fields stay bare. This
+    helper lets type assertions target the underlying ``T`` regardless of the
+    optional wrapper.
+    """
+    if typing.get_origin(field_type) is typing.Union:
+        args = [a for a in typing.get_args(field_type) if a is not type(None)]
+        if len(args) == 1:
+            return args[0]
+    return field_type
 
 
 class TestConvertPropertiesToFields:
@@ -38,11 +55,13 @@ class TestConvertPropertiesToFields:
         assert "price" in field_definitions
         assert "active" in field_definitions
 
-        # Check types
-        assert field_definitions["name"][0] is str
-        assert field_definitions["age"][0] is int
-        assert field_definitions["price"][0] is float
-        assert field_definitions["active"][0] is bool
+        # Check types. Required fields keep a bare annotation; optional fields
+        # are widened to Optional[...] (issue #149) so their None default is
+        # valid, so unwrap before comparing the underlying type.
+        assert field_definitions["name"][0] is str  # required -> bare
+        assert field_definitions["age"][0] is int  # required -> bare
+        assert _unwrap_optional(field_definitions["price"][0]) is float  # optional
+        assert _unwrap_optional(field_definitions["active"][0]) is bool  # optional
 
         # Check required vs optional (via is_required)
         name_field = field_definitions["name"][1]
@@ -54,6 +73,62 @@ class TestConvertPropertiesToFields:
         assert age_field.is_required()  # Required
         assert not price_field.is_required()  # Optional
         assert not active_field.is_required()  # Optional
+
+    def test_not_required_fields_are_optional_annotations(self):
+        """Non-required fields get Optional[...] annotations; required stay bare.
+
+        Regression for issue #149: an optional field has ``default=None`` but
+        must also be annotated as ``Optional[...]`` so that None is valid when
+        the rich-value path round-trips through from_json(...).model_dump().
+        Covers all three sites: primitive, nested object, and array.
+        """
+        schema = {
+            "type": "object",
+            "properties": {
+                # Required primitive -> bare
+                "req_str": {"type": "string"},
+                # Optional primitive -> Optional[str]
+                "opt_str": {"type": "string"},
+                # Optional nested object -> Optional[NestedModel]
+                "opt_obj": {
+                    "type": "object",
+                    "properties": {"inner": {"type": "string"}},
+                },
+                # Optional array -> Optional[List[str]]
+                "opt_arr": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["req_str"],
+        }
+
+        converter = JsonSchemaFieldConverter(schema)
+        field_definitions = converter.convert_properties_to_fields(
+            schema["properties"], schema["required"]
+        )
+
+        # Required field stays a bare annotation.
+        req_type = field_definitions["req_str"][0]
+        assert req_type is str
+        assert typing.get_origin(req_type) is not typing.Union
+
+        # Each optional field is wrapped in Optional[...] (Union[X, None]).
+        for name, inner_check in [
+            ("opt_str", lambda t: t is str),
+            (
+                "opt_obj",
+                lambda t: (
+                    __import__(
+                        "stickler.structured_object_evaluator.models.structured_model",
+                        fromlist=["StructuredModel"],
+                    ).StructuredModel
+                    in t.__mro__
+                ),
+            ),
+            ("opt_arr", lambda t: typing.get_origin(t) is list),
+        ]:
+            field_type = field_definitions[name][0]
+            assert typing.get_origin(field_type) is typing.Union, name
+            assert type(None) in typing.get_args(field_type), name
+            assert inner_check(_unwrap_optional(field_type)), name
 
     def test_convert_with_default_comparators(self):
         """Test that default comparators are assigned correctly."""
@@ -189,9 +264,11 @@ class TestConvertPropertiesToFields:
             schema["properties"], schema["required"]
         )
 
-        # Check types are List[primitive]
-        tags_type = field_definitions["tags"][0]
-        scores_type = field_definitions["scores"][0]
+        # Check types are List[primitive]. Both fields are optional (not in
+        # required), so they are widened to Optional[List[...]] (issue #149);
+        # unwrap to inspect the List.
+        tags_type = _unwrap_optional(field_definitions["tags"][0])
+        scores_type = _unwrap_optional(field_definitions["scores"][0])
 
         # Verify they are List types
         assert hasattr(tags_type, "__origin__")
@@ -317,8 +394,9 @@ class TestConvertPropertiesToFields:
             assert isinstance(field_name, str)
             assert isinstance(field_def, tuple)
             assert len(field_def) == 2
-            # First element is a type
-            assert isinstance(field_def[0], type)
+            # First element is a type. Optional fields are wrapped in
+            # Optional[...] (issue #149), so unwrap before the type check.
+            assert isinstance(_unwrap_optional(field_def[0]), type)
             # Second element is a Pydantic FieldInfo
             from pydantic.fields import FieldInfo
             assert isinstance(field_def[1], FieldInfo)
@@ -351,10 +429,12 @@ class TestRefResolution:
             schema["properties"], schema["required"]
         )
 
-        # Should successfully resolve and create nested model
+        # Should successfully resolve and create nested model.
+        # 'home' is optional, so the annotation is Optional[NestedModel]
+        # (issue #149); unwrap to inspect the model class.
         assert "home" in field_definitions
-        home_type = field_definitions["home"][0]
-        
+        home_type = _unwrap_optional(field_definitions["home"][0])
+
         # Verify it's a StructuredModel subclass
         from stickler.structured_object_evaluator.models.structured_model import (
             StructuredModel,
@@ -385,10 +465,12 @@ class TestRefResolution:
             schema["properties"], schema["required"]
         )
 
-        # Should successfully resolve and create nested model
+        # Should successfully resolve and create nested model.
+        # 'contact' is optional, so the annotation is Optional[NestedModel]
+        # (issue #149); unwrap to inspect the model class.
         assert "contact" in field_definitions
-        contact_type = field_definitions["contact"][0]
-        
+        contact_type = _unwrap_optional(field_definitions["contact"][0])
+
         # Verify it's a StructuredModel subclass
         from stickler.structured_object_evaluator.models.structured_model import (
             StructuredModel,
@@ -468,14 +550,16 @@ class TestRefResolution:
             schema["properties"], schema["required"]
         )
 
-        # Should successfully resolve and create List[StructuredModel]
+        # Should successfully resolve and create List[StructuredModel].
+        # 'items' is optional, so the annotation is Optional[List[...]]
+        # (issue #149); unwrap to inspect the List.
         assert "items" in field_definitions
-        items_type = field_definitions["items"][0]
-        
+        items_type = _unwrap_optional(field_definitions["items"][0])
+
         # Verify it's a List type
         assert hasattr(items_type, "__origin__")
         assert items_type.__origin__ is list
-        
+
         # Verify element is a StructuredModel subclass
         from stickler.structured_object_evaluator.models.structured_model import (
             StructuredModel,
@@ -508,16 +592,17 @@ class TestNestedObjectHandling:
             schema["properties"], schema["required"]
         )
 
-        # Check nested model was created
+        # Check nested model was created. 'person' is optional, so the
+        # annotation is Optional[NestedModel] (issue #149); unwrap it.
         assert "person" in field_definitions
-        person_type = field_definitions["person"][0]
-        
+        person_type = _unwrap_optional(field_definitions["person"][0])
+
         # Verify it's a StructuredModel subclass
         from stickler.structured_object_evaluator.models.structured_model import (
             StructuredModel,
         )
         assert issubclass(person_type, StructuredModel)
-        
+
         # Verify nested model has correct fields
         assert "name" in person_type.model_fields
         assert "age" in person_type.model_fields
@@ -583,15 +668,16 @@ class TestNestedObjectHandling:
             schema["properties"], schema["required"]
         )
 
-        # Should successfully create deeply nested structure
+        # Should successfully create deeply nested structure. 'company' is
+        # optional, so the annotation is Optional[NestedModel] (issue #149).
         assert "company" in field_definitions
-        company_type = field_definitions["company"][0]
-        
+        company_type = _unwrap_optional(field_definitions["company"][0])
+
         from stickler.structured_object_evaluator.models.structured_model import (
             StructuredModel,
         )
         assert issubclass(company_type, StructuredModel)
-        
+
         # Verify nested fields exist
         assert "name" in company_type.model_fields
         assert "address" in company_type.model_fields
@@ -624,14 +710,15 @@ class TestArrayHandling:
             schema["properties"], schema["required"]
         )
 
-        # Check array type
+        # Check array type. 'employees' is optional, so the annotation is
+        # Optional[List[...]] (issue #149); unwrap to inspect the List.
         assert "employees" in field_definitions
-        employees_type = field_definitions["employees"][0]
-        
+        employees_type = _unwrap_optional(field_definitions["employees"][0])
+
         # Verify it's a List type
         assert hasattr(employees_type, "__origin__")
         assert employees_type.__origin__ is list
-        
+
         # Verify element is a StructuredModel subclass
         from stickler.structured_object_evaluator.models.structured_model import (
             StructuredModel,
@@ -692,11 +779,12 @@ class TestArrayHandling:
             schema["properties"], schema["required"]
         )
 
-        # Check all array types
-        assert field_definitions["strings"][0].__args__[0] is str
-        assert field_definitions["integers"][0].__args__[0] is int
-        assert field_definitions["numbers"][0].__args__[0] is float
-        assert field_definitions["booleans"][0].__args__[0] is bool
+        # Check all array types. All fields are optional, so each annotation
+        # is Optional[List[...]] (issue #149); unwrap to inspect the List.
+        assert _unwrap_optional(field_definitions["strings"][0]).__args__[0] is str
+        assert _unwrap_optional(field_definitions["integers"][0]).__args__[0] is int
+        assert _unwrap_optional(field_definitions["numbers"][0]).__args__[0] is float
+        assert _unwrap_optional(field_definitions["booleans"][0]).__args__[0] is bool
 
 
 class TestErrorHandling:

--- a/tests/structured_object_evaluator/test_json_schema_integration.py
+++ b/tests/structured_object_evaluator/test_json_schema_integration.py
@@ -158,9 +158,103 @@ class TestEndToEndWorkflow:
         # Test exact match
         score = emp1.compare(emp2)
         assert score == 1.0
-        
+
         result = emp1.compare_with(emp2)
         assert result["overall_score"] == 1.0
+
+
+class TestOptionalFieldNoneFromJson:
+    """Regression tests for issue #149.
+
+    from_json(process_rich_values=True) must accept models where an OPTIONAL
+    JSON-Schema field (absent from ``required``) is omitted from the payload.
+
+    Before the fix, from_json_schema() built optional fields with
+    ``default=None`` but a NON-nullable annotation (bare ``str``). The
+    rich-value path round-trips nested objects through
+    ``from_json(...).model_dump()``, which materializes the ``None`` default
+    and re-validates it against ``str`` -> ValidationError. Plain
+    ``ModelClass(**data)`` never hit this because it does not re-validate the
+    dumped ``None``.
+    """
+
+    def test_optional_nested_field_none_via_from_json_rich_values(self):
+        """Nested object with an OPTIONAL inner field round-trips via from_json.
+
+        Both ``M(**data)`` and ``M.from_json(data, process_rich_values=True)``
+        must succeed and agree when the optional inner field is omitted.
+        """
+        schema = {
+            "type": "object",
+            "properties": {
+                "C": {
+                    "type": "object",
+                    "properties": {
+                        "A": {"type": "string"},
+                        "B": {"type": "string"},  # OPTIONAL (not in required)
+                    },
+                    "required": ["A"],
+                },
+            },
+            "required": ["C"],
+        }
+
+        M = StructuredModel.from_json_schema(schema)
+
+        data = {"C": {"A": "x"}}
+
+        # Plain construction accepts the missing optional field.
+        plain = M(**data)
+        assert plain.C.A == "x"
+        assert plain.C.B is None
+
+        # from_json with rich-value processing must also accept it (the bug).
+        rich = M.from_json(data, process_rich_values=True)
+        assert rich.C.A == "x"
+        assert rich.C.B is None
+
+        # The two paths must agree.
+        assert plain.model_dump() == rich.model_dump()
+
+    def test_optional_primitive_field_none_via_from_json_rich_values(self):
+        """Top-level OPTIONAL primitive field round-trips via from_json."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "required_name": {"type": "string"},
+                "optional_note": {"type": "string"},  # OPTIONAL
+            },
+            "required": ["required_name"],
+        }
+
+        M = StructuredModel.from_json_schema(schema)
+        data = {"required_name": "x"}
+
+        plain = M(**data)
+        rich = M.from_json(data, process_rich_values=True)
+        assert plain.optional_note is None
+        assert rich.optional_note is None
+        assert plain.model_dump() == rich.model_dump()
+
+    def test_optional_array_field_none_via_from_json_rich_values(self):
+        """Top-level OPTIONAL array field round-trips via from_json."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "tags": {"type": "array", "items": {"type": "string"}},  # OPTIONAL
+            },
+            "required": ["id"],
+        }
+
+        M = StructuredModel.from_json_schema(schema)
+        data = {"id": "x"}
+
+        plain = M(**data)
+        rich = M.from_json(data, process_rich_values=True)
+        assert plain.tags is None
+        assert rich.tags is None
+        assert plain.model_dump() == rich.model_dump()
 
 
 class TestComplexNestedStructures:


### PR DESCRIPTION
**Issue #, if available:** #149

## Problem

`from_json(process_rich_values=True)` rejects `None` for **optional** fields that plain `ModelClass(**data)` accepts. A model built from a JSON Schema raises `pydantic ValidationError` ("Input should be a valid string ... input_value=None") when an optional field is omitted and rich-value processing is on.

## Root cause

When a JSON-Schema field is optional (absent from `required`), `from_json_schema()` builds a Pydantic field with `default=None` but a **non-nullable** annotation (bare `str`, not `Optional[str]`). Plain construction tolerates the omitted field, but the rich-value path round-trips nested objects through `from_json(...).model_dump()` (`ConfigurationHelper._process_nested_structured_data`). `model_dump()` materializes the `None` default, and re-validation checks it against the bare annotation — which fails. The default-vs-annotation mismatch is the bug.

## Fix (3 sites)

In `json_schema_field_converter.py`, widen `field_type` to `Optional[field_type]` whenever the field is not required, mirroring the existing `default = ... if is_required else None` decision, at: primitive (`convert_property_to_field`), nested object (`_handle_nested_object`), and array (`_handle_array_type`). Required fields keep bare annotations. `configuration_helper.py` already handles `Optional[...]` correctly — it just never received them.

## Testing

Added a regression test (`TestOptionalFieldNoneFromJson`) covering nested/primitive/array optional fields, asserting both `M(**data)` and `M.from_json(data, process_rich_values=True)` succeed and agree. Added a focused converter test asserting optional fields → `Optional[...]` and required fields stay bare. Updated existing converter assertions to unwrap the Optional wrapper for not-required fields only. Full suite: 1080 passed, 2 skipped (pre-existing skips), 0 failures.

## Risk

Low. Annotation-only change for not-required fields; required-field behavior is unchanged. Export round-trip and None-handling suites pass.

> Coordination note: PR #127 also touches this file, handling **explicit-nullable** forms (`{"type": ["string","null"]}` / `nullable: true`); this PR handles the **implicit** case (optional = absent from `required`). The two are complementary but overlap around the `field_type` computation — happy to rebase/coordinate so both converge on a single Optional-widening point.

Fixes #149

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
