### PR TITLE
fix: prevent script injection in security workflow PR number step

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -35,7 +35,9 @@ jobs:
           ash --mode local
       - name: Save PR number
         if: github.event_name == 'pull_request'
-        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: echo "$PR_NUMBER" > pr-number.txt
       - name: Upload Security Reports
         uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
## Summary

Fixes a script-injection issue in `.github/workflows/security.yaml`.

The `Save PR number` step interpolated an untrusted GitHub context value directly into an inline shell script:

```yaml
run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
```

GitHub Actions expands `${{ }}` **before** the shell runs, substituting the raw value into the script text. Any field under the `github.event` context must be treated as untrusted input, so this is the classic script-injection pattern.

## Fix

Bind the expression to an intermediate environment variable and reference it quoted in the script — GitHub's [documented mitigation](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#good-practices-for-mitigating-script-injection-attacks) for inline scripts:

```yaml
env:
  PR_NUMBER: ${{ github.event.pull_request.number }}
run: echo "$PR_NUMBER" > pr-number.txt
```

The value is now passed as environment data and the shell never re-evaluates it as code. No `${{ }}` remains inside any `run:` block.

## Verification

- Scanned all six workflow files: this was the only `${{ }}` interpolated into a `run:` block. Remaining expressions (`matrix.python-version`, `secrets.GITHUB_TOKEN`, the `run-id:` action input, and `if:` conditions) are not shell interpolations and are safe.
- YAML parses cleanly.
- Behavior is unchanged: `pr-number.txt` still receives the PR number consumed by `security-pr-comment.yaml`.