### PR TITLE
fix: resolve ASH security scan findings

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build distribution

--- a/tests/test_top_level_exports.py
+++ b/tests/test_top_level_exports.py
@@ -69,7 +69,7 @@ class TestAllConsistency:
     def test_star_import_matches_all(self):
         """from stickler import * should yield exactly __all__."""
         ns = {}
-        exec("from stickler import *", ns)  # noqa: S102
+        exec("from stickler import *", ns)  # noqa: S102  # nosec B102
         exported_names = set(ns) - {"__builtins__"}
         assert exported_names == set(stickler.__all__)
 


### PR DESCRIPTION
## Summary
Resolves two findings from the ASH security scan:

- **checkov CKV2_GHA_1** — add a restrictive top-level `permissions: contents: read` default to the PyPI publish workflow. Job-level permissions still override this, so the build job (`contents: read`) and the publish jobs (`id-token: write`) are unaffected — publishing behavior does not change.
- **bandit B102** — add `# nosec B102` to the intentional `exec("from stickler import *", ...)` in `test_top_level_exports.py`. The exec is required to exercise real star-import behavior; `pyproject.toml` already excludes `tests/` from bandit but ASH's invocation does not honor that, so an inline suppression is the robust fix.

## Test plan
- [ ] CI passes (lint, tests, security)
- [ ] ASH security scan no longer reports CKV2_GHA_1 / B102 as actionable