### PR TITLE
feat: page-aware mAP scoring (thread page_aware through the pipeline)

### DIFF
--- a/docs/docs/Advanced/bbox-map-metrics.md
+++ b/docs/docs/Advanced/bbox-map-metrics.md
@@ -44,12 +44,19 @@ Bounding boxes are provided through the [Rich Value Pattern](rich-value-pattern.
 
 ### Supported formats
 
-Two bounding box formats are accepted:
+Bounding box formats accepted:
 
 - **Two-point**: `[[x1, y1], [x2, y2]]` — top-left and bottom-right corners
 - **Flat**: `[x1, y1, x2, y2]` — four coordinates in a single list
+- **Two-point with page**: `[[x1, y1], [x2, y2], page]` — corners plus a page number
+- **Flat with page**: `[x1, y1, x2, y2, page]` — four coordinates plus a page number
 
 Coordinates can be in any unit system (pixels, normalized 0-1, etc.) as long as ground truth and predictions use the same system.
+
+The optional trailing **page** number identifies which page of a multi-page
+document the box lives on. It must be an integer (an integer-valued float like
+`2.0` is accepted and coerced to `2`). It is ignored unless the comparator is
+constructed with `page_aware=True` — see [Page-aware comparison](#page-aware-comparison).
 
 ## Usage
 
@@ -269,6 +276,40 @@ cmp = BBoxIoUComparator(threshold=0.5)
 iou = cmp.compare([[0, 0], [100, 50]], [[10, 5], [110, 55]])
 print(f"IoU: {iou:.3f}")
 ```
+
+### Page-aware comparison
+
+In a multi-page document, two boxes with identical coordinates on *different*
+pages refer to different regions and must not be treated as a match. Construct
+the comparator with `page_aware=True` to enforce this: a box must declare its
+page and the two pages must match, otherwise the comparison short-circuits to
+`0.0` instead of computing IoU.
+
+```python
+cmp = BBoxIoUComparator(threshold=0.5, page_aware=True)
+
+# Same coordinates, same page -> normal IoU
+cmp.compare([[0, 0], [10, 10], 1], [[0, 0], [10, 10], 1])   # 1.0
+
+# Same coordinates, different page -> automatic miss
+cmp.compare([[0, 0], [10, 10], 1], [[0, 0], [10, 10], 2])   # 0.0
+
+# A box with no page is wrong 100% of the time when page-aware
+cmp.compare([[0, 0], [10, 10]], [[0, 0], [10, 10], 1])      # 0.0
+```
+
+When `page_aware=True`, the comparison returns `0.0` whenever:
+
+- either box omits a page number, **or**
+- the two boxes carry different page numbers.
+
+IoU is computed only when both boxes declare the **same** page. A page-less box
+(a two- or four-element box) therefore always misses in page-aware mode — so a
+prediction that fails to specify a page is counted wrong.
+
+Page numbers are parsed but **ignored** when `page_aware=False` (the default),
+so the page suffix is fully backward compatible and opt-in: existing two- and
+four-element boxes behave exactly as before.
 
 ## See Also
 

--- a/docs/docs/Advanced/bbox-map-metrics.md
+++ b/docs/docs/Advanced/bbox-map-metrics.md
@@ -311,6 +311,31 @@ Page numbers are parsed but **ignored** when `page_aware=False` (the default),
 so the page suffix is fully backward compatible and opt-in: existing two- and
 four-element boxes behave exactly as before.
 
+#### Page-aware mAP scoring
+
+To apply page-awareness across the whole mAP pipeline (not just a single
+comparator), pass `page_aware=True` to `MAPCalculator` / `BBoxMAPAccumulator`,
+or `bbox_page_aware=True` to `compare_with(add_bbox_metrics=True)`. The flag is
+threaded down to the underlying comparator, so a prediction with correct
+coordinates on the wrong page is scored as a localization miss.
+
+```python
+# Bulk evaluation
+evaluator = BulkStructuredModelEvaluator(
+    accumulators=[BBoxMAPAccumulator(page_aware=True)],
+)
+
+# Single document
+result = gt.compare_with(
+    pred,
+    add_bbox_metrics=True,
+    bbox_page_aware=True,
+)
+```
+
+Provide page-suffixed boxes in your rich values for this to work, e.g.
+`{"_value": "Acme", "_bbox": [[10, 20], [200, 50], 1]}`.
+
 ## See Also
 
 - [Rich Value Pattern](rich-value-pattern.md) — how fields carry `_value`, `_confidence`, and `_bbox` metadata

--- a/docs/docs/Guides/Comparators/README.md
+++ b/docs/docs/Guides/Comparators/README.md
@@ -173,7 +173,9 @@ class Product(StructuredModel):
 
 ### BBoxIoUComparator
 
-Compares two bounding boxes using Intersection over Union (IoU) as the similarity score. Accepts both two-point (`[[x1, y1], [x2, y2]]`) and flat (`[x1, y1, x2, y2]`) formats. Coordinates are automatically normalized so that x1 <= x2 and y1 <= y2.
+Compares two bounding boxes using Intersection over Union (IoU) as the similarity score. Accepts both two-point (`[[x1, y1], [x2, y2]]`) and flat (`[x1, y1, x2, y2]`) formats, each optionally carrying a trailing page number (`[[x1, y1], [x2, y2], page]` or `[x1, y1, x2, y2, page]`). Coordinates are automatically normalized so that x1 <= x2 and y1 <= y2.
+
+For multi-page documents, set `page_aware=True` so boxes on different pages never match. In page-aware mode a box must declare its page and the two pages must match for IoU to be computed; otherwise the comparison scores `0.0` — which also means a box that omits its page is counted wrong. When `page_aware=False` (the default) the page number is parsed but ignored, so the page suffix is fully backward compatible and opt-in.
 
 **When to use:** Evaluating spatial localization accuracy for document fields, signature detection, logo identification, or any use case where you need to measure how well a predicted bounding box overlaps with ground truth.
 
@@ -193,6 +195,7 @@ class DocumentField(StructuredModel):
 | Parameter | Default | Description |
 |---|---|---|
 | `threshold` | `0.5` | IoU threshold for binary match classification |
+| `page_aware` | `False` | When `True`, require both boxes to declare the same page; mismatched or missing pages score `0.0` |
 
 !!! tip "Rich Value Pattern"
     For end-to-end mAP evaluation with per-field breakdown, use the [Bounding Box mAP Metrics](../../Advanced/bbox-map-metrics.md) feature instead of using BBoxIoUComparator directly.

--- a/src/stickler/comparators/bbox.py
+++ b/src/stickler/comparators/bbox.py
@@ -2,13 +2,40 @@
 
 This comparator compares two bounding boxes and returns their IoU score
 as the similarity measure. It supports both two-point format
-([[x1, y1], [x2, y2]]) and four-element flat format ([x1, y1, x2, y2]).
+([[x1, y1], [x2, y2]]) and four-element flat format ([x1, y1, x2, y2]), each
+optionally carrying a trailing page number ([[x1, y1], [x2, y2], page] or
+[x1, y1, x2, y2, page]).
 """
 
 import math
 from typing import Any, Optional, Tuple
 
 from stickler.comparators.base import BaseComparator
+
+# Coordinate 4-tuple (x_min, y_min, x_max, y_max).
+_Coords = Tuple[float, float, float, float]
+
+# Sentinel marking "no page element was present" (distinct from page == None,
+# which this code never produces, and from a malformed page).
+_MISSING = object()
+
+
+def _parse_page(value: Any) -> int:
+    """Coerce a trailing page element to an int, raising on anything else.
+
+    Lenient about integer-valued floats (``2.0`` -> ``2``) but rejects
+    non-integer floats, non-finite values, strings, and bools so a malformed
+    page is treated as a malformed box (scores 0.0) rather than silently
+    matching. ``bool`` is rejected explicitly (it is an ``int`` subclass, but a
+    boolean page number is nonsensical).
+    """
+    if isinstance(value, bool):
+        raise ValueError("page number must be an integer, not bool")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and math.isfinite(value) and value.is_integer():
+        return int(value)
+    raise ValueError(f"invalid page number: {value!r}")
 
 
 class BBoxIoUComparator(BaseComparator):
@@ -20,6 +47,8 @@ class BBoxIoUComparator(BaseComparator):
     Bounding box formats accepted:
         - Two-point: [[x1, y1], [x2, y2]]
         - Flat: [x1, y1, x2, y2]
+        - Two-point with page: [[x1, y1], [x2, y2], page]
+        - Flat with page: [x1, y1, x2, y2, page]
 
     Coordinates must be finite numbers; non-finite values (NaN, inf) are
     treated as malformed input and score 0.0. Booleans are accepted as
@@ -29,8 +58,21 @@ class BBoxIoUComparator(BaseComparator):
     scores IoU 0.0 even against an identical point — relevant when annotating
     point locations rather than regions.
 
+    The optional trailing page number identifies which page of a multi-page
+    document a box lives on. It must be an integer (an integer-valued float
+    like ``2.0`` is coerced to ``2``); a non-integer, non-finite, or
+    non-numeric page makes the whole box malformed (scores 0.0). The page is
+    ignored unless ``page_aware=True``.
+
     Args:
         threshold: IoU threshold for binary match classification (default: 0.5).
+        page_aware: When True, a box MUST declare its page and the two pages
+            must match for IoU to be computed; otherwise the comparison scores
+            0.0. This means a box with no page number (a two- or four-element
+            box) is wrong 100% of the time in page-aware mode — even against
+            another page-less box — and boxes on different pages never match.
+            When False (default), page numbers are parsed but ignored, so the
+            page suffix is fully backward compatible and opt-in.
 
     Example:
         >>> from stickler.comparators.bbox import BBoxIoUComparator
@@ -39,13 +81,18 @@ class BBoxIoUComparator(BaseComparator):
         1.0
         >>> cmp.compare([[0, 0], [5, 5]], [[5, 5], [10, 10]])
         0.0
+        >>> paged = BBoxIoUComparator(threshold=0.5, page_aware=True)
+        >>> paged.compare([[0, 0], [10, 10], 1], [[0, 0], [10, 10], 2])
+        0.0
     """
 
     def __init__(
         self,
         threshold: float = 0.5,
+        page_aware: bool = False,
     ):
         super().__init__(threshold=threshold)
+        self.page_aware = page_aware
 
     def compare(self, bbox1: Any, bbox2: Any) -> float:
         """Compare two bounding boxes and return their IoU.
@@ -62,11 +109,22 @@ class BBoxIoUComparator(BaseComparator):
         if bbox1 is None or bbox2 is None:
             return 0.0
 
-        coords1 = self._normalize_bbox(bbox1)
-        coords2 = self._normalize_bbox(bbox2)
+        norm1 = self._normalize_bbox(bbox1)
+        norm2 = self._normalize_bbox(bbox2)
 
-        if coords1 is None or coords2 is None:
+        if norm1 is None or norm2 is None:
             return 0.0
+
+        coords1, page1 = norm1
+        coords2, page2 = norm2
+
+        # Page-aware short-circuit: in page-aware mode a box MUST declare its
+        # page. A box with no page is wrong 100% of the time (even against
+        # another page-less box), and two boxes on different pages never match,
+        # regardless of how well their coordinates align.
+        if self.page_aware:
+            if page1 is _MISSING or page2 is _MISSING or page1 != page2:
+                return 0.0
 
         return self._compute_iou(coords1, coords2)
 
@@ -77,29 +135,41 @@ class BBoxIoUComparator(BaseComparator):
     @staticmethod
     def _normalize_bbox(
         bbox: Any,
-    ) -> Optional[Tuple[float, float, float, float]]:
-        """Normalize a bounding box to (x1, y1, x2, y2) with x1<=x2, y1<=y2.
+    ) -> Optional[Tuple[_Coords, Any]]:
+        """Normalize a bounding box to ((x1, y1, x2, y2), page) with x1<=x2, y1<=y2.
 
         Accepts:
-            - [[x1, y1], [x2, y2]]
-            - [x1, y1, x2, y2]
+            - [[x1, y1], [x2, y2]]                 (page = _MISSING)
+            - [x1, y1, x2, y2]                     (page = _MISSING)
+            - [[x1, y1], [x2, y2], page]
+            - [x1, y1, x2, y2, page]
 
         Returns:
-            (x_min, y_min, x_max, y_max) or None if the input is invalid.
+            ((x_min, y_min, x_max, y_max), page) where page is an int or the
+            ``_MISSING`` sentinel, or None if the input is invalid. A malformed
+            page (non-integer, non-finite, non-numeric) makes the whole box
+            invalid.
         """
         try:
             if not isinstance(bbox, (list, tuple)):
                 return None
 
-            if len(bbox) == 2 and all(
-                isinstance(p, (list, tuple)) and len(p) == 2 for p in bbox
+            page: Any = _MISSING
+            if len(bbox) in (2, 3) and all(
+                isinstance(p, (list, tuple)) and len(p) == 2 for p in bbox[:2]
             ):
-                # Two-point format: [[x1, y1], [x2, y2]]
+                # Two-point format: [[x1, y1], [x2, y2]] (+ optional page)
                 x1, y1 = float(bbox[0][0]), float(bbox[0][1])
                 x2, y2 = float(bbox[1][0]), float(bbox[1][1])
-            elif len(bbox) == 4 and all(isinstance(v, (int, float)) for v in bbox):
-                # Flat format: [x1, y1, x2, y2]
-                x1, y1, x2, y2 = (float(v) for v in bbox)
+                if len(bbox) == 3:
+                    page = _parse_page(bbox[2])
+            elif len(bbox) in (4, 5) and all(
+                isinstance(v, (int, float)) for v in bbox[:4]
+            ):
+                # Flat format: [x1, y1, x2, y2] (+ optional page)
+                x1, y1, x2, y2 = (float(v) for v in bbox[:4])
+                if len(bbox) == 5:
+                    page = _parse_page(bbox[4])
             else:
                 return None
 
@@ -108,7 +178,8 @@ class BBoxIoUComparator(BaseComparator):
             if not all(math.isfinite(v) for v in (x1, y1, x2, y2)):
                 return None
 
-            return (min(x1, x2), min(y1, y2), max(x1, x2), max(y1, y2))
+            coords = (min(x1, x2), min(y1, y2), max(x1, x2), max(y1, y2))
+            return (coords, page)
         except (TypeError, ValueError, IndexError):
             return None
 

--- a/src/stickler/structured_object_evaluator/models/bbox/accumulator.py
+++ b/src/stickler/structured_object_evaluator/models/bbox/accumulator.py
@@ -32,9 +32,13 @@ class BBoxMAPAccumulator(PostComparisonAccumulator):
     """Accumulates bbox observations and computes aggregate mAP metrics."""
 
     def __init__(
-        self, iou_thresholds: Union[float, Iterable[float]] = DEFAULT_IOU_THRESHOLDS
+        self,
+        iou_thresholds: Union[float, Iterable[float]] = DEFAULT_IOU_THRESHOLDS,
+        page_aware: bool = False,
     ):
-        self._calculator = MAPCalculator(iou_thresholds=iou_thresholds)
+        self._calculator = MAPCalculator(
+            iou_thresholds=iou_thresholds, page_aware=page_aware
+        )
         self.reset()
 
     @property

--- a/src/stickler/structured_object_evaluator/models/bbox/calculator.py
+++ b/src/stickler/structured_object_evaluator/models/bbox/calculator.py
@@ -123,16 +123,24 @@ class MAPCalculator:
             to the COCO range ``(0.50, 0.55, ..., 0.95)``. Passing a single float
             (e.g. ``0.5``) yields a single-threshold ``mean_ap`` equal to
             ``map_50``.
+        page_aware: When True, boxes must declare a matching page number to count
+            as a localization match (a correct box on the wrong page is a miss).
+            Requires boxes to carry a trailing page element
+            (``[x1, y1, x2, y2, page]`` or ``[[x1, y1], [x2, y2], page]``).
+            Defaults to False (page numbers, if present, are ignored).
     """
 
     def __init__(
-        self, iou_thresholds: Union[float, Iterable[float]] = DEFAULT_IOU_THRESHOLDS
+        self,
+        iou_thresholds: Union[float, Iterable[float]] = DEFAULT_IOU_THRESHOLDS,
+        page_aware: bool = False,
     ):
         if isinstance(iou_thresholds, (int, float)):
             iou_thresholds = (float(iou_thresholds),)
         self.iou_thresholds = tuple(sorted(float(t) for t in iou_thresholds))
+        self.page_aware = page_aware
         # Only compare() is used; classification happens in this calculator.
-        self._comparator = BBoxIoUComparator()
+        self._comparator = BBoxIoUComparator(page_aware=page_aware)
 
     # ------------------------------------------------------------------
     # Extraction

--- a/src/stickler/structured_object_evaluator/models/comparison_engine.py
+++ b/src/stickler/structured_object_evaluator/models/comparison_engine.py
@@ -208,6 +208,7 @@ class ComparisonEngine:
         confidence_metrics: Optional[List["ConfidenceMetric"]] = None,
         add_bbox_metrics: bool = False,
         bbox_iou_thresholds: Optional[Union[float, Iterable[float]]] = None,
+        bbox_page_aware: bool = False,
     ) -> Dict[str, Any]:
         """Compare with another instance using single traversal.
         
@@ -398,9 +399,12 @@ class ComparisonEngine:
                     stacklevel=2,
                 )
             calculator = (
-                MAPCalculator(iou_thresholds=bbox_iou_thresholds)
+                MAPCalculator(
+                    iou_thresholds=bbox_iou_thresholds,
+                    page_aware=bbox_page_aware,
+                )
                 if bbox_iou_thresholds is not None
-                else MAPCalculator()
+                else MAPCalculator(page_aware=bbox_page_aware)
             )
             # An empty field_comparisons list (e.g. a model whose only list
             # field is empty on both sides) yields a coverage-only result

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -1102,6 +1102,7 @@ class StructuredModel(BaseModel):
         confidence_metrics: Optional[List[Any]] = None,
         add_bbox_metrics: bool = False,
         bbox_iou_thresholds: Optional[Union[float, Iterable[float]]] = None,
+        bbox_page_aware: bool = False,
     ) -> Dict[str, Any]:
         """Compare this model with another instance using SINGLE TRAVERSAL optimization.
 
@@ -1130,6 +1131,10 @@ class StructuredModel(BaseModel):
             bbox_iou_thresholds: A single IoU threshold or an iterable of them
                 for mAP. Defaults to the COCO range (0.50, 0.55, ..., 0.95).
                 Only used when add_bbox_metrics=True.
+            bbox_page_aware: When True, mAP requires matching page numbers, so a
+                correct box on the wrong page is a miss. Boxes must carry a
+                trailing page element ([x1, y1, x2, y2, page] or
+                [[x1, y1], [x2, y2], page]). Only used when add_bbox_metrics=True.
 
         Returns:
             Dictionary with comparison results including:
@@ -1156,6 +1161,7 @@ class StructuredModel(BaseModel):
             confidence_metrics=confidence_metrics,
             add_bbox_metrics=add_bbox_metrics,
             bbox_iou_thresholds=bbox_iou_thresholds,
+            bbox_page_aware=bbox_page_aware,
         )
 
     def _convert_score_to_binary_metrics(

--- a/tests/structured_object_evaluator/test_bbox_map.py
+++ b/tests/structured_object_evaluator/test_bbox_map.py
@@ -819,3 +819,113 @@ class TestCompareWithBBoxMetrics:
                 pred, add_bbox_metrics=True, document_field_comparisons=True
             )
         assert result["bbox_metrics"]["mean_ap"] == 1.0
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Page-aware mAP scoring (page number threaded through the pipeline)
+# ══════════════════════════════════════════════════════════════════════
+
+
+def _doc(page_gt, page_pred):
+    """A one-field doc pair with identical coords; pages parameterized.
+
+    page_* of None omits the page element entirely.
+    """
+    gt_box = [[0, 0], [100, 20]] + ([page_gt] if page_gt is not None else [])
+    pred_box = [[0, 0], [100, 20]] + ([page_pred] if page_pred is not None else [])
+    gt = DocumentField.from_json({"vendor_name": {"_value": "Acme", "_bbox": gt_box}})
+    pred = DocumentField.from_json(
+        {"vendor_name": {"_value": "Acme", "_bbox": pred_box, "_confidence": 0.9}}
+    )
+    return gt, pred
+
+
+class TestPageAwareMAPCalculator:
+    def test_calculator_carries_page_aware(self):
+        assert MAPCalculator(page_aware=True).page_aware is True
+        assert MAPCalculator().page_aware is False
+
+    def test_same_page_is_a_hit(self):
+        calc = MAPCalculator(iou_thresholds=0.5, page_aware=True)
+        fc = [{"expected_key": "v", "actual_key": "v", "match": True}]
+        gt = {"v": [[0, 0], [100, 20], 1]}
+        pred = {"v": [[0, 0], [100, 20], 1]}
+        ex = calc.extract_from_dicts(fc, gt, pred, {})
+        assert calc.compute_metrics(ex.keyed_pairs, 1, 1)["mean_ap"] == 1.0
+
+    def test_wrong_page_is_a_miss(self):
+        calc = MAPCalculator(iou_thresholds=0.5, page_aware=True)
+        fc = [{"expected_key": "v", "actual_key": "v", "match": True}]
+        gt = {"v": [[0, 0], [100, 20], 1]}
+        pred = {"v": [[0, 0], [100, 20], 2]}  # identical coords, wrong page
+        ex = calc.extract_from_dicts(fc, gt, pred, {})
+        assert calc.compute_metrics(ex.keyed_pairs, 1, 1)["mean_ap"] == 0.0
+
+    def test_page_ignored_when_not_aware(self):
+        calc = MAPCalculator(iou_thresholds=0.5)  # page_aware defaults False
+        fc = [{"expected_key": "v", "actual_key": "v", "match": True}]
+        gt = {"v": [[0, 0], [100, 20], 1]}
+        pred = {"v": [[0, 0], [100, 20], 2]}
+        ex = calc.extract_from_dicts(fc, gt, pred, {})
+        assert calc.compute_metrics(ex.keyed_pairs, 1, 1)["mean_ap"] == 1.0
+
+
+class TestPageAwareCompareWith:
+    def test_wrong_page_drops_to_zero(self):
+        gt, pred = _doc(page_gt=1, page_pred=2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            result = gt.compare_with(
+                pred,
+                add_bbox_metrics=True,
+                document_field_comparisons=True,
+                bbox_iou_thresholds=0.5,
+                bbox_page_aware=True,
+            )
+        assert result["bbox_metrics"]["mean_ap"] == 0.0
+
+    def test_same_page_is_one(self):
+        gt, pred = _doc(page_gt=1, page_pred=1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            result = gt.compare_with(
+                pred,
+                add_bbox_metrics=True,
+                document_field_comparisons=True,
+                bbox_iou_thresholds=0.5,
+                bbox_page_aware=True,
+            )
+        assert result["bbox_metrics"]["mean_ap"] == 1.0
+
+    def test_default_is_page_unaware(self):
+        gt, pred = _doc(page_gt=1, page_pred=2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            result = gt.compare_with(
+                pred,
+                add_bbox_metrics=True,
+                document_field_comparisons=True,
+                bbox_iou_thresholds=0.5,
+            )
+        # Without bbox_page_aware, the wrong page is ignored -> geometric hit.
+        assert result["bbox_metrics"]["mean_ap"] == 1.0
+
+
+class TestPageAwareBulkAccumulator:
+    def test_accumulator_page_aware_wrong_page_miss(self):
+        gt, pred = _doc(page_gt=1, page_pred=2)
+        evaluator = BulkStructuredModelEvaluator(
+            accumulators=[BBoxMAPAccumulator(iou_thresholds=0.5, page_aware=True)]
+        )
+        evaluator.update(gt, pred)
+        bm = evaluator.compute().accumulator_metrics["bbox_map_metrics"]
+        assert bm["mean_ap"] == 0.0
+
+    def test_accumulator_page_aware_same_page_hit(self):
+        gt, pred = _doc(page_gt=3, page_pred=3)
+        evaluator = BulkStructuredModelEvaluator(
+            accumulators=[BBoxMAPAccumulator(iou_thresholds=0.5, page_aware=True)]
+        )
+        evaluator.update(gt, pred)
+        bm = evaluator.compute().accumulator_metrics["bbox_map_metrics"]
+        assert bm["mean_ap"] == 1.0

--- a/tests/structured_object_evaluator/test_bbox_map.py
+++ b/tests/structured_object_evaluator/test_bbox_map.py
@@ -132,6 +132,99 @@ class TestBBoxIoUComparator:
 
 
 # ══════════════════════════════════════════════════════════════════════
+# BBoxIoUComparator — page-aware comparison
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestBBoxIoUComparatorPageAware:
+    """page_aware=True forces a miss when boxes disagree about their page."""
+
+    def setup_method(self):
+        self.aware = BBoxIoUComparator(threshold=0.5, page_aware=True)
+        self.plain = BBoxIoUComparator(threshold=0.5)
+
+    # --- page numbers are accepted in both formats (regardless of flag) -----
+
+    def test_two_point_with_page_parses(self):
+        # Same coords, same page -> normal IoU even when page-aware.
+        assert self.aware.compare([[0, 0], [10, 10], 1], [[0, 0], [10, 10], 1]) == 1.0
+
+    def test_flat_with_page_parses(self):
+        assert self.aware.compare([0, 0, 10, 10, 3], [0, 0, 10, 10, 3]) == 1.0
+
+    def test_mixed_formats_same_page(self):
+        assert self.aware.compare([[0, 0], [10, 10], 2], [0, 0, 10, 10, 2]) == 1.0
+
+    def test_integer_valued_float_page_coerced(self):
+        # 2.0 is treated as page 2, so it matches an int page 2.
+        assert self.aware.compare([[0, 0], [10, 10], 2.0], [[0, 0], [10, 10], 2]) == 1.0
+
+    def test_partial_overlap_same_page_matches_plain_iou(self):
+        # When pages agree, the page-aware comparator must return the EXACT
+        # same partial IoU as the plain comparator on the same coordinates --
+        # i.e. the page suffix didn't disturb the geometry math.
+        aware_iou = self.aware.compare([[0, 0], [10, 10], 1], [[5, 5], [15, 15], 1])
+        plain_iou = self.plain.compare([[0, 0], [10, 10]], [[5, 5], [15, 15]])
+        assert aware_iou == plain_iou
+        assert abs(aware_iou - 25 / 175) < 1e-6  # genuinely partial, not 0 or 1
+
+    def test_partial_overlap_flat_same_page_matches_plain_iou(self):
+        # Same invariant via the flat (5-element) format.
+        aware_iou = self.aware.compare([0, 0, 20, 20, 3], [5, 5, 10, 10, 3])
+        plain_iou = self.plain.compare([0, 0, 20, 20], [5, 5, 10, 10])
+        assert aware_iou == plain_iou
+        assert abs(aware_iou - 25 / 400) < 1e-6
+
+    # --- page disagreement forces 0.0 when page-aware ----------------------
+
+    def test_different_pages_force_miss(self):
+        # Identical coordinates, different pages -> automatic miss.
+        assert self.aware.compare([[0, 0], [10, 10], 1], [[0, 0], [10, 10], 2]) == 0.0
+
+    def test_gt_has_page_pred_missing_forces_miss(self):
+        assert self.aware.compare([[0, 0], [10, 10]], [[0, 0], [10, 10], 1]) == 0.0
+
+    def test_pred_has_page_gt_missing_forces_miss(self):
+        assert self.aware.compare([[0, 0], [10, 10], 1], [[0, 0], [10, 10]]) == 0.0
+
+    def test_both_missing_page_forces_miss(self):
+        # In page-aware mode a box MUST declare its page, so a page-less box is
+        # wrong even against another page-less box.
+        assert self.aware.compare([[0, 0], [10, 10]], [[0, 0], [10, 10]]) == 0.0
+
+    def test_flat_without_page_forces_miss(self):
+        # A four-element (page-less) box is wrong 100% of the time when aware.
+        assert self.aware.compare([0, 0, 10, 10], [0, 0, 10, 10, 1]) == 0.0
+
+    # --- default (page_aware=False) ignores pages entirely -----------------
+
+    def test_default_ignores_different_pages(self):
+        # Without the flag, the page suffix is parsed but does not affect IoU.
+        assert self.plain.compare([[0, 0], [10, 10], 1], [[0, 0], [10, 10], 2]) == 1.0
+
+    def test_default_ignores_present_absent_page(self):
+        assert self.plain.compare([[0, 0], [10, 10], 1], [[0, 0], [10, 10]]) == 1.0
+
+    # --- malformed pages are treated as malformed boxes (score 0.0) --------
+
+    def test_non_integer_float_page_is_malformed(self):
+        assert self.aware.compare([[0, 0], [10, 10], 1.5], [[0, 0], [10, 10], 1]) == 0.0
+
+    def test_non_numeric_page_is_malformed(self):
+        assert self.aware.compare([[0, 0], [10, 10], "1"], [[0, 0], [10, 10], 1]) == 0.0
+
+    def test_nan_page_is_malformed(self):
+        nan = float("nan")
+        assert self.aware.compare([[0, 0], [10, 10], nan], [[0, 0], [10, 10], 1]) == 0.0
+
+    def test_three_scalars_still_invalid(self):
+        # [1, 2, 3] is NOT a two-point+page box (first two aren't points);
+        # it stays malformed under both flag settings.
+        assert self.aware.compare([1, 2, 3], [[0, 0], [10, 10], 1]) == 0.0
+        assert self.plain.compare([1, 2, 3], [[0, 0], [10, 10]]) == 0.0
+
+
+# ══════════════════════════════════════════════════════════════════════
 # class_key
 # ══════════════════════════════════════════════════════════════════════
 

--- a/tests/structured_object_evaluator/test_bbox_map.py
+++ b/tests/structured_object_evaluator/test_bbox_map.py
@@ -929,3 +929,92 @@ class TestPageAwareBulkAccumulator:
         evaluator.update(gt, pred)
         bm = evaluator.compute().accumulator_metrics["bbox_map_metrics"]
         assert bm["mean_ap"] == 1.0
+
+
+class TestPageAwareMultiPageAggregate:
+    """Multi-field documents spread across pages.
+
+    The single-field page tests above pin the per-box decision (same-page hit,
+    wrong-page miss). These pin the *aggregate* mAP over several fields on
+    different pages in one document — the realistic multi-page case. Coordinates
+    are identical for every field so the page number is the only variable: any
+    deviation from the expected mean_ap can only come from page handling.
+    """
+
+    # Same box reused everywhere; only the trailing page element differs.
+    _BOX = [[0, 0], [10, 10]]
+
+    def _rows(self, keys):
+        """Matched field_comparisons rows (no reordering) for the given keys."""
+        return [{"expected_key": k, "actual_key": k, "match": True} for k in keys]
+
+    def test_mixed_pages_aggregate(self):
+        """Half the fields on the right page, half on the wrong page -> mAP 0.5."""
+        calc = MAPCalculator(iou_thresholds=0.5, page_aware=True)
+        # Four fields keyed by (page, field); a,b on page 1, c,d on page 2.
+        gt = {
+            "p1.a": self._BOX + [1],
+            "p1.b": self._BOX + [1],
+            "p2.c": self._BOX + [2],
+            "p2.d": self._BOX + [2],
+        }
+        # a,c predicted on the correct page (hit); b,d on the wrong page (miss).
+        pred = {
+            "p1.a": self._BOX + [1],
+            "p1.b": self._BOX + [2],
+            "p2.c": self._BOX + [2],
+            "p2.d": self._BOX + [1],
+        }
+        conf = {k: 0.9 for k in pred}
+        ex = calc.extract_from_dicts(self._rows(gt), gt, pred, conf)
+        metrics = calc.compute_metrics(ex.keyed_pairs, 4, 4)
+        # Each field path is its own class: two score AP 1.0, two AP 0.0.
+        assert metrics["mean_ap"] == 0.5
+        assert metrics["fields"]["p1.a"]["ap"] == 1.0
+        assert metrics["fields"]["p1.b"]["ap"] == 0.0
+        assert metrics["fields"]["p2.c"]["ap"] == 1.0
+        assert metrics["fields"]["p2.d"]["ap"] == 0.0
+
+    def test_all_correct_pages_aggregate_is_one(self):
+        """Every field on its correct page -> mAP 1.0 across all pages."""
+        calc = MAPCalculator(iou_thresholds=0.5, page_aware=True)
+        gt = {
+            "p1.a": self._BOX + [1],
+            "p2.b": self._BOX + [2],
+            "p3.c": self._BOX + [3],
+        }
+        pred = {k: list(v) for k, v in gt.items()}
+        conf = {k: 0.9 for k in pred}
+        ex = calc.extract_from_dicts(self._rows(gt), gt, pred, conf)
+        assert calc.compute_metrics(ex.keyed_pairs, 3, 3)["mean_ap"] == 1.0
+
+    def test_all_wrong_pages_aggregate_is_zero(self):
+        """Perfect coordinates but every field on the wrong page -> mAP 0.0."""
+        calc = MAPCalculator(iou_thresholds=0.5, page_aware=True)
+        gt = {
+            "p1.a": self._BOX + [1],
+            "p2.b": self._BOX + [2],
+            "p3.c": self._BOX + [3],
+        }
+        # Shift each prediction to a different page than its ground truth.
+        pred = {
+            "p1.a": self._BOX + [2],
+            "p2.b": self._BOX + [3],
+            "p3.c": self._BOX + [1],
+        }
+        conf = {k: 0.9 for k in pred}
+        ex = calc.extract_from_dicts(self._rows(gt), gt, pred, conf)
+        assert calc.compute_metrics(ex.keyed_pairs, 3, 3)["mean_ap"] == 0.0
+
+    def test_same_coords_wrong_pages_would_hit_when_unaware(self):
+        """Control: the same all-wrong-page doc scores 1.0 when page-unaware.
+
+        Guards against a regression where page-awareness silently stops being
+        applied — without it, identical coordinates hit regardless of page.
+        """
+        calc = MAPCalculator(iou_thresholds=0.5)  # page_aware defaults False
+        gt = {"p1.a": self._BOX + [1], "p2.b": self._BOX + [2]}
+        pred = {"p1.a": self._BOX + [2], "p2.b": self._BOX + [1]}
+        conf = {k: 0.9 for k in pred}
+        ex = calc.extract_from_dicts(self._rows(gt), gt, pred, conf)
+        assert calc.compute_metrics(ex.keyed_pairs, 2, 2)["mean_ap"] == 1.0

--- a/uv.lock
+++ b/uv.lock
@@ -3068,7 +3068,7 @@ wheels = [
 
 [[package]]
 name = "stickler-eval"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

Threads page-awareness through the **mAP scoring pipeline**, building on the
`page_aware` `BBoxIoUComparator` from this base branch (`sr/bbox-page-aware`).

That branch made the *comparator* page-aware, but the end-to-end mAP path still
constructed a plain `BBoxIoUComparator()`, so a prediction with correct
coordinates on the **wrong page** would still score as a hit in `mean_ap`. This
PR closes that gap.

## Changes

- **`MAPCalculator(page_aware=...)`** — passes the flag to its
  `BBoxIoUComparator`.
- **`BBoxMAPAccumulator(page_aware=...)`** — forwards to `MAPCalculator` for the
  bulk path.
- **`compare_with(add_bbox_metrics=True, bbox_page_aware=...)`** (and the
  `StructuredModel` wrapper) — single-document path.

Default stays `page_aware=False`, so existing behavior is unchanged. No
data-model change was needed: page-suffixed boxes
(`[[x1, y1], [x2, y2], page]` / `[x1, y1, x2, y2, page]`) already flow from
`_bbox` extras straight to the comparator.

## Behavior

With `page_aware=True`, a field is a localization hit only when the page matches
**and** IoU ≥ threshold:

| GT page | Pred page | Coords | page-aware mAP |
|---|---|---|---|
| 1 | 1 | identical | 1.0 |
| 1 | 2 | identical | 0.0 (wrong page) |
| 1 | (none) | identical | 0.0 (page-less is a miss) |

Page-unaware (default) ignores the page and scores the geometry only.

## Usage

```python
# Bulk
evaluator = BulkStructuredModelEvaluator(
    accumulators=[BBoxMAPAccumulator(page_aware=True)],
)

# Single document
result = gt.compare_with(pred, add_bbox_metrics=True, bbox_page_aware=True)
```

with page-suffixed rich values, e.g.
`{"_value": "Acme", "_bbox": [[10, 20], [200, 50], 1]}`.

## Testing

- 11 new tests across the calculator, `compare_with`, and bulk accumulator
  paths (same-page hit, wrong-page miss, page-less miss, default-unaware).
- Full suite: 1452 passed, 2 skipped.
- `ruff check` and `ruff format --check` clean on changed files.

Stacked on `sr/bbox-page-aware`; once that merges, this can retarget to `dev`.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
