### PR TITLE
fix(json-schema): annotate optional fields as Optional[T] so from_json accepts None

### DIFF
--- a/docs/docs/Advanced/dynamic-models.md
+++ b/docs/docs/Advanced/dynamic-models.md
@@ -135,6 +135,13 @@ Two consequences are worth noting:
   rather than crash evaluation.
 - `model_json_schema()` reflects this by emitting `{"anyOf": [{"type": "string"}, {"type": "null"}]}`
   for such fields.
+- `to_json_schema()` likewise makes the nullability explicit, emitting
+  `{"type": ["string", "null"]}`. So an optional property declared only as
+  `{"type": "string"}` gains an explicit `"null"` on export that the input schema
+  never stated. This is intended: "absent from `required`" already means the value
+  may be `None`, and the exported schema now says so out loud instead of leaving it
+  implicit. The round trip is idempotent — re-importing the exported schema and
+  exporting again yields the same document, and accepts the same values.
 
 ---
 

--- a/docs/docs/Advanced/dynamic-models.md
+++ b/docs/docs/Advanced/dynamic-models.md
@@ -117,6 +117,25 @@ Default comparators are assigned by JSON Schema type when no extension is specif
 
 For the complete reference, see the [Evaluation](../Guides/Evaluation/README.md) page.
 
+### Optional fields and `null`
+
+A property that is **not** listed in `required` (or that declares an explicit
+`"default": null`) is built as an optional field: its Python annotation is
+widened to `Optional[T]` and its default is `None`. This keeps the model usable
+through every construction path — in particular `from_json(..., process_rich_values=True)`,
+which round-trips nested objects and would otherwise re-validate the `None`
+default against a non-nullable annotation and raise.
+
+Two consequences are worth noting:
+
+- An explicit `null` is **accepted** for an optional typed field (e.g. a JSON
+  payload `{"note": null}` for an optional `string`), even though strict JSON
+  Schema treats `null` as invalid for `"type": "string"`. This is deliberate:
+  model predictions often emit explicit nulls, and these should score as a value
+  rather than crash evaluation.
+- `model_json_schema()` reflects this by emitting `{"anyOf": [{"type": "string"}, {"type": "null"}]}`
+  for such fields.
+
 ---
 
 ## Method 2: Custom Stickler Configuration

--- a/src/stickler/reporting/html/utils/data_extractors.py
+++ b/src/stickler/reporting/html/utils/data_extractors.py
@@ -3,7 +3,7 @@ Data extraction utilities for HTML reporting.
 Centralizes data access patterns that were previously duplicated across multiple modules.
 """
 import logging
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, get_args, get_origin
 
 from stickler.utils.process_evaluation import ProcessEvaluation
 
@@ -194,7 +194,19 @@ class DataExtractor:
                 # Handle nested fields
                 field_info = model_schema.__fields__[field_name]
                 field_type = getattr(field_info, 'annotation', None)
-                
+
+                # Unwrap Optional[...] (Union[X, None]) so nested-model and
+                # List[...] detection below also fires for non-required fields,
+                # which are annotated Optional[T] (issue #149). Without this,
+                # nested thresholds vanish from HTML reports for schema-built
+                # models whose nested object / list fields are optional.
+                if get_origin(field_type) is Union:
+                    non_none_args = [
+                        arg for arg in get_args(field_type) if arg is not type(None)
+                    ]
+                    if len(non_none_args) == 1:
+                        field_type = non_none_args[0]
+
                 # Check for nested StructuredModel
                 if field_type and hasattr(field_type, '__fields__'):
                     nested_thresholds = DataExtractor.extract_all_field_thresholds(field_type)

--- a/src/stickler/structured_object_evaluator/models/configuration_helper.py
+++ b/src/stickler/structured_object_evaluator/models/configuration_helper.py
@@ -162,6 +162,13 @@ class ConfigurationHelper:
                             ):
                                 return True
 
+                # Handle Optional[StructuredModel] (Union[StructuredModel, NoneType]).
+                # Non-required nested object fields are annotated this way (#149); without
+                # this, optional nested objects inside list items are routed down the
+                # non-hierarchical path and lose their nested metric breakdown.
+                if ConfigurationHelper._is_optional_structured_model(annotation):
+                    return True
+
             # Handle direct StructuredModel annotations
             elif inspect.isclass(annotation):
                 if issubclass(annotation, StructuredModel):

--- a/src/stickler/structured_object_evaluator/models/field_converter.py
+++ b/src/stickler/structured_object_evaluator/models/field_converter.py
@@ -4,7 +4,7 @@ This module provides utilities for converting JSON field configurations to
 Pydantic Field instances with ComparableField functionality.
 """
 
-from typing import Any, Dict, Tuple, Type
+from typing import Any, Dict, Optional, Tuple, Type
 
 from pydantic import Field
 
@@ -85,6 +85,16 @@ class FieldConverter:
         elif not required and default == ...:
             # If not required and no default specified, use None
             default = None
+
+        # Widen the annotation to Optional[...] whenever the resolved default is
+        # None, so the None default is a valid value. Mirrors the JSON-Schema path
+        # (json_schema_field_converter.py) — issue #149: the rich-value path
+        # round-trips through from_json(...).model_dump(), which materializes the
+        # None default and re-validates it against the annotation. Without this,
+        # a schema -> to_stickler_config -> model_from_json round-trip rebuilds a
+        # broken model.
+        if default is None:
+            field_type = Optional[field_type]
 
         # Create ComparableField
         comparable_field = ComparableField(

--- a/src/stickler/structured_object_evaluator/models/json_schema_field_converter.py
+++ b/src/stickler/structured_object_evaluator/models/json_schema_field_converter.py
@@ -126,12 +126,24 @@ class JsonSchemaFieldConverter:
             property_schema.get("type"), field_path
         )
 
+        # Decide annotation widening ONCE here, the sole dispatcher (and the
+        # convergence point with #127). Three independent reasons a field needs
+        # a nullable annotation, folded into one condition below:
+        #   - it is not required, so it carries a None default (issue #149);
+        #   - it declares an explicit ``"default": null`` even while required;
+        #   - it declares explicit nullability as ``type: ["X", "null"]`` (#127).
+        # Optional[Optional[T]] collapses, so the nested-object / array handlers
+        # never widen themselves -- item-level nullability inside arrays
+        # (List[Optional[T]]) is still applied by _handle_array_type.
+        default = property_schema.get("default", ... if is_required else None)
+        widen_to_optional = (not is_required) or (default is None) or is_nullable
+
         # Handle nested objects
         if json_type == "object":
             field_type, field = self._handle_nested_object(
                 field_name, property_schema, is_required, field_path
             )
-            if is_nullable:
+            if widen_to_optional:
                 field_type = Optional[field_type]
             return field_type, field
 
@@ -140,15 +152,13 @@ class JsonSchemaFieldConverter:
             field_type, field = self._handle_array_type(
                 field_name, property_schema, is_required, field_path
             )
-            if is_nullable:
+            if widen_to_optional:
                 field_type = Optional[field_type]
             return field_type, field
 
         # Handle primitive types
         field_type = self._map_json_type_to_python_type(json_type)
-        if is_nullable:
-            field_type = Optional[field_type]
-        
+
         # Extract x-aws-stickler-* extensions
         extensions = self._extract_stickler_extensions(property_schema, field_path)
         
@@ -160,11 +170,14 @@ class JsonSchemaFieldConverter:
         weight = extensions.get("weight", 1.0)
         clip_under_threshold = extensions.get("clip_under_threshold", True)
         
-        # Get Pydantic field parameters
-        default = property_schema.get("default", ... if is_required else None)
+        # Get Pydantic field parameters (``default`` resolved above, where the
+        # widening decision needed it).
         description = property_schema.get("description")
         examples = property_schema.get("examples")
-        
+
+        if widen_to_optional:
+            field_type = Optional[field_type]
+
         # Call ComparableField() to create the Pydantic Field
         field = ComparableField(
             comparator=comparator,
@@ -175,7 +188,7 @@ class JsonSchemaFieldConverter:
             description=description,
             examples=examples
         )
-        
+
         return field_type, field
 
     def _normalize_type(
@@ -409,8 +422,16 @@ class JsonSchemaFieldConverter:
             default=default,
             description=description
         )
-        
-        return NestedModel, field
+
+        # Widen the annotation to Optional[...] for non-required fields so the
+        # None default is a valid value. See issue #149: the rich-value path
+        # round-trips through from_json(...).model_dump(), which materializes
+        # the None default and re-validates it against the annotation.
+        field_type = NestedModel
+        if not is_required:
+            field_type = Optional[field_type]
+
+        return field_type, field
 
     def _handle_array_type(
         self, field_name: str, property_schema: Dict[str, Any], is_required: bool, field_path: str = None
@@ -474,7 +495,14 @@ class JsonSchemaFieldConverter:
         # Get default
         default = property_schema.get("default", ... if is_required else None)
         description = property_schema.get("description")
-        
+
+        # Widen the annotation to Optional[...] for non-required fields so the
+        # None default is a valid value. See issue #149: the rich-value path
+        # round-trips through from_json(...).model_dump(), which materializes
+        # the None default and re-validates it against the annotation.
+        if not is_required:
+            field_type = Optional[field_type]
+
         # Create ComparableField
         field = ComparableField(
             comparator=comparator,
@@ -484,7 +512,7 @@ class JsonSchemaFieldConverter:
             default=default,
             description=description
         )
-        
+
         return field_type, field
 
     

--- a/src/stickler/structured_object_evaluator/models/json_schema_field_converter.py
+++ b/src/stickler/structured_object_evaluator/models/json_schema_field_converter.py
@@ -126,68 +126,62 @@ class JsonSchemaFieldConverter:
             property_schema.get("type"), field_path
         )
 
-        # Decide annotation widening ONCE here, the sole dispatcher (and the
-        # convergence point with #127). Three independent reasons a field needs
-        # a nullable annotation, folded into one condition below:
+        # Decide annotation widening ONCE here, in the sole dispatcher (also the
+        # convergence point with #127). Three independent reasons a field needs a
+        # nullable annotation, folded into one condition:
         #   - it is not required, so it carries a None default (issue #149);
         #   - it declares an explicit ``"default": null`` even while required;
         #   - it declares explicit nullability as ``type: ["X", "null"]`` (#127).
-        # Optional[Optional[T]] collapses, so the nested-object / array handlers
-        # never widen themselves -- item-level nullability inside arrays
+        # Both leave a None that the rich-value path materializes via
+        # from_json(...).model_dump() and re-validates against the annotation.
+        # Keeping this in one place means the nested-object / array handlers
+        # never widen themselves; item-level nullability inside arrays
         # (List[Optional[T]]) is still applied by _handle_array_type.
         default = property_schema.get("default", ... if is_required else None)
         widen_to_optional = (not is_required) or (default is None) or is_nullable
 
-        # Handle nested objects
+        # Handle nested objects / arrays via their handlers; primitives inline.
         if json_type == "object":
             field_type, field = self._handle_nested_object(
                 field_name, property_schema, is_required, field_path
             )
-            if widen_to_optional:
-                field_type = Optional[field_type]
-            return field_type, field
-
-        # Handle arrays
-        if json_type == "array":
+        elif json_type == "array":
             field_type, field = self._handle_array_type(
                 field_name, property_schema, is_required, field_path
             )
-            if widen_to_optional:
-                field_type = Optional[field_type]
-            return field_type, field
+        else:
+            # Handle primitive types
+            field_type = self._map_json_type_to_python_type(json_type)
 
-        # Handle primitive types
-        field_type = self._map_json_type_to_python_type(json_type)
+            # Extract x-aws-stickler-* extensions
+            extensions = self._extract_stickler_extensions(property_schema, field_path)
 
-        # Extract x-aws-stickler-* extensions
-        extensions = self._extract_stickler_extensions(property_schema, field_path)
-        
-        # Get comparator (from extension or default)
-        comparator = extensions.get("comparator") or self._get_default_comparator_for_type(json_type)
-        
-        # Get other parameters
-        threshold = extensions.get("threshold", 0.5)
-        weight = extensions.get("weight", 1.0)
-        clip_under_threshold = extensions.get("clip_under_threshold", True)
-        
-        # Get Pydantic field parameters (``default`` resolved above, where the
-        # widening decision needed it).
-        description = property_schema.get("description")
-        examples = property_schema.get("examples")
+            # Get comparator (from extension or default)
+            comparator = extensions.get("comparator") or self._get_default_comparator_for_type(json_type)
+
+            # Get other parameters
+            threshold = extensions.get("threshold", 0.5)
+            weight = extensions.get("weight", 1.0)
+            clip_under_threshold = extensions.get("clip_under_threshold", True)
+
+            # Get Pydantic field parameters (``default`` resolved above, where
+            # the widening decision needed it).
+            description = property_schema.get("description")
+            examples = property_schema.get("examples")
+
+            # Call ComparableField() to create the Pydantic Field
+            field = ComparableField(
+                comparator=comparator,
+                threshold=threshold,
+                weight=weight,
+                clip_under_threshold=clip_under_threshold,
+                default=default,
+                description=description,
+                examples=examples
+            )
 
         if widen_to_optional:
             field_type = Optional[field_type]
-
-        # Call ComparableField() to create the Pydantic Field
-        field = ComparableField(
-            comparator=comparator,
-            threshold=threshold,
-            weight=weight,
-            clip_under_threshold=clip_under_threshold,
-            default=default,
-            description=description,
-            examples=examples
-        )
 
         return field_type, field
 
@@ -423,15 +417,9 @@ class JsonSchemaFieldConverter:
             description=description
         )
 
-        # Widen the annotation to Optional[...] for non-required fields so the
-        # None default is a valid value. See issue #149: the rich-value path
-        # round-trips through from_json(...).model_dump(), which materializes
-        # the None default and re-validates it against the annotation.
-        field_type = NestedModel
-        if not is_required:
-            field_type = Optional[field_type]
-
-        return field_type, field
+        # Annotation widening (Optional[...]) is decided once by the caller
+        # convert_property_to_field; this handler returns the bare nested model.
+        return NestedModel, field
 
     def _handle_array_type(
         self, field_name: str, property_schema: Dict[str, Any], is_required: bool, field_path: str = None
@@ -496,13 +484,6 @@ class JsonSchemaFieldConverter:
         default = property_schema.get("default", ... if is_required else None)
         description = property_schema.get("description")
 
-        # Widen the annotation to Optional[...] for non-required fields so the
-        # None default is a valid value. See issue #149: the rich-value path
-        # round-trips through from_json(...).model_dump(), which materializes
-        # the None default and re-validates it against the annotation.
-        if not is_required:
-            field_type = Optional[field_type]
-
         # Create ComparableField
         field = ComparableField(
             comparator=comparator,
@@ -513,6 +494,8 @@ class JsonSchemaFieldConverter:
             description=description
         )
 
+        # Annotation widening (Optional[...]) is decided once by the caller
+        # convert_property_to_field; this handler returns the bare List[...].
         return field_type, field
 
     

--- a/tests/structured_object_evaluator/test_configuration_helper_optional_structured.py
+++ b/tests/structured_object_evaluator/test_configuration_helper_optional_structured.py
@@ -1,0 +1,55 @@
+"""Tests for ConfigurationHelper.is_structured_field_type on Optional[StructuredModel].
+
+Regression for issue #149 review (@adiadd): the annotation-level fix widens
+non-required nested object fields to ``Optional[NestedModel]``, but
+``is_structured_field_type`` only recognized ``StructuredModel`` and
+``List[StructuredModel]`` (bare or Optional-wrapped) — never a bare
+``Optional[StructuredModel]``. That routed optional nested objects inside
+list-of-object items down the non-hierarchical (flat-counts) path, silently
+dropping the nested metric breakdown.
+"""
+
+from typing import List, Optional
+
+from stickler.comparators.exact import ExactComparator
+from stickler.structured_object_evaluator.models.comparable_field import ComparableField
+from stickler.structured_object_evaluator.models.configuration_helper import (
+    ConfigurationHelper,
+)
+from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+
+
+class _Inner(StructuredModel):
+    city: str = ComparableField(comparator=ExactComparator())
+
+
+class _Outer(StructuredModel):
+    req_obj: _Inner = ComparableField(comparator=ExactComparator())
+    opt_obj: Optional[_Inner] = ComparableField(
+        default=None, comparator=ExactComparator()
+    )
+    opt_list: Optional[List[_Inner]] = ComparableField(default=None)
+    opt_str: Optional[str] = ComparableField(default=None, comparator=ExactComparator())
+
+
+class TestIsStructuredFieldTypeOptional:
+    """is_structured_field_type must recognize Optional[StructuredModel]."""
+
+    def test_bare_structured_model_is_structured(self):
+        fi = _Outer.model_fields["req_obj"]
+        assert ConfigurationHelper.is_structured_field_type(fi) is True
+
+    def test_optional_structured_model_is_structured(self):
+        """Optional[StructuredModel] must be recognized as structured (#149)."""
+        fi = _Outer.model_fields["opt_obj"]
+        assert ConfigurationHelper.is_structured_field_type(fi) is True
+
+    def test_optional_list_of_structured_model_is_structured(self):
+        """Pre-existing support: Optional[List[StructuredModel]] stays structured."""
+        fi = _Outer.model_fields["opt_list"]
+        assert ConfigurationHelper.is_structured_field_type(fi) is True
+
+    def test_optional_primitive_is_not_structured(self):
+        """Optional[str] must NOT be treated as structured."""
+        fi = _Outer.model_fields["opt_str"]
+        assert ConfigurationHelper.is_structured_field_type(fi) is False

--- a/tests/structured_object_evaluator/test_data_extractors_optional_thresholds.py
+++ b/tests/structured_object_evaluator/test_data_extractors_optional_thresholds.py
@@ -1,0 +1,67 @@
+"""Regression test for issue #149 review (@adiadd): HTML report thresholds.
+
+The Optional[T] widening means a non-required nested object on a schema-built
+model is annotated ``Optional[NestedModel]`` (and a non-required list of objects
+``Optional[List[NestedModel]]``). ``DataExtractor.extract_all_field_thresholds``
+walked into nested models via ``hasattr(field_type, '__fields__')`` and into
+lists via ``__origin__ is list`` but never unwrapped ``Optional[...]``, so nested
+field thresholds silently vanished from HTML reports for those fields.
+"""
+
+from stickler.reporting.html.utils.data_extractors import DataExtractor
+from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+
+
+class TestOptionalNestedThresholds:
+    def test_optional_nested_object_thresholds_extracted(self):
+        """Thresholds on an OPTIONAL nested object's inner fields survive."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "addr": {  # OPTIONAL nested object -> Optional[NestedModel]
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string", "x-aws-stickler-threshold": 0.9},
+                    },
+                    "required": ["city"],
+                },
+            },
+            "required": [],
+        }
+
+        M = StructuredModel.from_json_schema(schema)
+        thresholds = DataExtractor.extract_all_field_thresholds(M)
+
+        assert "addr.city" in thresholds, (
+            "nested threshold on an optional nested object was dropped "
+            "(Optional[NestedModel] not unwrapped)"
+        )
+        assert thresholds["addr.city"] == 0.9
+
+    def test_optional_list_of_objects_thresholds_extracted(self):
+        """Thresholds on an OPTIONAL list-of-objects' inner fields survive."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "items": {  # OPTIONAL array of objects -> Optional[List[NestedModel]]
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "sku": {"type": "string", "x-aws-stickler-threshold": 0.8},
+                        },
+                        "required": ["sku"],
+                    },
+                },
+            },
+            "required": [],
+        }
+
+        M = StructuredModel.from_json_schema(schema)
+        thresholds = DataExtractor.extract_all_field_thresholds(M)
+
+        assert "items.sku" in thresholds, (
+            "nested threshold on an optional list-of-objects was dropped "
+            "(Optional[List[NestedModel]] not unwrapped)"
+        )
+        assert thresholds["items.sku"] == 0.8

--- a/tests/structured_object_evaluator/test_export_roundtrip.py
+++ b/tests/structured_object_evaluator/test_export_roundtrip.py
@@ -231,7 +231,15 @@ def test_optional_field_roundtrip():
     schema = OptionalModel.to_json_schema()
     Reconstructed = StructuredModel.from_json_schema(schema)
 
-    # Test with non-None values (Optional nature is not preserved in round-trip — known limitation)
+    # The Optional nature now survives the JSON-Schema round-trip (issue #149):
+    # the reconstructed optional field is annotated Optional[str] and accepts None.
+    import typing
+
+    recon_note = Reconstructed.model_fields["note"].annotation
+    assert typing.get_origin(recon_note) is typing.Union
+    assert type(None) in typing.get_args(recon_note)
+    assert Reconstructed(name="Test", note=None).note is None
+
     o1 = OptionalModel(name="Test", note="hello")
     r1 = Reconstructed(name="Test", note="hello")
 

--- a/tests/structured_object_evaluator/test_field_converter_optional_roundtrip.py
+++ b/tests/structured_object_evaluator/test_field_converter_optional_roundtrip.py
@@ -1,0 +1,73 @@
+"""Regression tests for the stickler-config path of issue #149 (@adiadd review).
+
+The JSON-Schema path (json_schema_field_converter.py) widens non-required fields
+to ``Optional[T]``. The parallel stickler-config path (field_converter.py, used by
+``StructuredModel.model_from_json``) did not, so a schema-built model that is
+exported via ``to_stickler_config`` and rebuilt via ``model_from_json`` round-trips
+a fixed model back into a broken one: ``from_json(process_rich_values=True)`` then
+crashes on the materialized ``None`` default exactly as in #149.
+"""
+
+from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+
+
+class TestFieldConverterOptionalRoundTrip:
+    def test_model_from_json_optional_field_accepts_none_via_from_json(self):
+        """A non-required field built via model_from_json accepts an omitted value
+        through the rich-value path."""
+        config = {
+            "model_name": "Doc",
+            "fields": {
+                "title": {
+                    "type": "str",
+                    "comparator": "LevenshteinComparator",
+                    "required": True,
+                },
+                "note": {
+                    "type": "str",
+                    "comparator": "LevenshteinComparator",
+                    "required": False,  # optional -> Optional[str]
+                },
+            },
+        }
+
+        M = StructuredModel.model_from_json(config)
+        data = {"title": "x"}
+
+        plain = M(**data)
+        rich = M.from_json(data, process_rich_values=True)
+        assert plain.note is None
+        assert rich.note is None
+        assert plain.model_dump() == rich.model_dump()
+
+    def test_schema_to_stickler_config_to_model_round_trip(self):
+        """schema -> to_stickler_config -> model_from_json yields a WORKING model.
+
+        Pins the round-trip hole @adiadd flagged: the optional inner field must
+        survive the round-trip and still accept an omitted value through
+        from_json(process_rich_values=True).
+        """
+        schema = {
+            "type": "object",
+            "properties": {
+                "C": {
+                    "type": "object",
+                    "properties": {
+                        "A": {"type": "string"},
+                        "B": {"type": "string"},  # OPTIONAL inner
+                    },
+                    "required": ["A"],
+                },
+            },
+            "required": ["C"],
+        }
+
+        M = StructuredModel.from_json_schema(schema)
+        rebuilt = StructuredModel.model_from_json(M.to_stickler_config())
+
+        data = {"C": {"A": "x"}}
+        plain = rebuilt(**data)
+        rich = rebuilt.from_json(data, process_rich_values=True)
+        assert plain.C.B is None
+        assert rich.C.B is None
+        assert plain.model_dump() == rich.model_dump()

--- a/tests/structured_object_evaluator/test_json_schema_field_converter.py
+++ b/tests/structured_object_evaluator/test_json_schema_field_converter.py
@@ -1,6 +1,8 @@
 """Integration tests for JsonSchemaFieldConverter.convert_properties_to_fields()."""
 
 
+import typing
+
 import pytest
 
 from stickler.comparators.exact import ExactComparator
@@ -9,6 +11,21 @@ from stickler.comparators.numeric import NumericComparator
 from stickler.structured_object_evaluator.models.json_schema_field_converter import (
     JsonSchemaFieldConverter,
 )
+
+
+def _unwrap_optional(field_type):
+    """Strip ``Optional[...]`` (i.e. ``Union[X, None]``) down to the inner type.
+
+    Non-required JSON-Schema fields are annotated as ``Optional[T]`` so their
+    ``None`` default is valid (issue #149). Required fields stay bare. This
+    helper lets type assertions target the underlying ``T`` regardless of the
+    optional wrapper.
+    """
+    if typing.get_origin(field_type) is typing.Union:
+        args = [a for a in typing.get_args(field_type) if a is not type(None)]
+        if len(args) == 1:
+            return args[0]
+    return field_type
 
 
 class TestConvertPropertiesToFields:
@@ -38,11 +55,13 @@ class TestConvertPropertiesToFields:
         assert "price" in field_definitions
         assert "active" in field_definitions
 
-        # Check types
-        assert field_definitions["name"][0] is str
-        assert field_definitions["age"][0] is int
-        assert field_definitions["price"][0] is float
-        assert field_definitions["active"][0] is bool
+        # Check types. Required fields keep a bare annotation; optional fields
+        # are widened to Optional[...] (issue #149) so their None default is
+        # valid, so unwrap before comparing the underlying type.
+        assert field_definitions["name"][0] is str  # required -> bare
+        assert field_definitions["age"][0] is int  # required -> bare
+        assert _unwrap_optional(field_definitions["price"][0]) is float  # optional
+        assert _unwrap_optional(field_definitions["active"][0]) is bool  # optional
 
         # Check required vs optional (via is_required)
         name_field = field_definitions["name"][1]
@@ -54,6 +73,62 @@ class TestConvertPropertiesToFields:
         assert age_field.is_required()  # Required
         assert not price_field.is_required()  # Optional
         assert not active_field.is_required()  # Optional
+
+    def test_not_required_fields_are_optional_annotations(self):
+        """Non-required fields get Optional[...] annotations; required stay bare.
+
+        Regression for issue #149: an optional field has ``default=None`` but
+        must also be annotated as ``Optional[...]`` so that None is valid when
+        the rich-value path round-trips through from_json(...).model_dump().
+        Covers all three sites: primitive, nested object, and array.
+        """
+        schema = {
+            "type": "object",
+            "properties": {
+                # Required primitive -> bare
+                "req_str": {"type": "string"},
+                # Optional primitive -> Optional[str]
+                "opt_str": {"type": "string"},
+                # Optional nested object -> Optional[NestedModel]
+                "opt_obj": {
+                    "type": "object",
+                    "properties": {"inner": {"type": "string"}},
+                },
+                # Optional array -> Optional[List[str]]
+                "opt_arr": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["req_str"],
+        }
+
+        converter = JsonSchemaFieldConverter(schema)
+        field_definitions = converter.convert_properties_to_fields(
+            schema["properties"], schema["required"]
+        )
+
+        # Required field stays a bare annotation.
+        req_type = field_definitions["req_str"][0]
+        assert req_type is str
+        assert typing.get_origin(req_type) is not typing.Union
+
+        # Each optional field is wrapped in Optional[...] (Union[X, None]).
+        for name, inner_check in [
+            ("opt_str", lambda t: t is str),
+            (
+                "opt_obj",
+                lambda t: (
+                    __import__(
+                        "stickler.structured_object_evaluator.models.structured_model",
+                        fromlist=["StructuredModel"],
+                    ).StructuredModel
+                    in t.__mro__
+                ),
+            ),
+            ("opt_arr", lambda t: typing.get_origin(t) is list),
+        ]:
+            field_type = field_definitions[name][0]
+            assert typing.get_origin(field_type) is typing.Union, name
+            assert type(None) in typing.get_args(field_type), name
+            assert inner_check(_unwrap_optional(field_type)), name
 
     def test_convert_with_default_comparators(self):
         """Test that default comparators are assigned correctly."""
@@ -189,9 +264,11 @@ class TestConvertPropertiesToFields:
             schema["properties"], schema["required"]
         )
 
-        # Check types are List[primitive]
-        tags_type = field_definitions["tags"][0]
-        scores_type = field_definitions["scores"][0]
+        # Check types are List[primitive]. Both fields are optional (not in
+        # required), so they are widened to Optional[List[...]] (issue #149);
+        # unwrap to inspect the List.
+        tags_type = _unwrap_optional(field_definitions["tags"][0])
+        scores_type = _unwrap_optional(field_definitions["scores"][0])
 
         # Verify they are List types
         assert hasattr(tags_type, "__origin__")
@@ -317,8 +394,9 @@ class TestConvertPropertiesToFields:
             assert isinstance(field_name, str)
             assert isinstance(field_def, tuple)
             assert len(field_def) == 2
-            # First element is a type
-            assert isinstance(field_def[0], type)
+            # First element is a type. Optional fields are wrapped in
+            # Optional[...] (issue #149), so unwrap before the type check.
+            assert isinstance(_unwrap_optional(field_def[0]), type)
             # Second element is a Pydantic FieldInfo
             from pydantic.fields import FieldInfo
             assert isinstance(field_def[1], FieldInfo)
@@ -351,10 +429,12 @@ class TestRefResolution:
             schema["properties"], schema["required"]
         )
 
-        # Should successfully resolve and create nested model
+        # Should successfully resolve and create nested model.
+        # 'home' is optional, so the annotation is Optional[NestedModel]
+        # (issue #149); unwrap to inspect the model class.
         assert "home" in field_definitions
-        home_type = field_definitions["home"][0]
-        
+        home_type = _unwrap_optional(field_definitions["home"][0])
+
         # Verify it's a StructuredModel subclass
         from stickler.structured_object_evaluator.models.structured_model import (
             StructuredModel,
@@ -385,10 +465,12 @@ class TestRefResolution:
             schema["properties"], schema["required"]
         )
 
-        # Should successfully resolve and create nested model
+        # Should successfully resolve and create nested model.
+        # 'contact' is optional, so the annotation is Optional[NestedModel]
+        # (issue #149); unwrap to inspect the model class.
         assert "contact" in field_definitions
-        contact_type = field_definitions["contact"][0]
-        
+        contact_type = _unwrap_optional(field_definitions["contact"][0])
+
         # Verify it's a StructuredModel subclass
         from stickler.structured_object_evaluator.models.structured_model import (
             StructuredModel,
@@ -468,14 +550,16 @@ class TestRefResolution:
             schema["properties"], schema["required"]
         )
 
-        # Should successfully resolve and create List[StructuredModel]
+        # Should successfully resolve and create List[StructuredModel].
+        # 'items' is optional, so the annotation is Optional[List[...]]
+        # (issue #149); unwrap to inspect the List.
         assert "items" in field_definitions
-        items_type = field_definitions["items"][0]
-        
+        items_type = _unwrap_optional(field_definitions["items"][0])
+
         # Verify it's a List type
         assert hasattr(items_type, "__origin__")
         assert items_type.__origin__ is list
-        
+
         # Verify element is a StructuredModel subclass
         from stickler.structured_object_evaluator.models.structured_model import (
             StructuredModel,
@@ -508,16 +592,17 @@ class TestNestedObjectHandling:
             schema["properties"], schema["required"]
         )
 
-        # Check nested model was created
+        # Check nested model was created. 'person' is optional, so the
+        # annotation is Optional[NestedModel] (issue #149); unwrap it.
         assert "person" in field_definitions
-        person_type = field_definitions["person"][0]
-        
+        person_type = _unwrap_optional(field_definitions["person"][0])
+
         # Verify it's a StructuredModel subclass
         from stickler.structured_object_evaluator.models.structured_model import (
             StructuredModel,
         )
         assert issubclass(person_type, StructuredModel)
-        
+
         # Verify nested model has correct fields
         assert "name" in person_type.model_fields
         assert "age" in person_type.model_fields
@@ -583,15 +668,16 @@ class TestNestedObjectHandling:
             schema["properties"], schema["required"]
         )
 
-        # Should successfully create deeply nested structure
+        # Should successfully create deeply nested structure. 'company' is
+        # optional, so the annotation is Optional[NestedModel] (issue #149).
         assert "company" in field_definitions
-        company_type = field_definitions["company"][0]
-        
+        company_type = _unwrap_optional(field_definitions["company"][0])
+
         from stickler.structured_object_evaluator.models.structured_model import (
             StructuredModel,
         )
         assert issubclass(company_type, StructuredModel)
-        
+
         # Verify nested fields exist
         assert "name" in company_type.model_fields
         assert "address" in company_type.model_fields
@@ -624,14 +710,15 @@ class TestArrayHandling:
             schema["properties"], schema["required"]
         )
 
-        # Check array type
+        # Check array type. 'employees' is optional, so the annotation is
+        # Optional[List[...]] (issue #149); unwrap to inspect the List.
         assert "employees" in field_definitions
-        employees_type = field_definitions["employees"][0]
-        
+        employees_type = _unwrap_optional(field_definitions["employees"][0])
+
         # Verify it's a List type
         assert hasattr(employees_type, "__origin__")
         assert employees_type.__origin__ is list
-        
+
         # Verify element is a StructuredModel subclass
         from stickler.structured_object_evaluator.models.structured_model import (
             StructuredModel,
@@ -692,11 +779,12 @@ class TestArrayHandling:
             schema["properties"], schema["required"]
         )
 
-        # Check all array types
-        assert field_definitions["strings"][0].__args__[0] is str
-        assert field_definitions["integers"][0].__args__[0] is int
-        assert field_definitions["numbers"][0].__args__[0] is float
-        assert field_definitions["booleans"][0].__args__[0] is bool
+        # Check all array types. All fields are optional, so each annotation
+        # is Optional[List[...]] (issue #149); unwrap to inspect the List.
+        assert _unwrap_optional(field_definitions["strings"][0]).__args__[0] is str
+        assert _unwrap_optional(field_definitions["integers"][0]).__args__[0] is int
+        assert _unwrap_optional(field_definitions["numbers"][0]).__args__[0] is float
+        assert _unwrap_optional(field_definitions["booleans"][0]).__args__[0] is bool
 
 
 class TestErrorHandling:
@@ -997,8 +1085,9 @@ class TestNullableTypeListForm:
         from typing import Union, get_args, get_origin
 
         field_type, _ = fields["tags"]
-        # List[Optional[str]]
-        (inner,) = get_args(field_type)
+        # The field is not required, so the outer annotation is
+        # Optional[List[Optional[str]]] (issue #149); unwrap to inspect the List.
+        (inner,) = get_args(_unwrap_optional(field_type))
         assert get_origin(inner) is Union
         assert str in get_args(inner)
         assert type(None) in get_args(inner)
@@ -1049,6 +1138,47 @@ class TestNullableTypeListForm:
 
         Rebuilt = StructuredModel.from_json_schema(schema)
         assert Rebuilt(description=None).description is None
+
+    def test_optional_field_round_trips_as_explicitly_nullable(self):
+        """An optional-but-not-nullable field gains an explicit "null" on export.
+
+        This pins the interaction between the #149 widening (an optional field
+        is annotated Optional[T] so its None default validates) and the #127
+        exporter (an Optional[T] primitive is emitted as ["X", "null"]): a
+        property declared only as {"type": "string"} and omitted from
+        ``required`` round-trips out as ["string", "null"].
+
+        This is intentional, not incidental. Under the explicit-null contract
+        documented in docs/dynamic-models.md, "absent from required" means the
+        value may be None, and the exported schema now says so out loud rather
+        than leaving it implicit. The round trip is idempotent and lossless in
+        meaning -- rebuilding from the exported schema yields a model that
+        accepts exactly the same values.
+        """
+        from stickler import StructuredModel
+
+        Model = StructuredModel.from_json_schema(
+            {
+                "type": "object",
+                "properties": {"nickname": {"type": "string"}},
+                "required": [],
+            }
+        )
+
+        schema = Model.to_json_schema()
+        assert schema["properties"]["nickname"]["type"] == ["string", "null"]
+        assert "nickname" not in schema.get("required", [])
+
+        # Idempotent: exporting the rebuilt model produces the same schema, and
+        # the accepted value set is unchanged.
+        Rebuilt = StructuredModel.from_json_schema(schema)
+        assert Rebuilt.to_json_schema()["properties"]["nickname"]["type"] == [
+            "string",
+            "null",
+        ]
+        assert Rebuilt(nickname=None).nickname is None
+        assert Rebuilt(nickname="ada").nickname == "ada"
+        assert Model(nickname=None).nickname is None
 
     def test_nullable_object_array_element_accepts_none(self):
         """An array of nullable objects accepts None as a list element."""

--- a/tests/structured_object_evaluator/test_json_schema_field_converter.py
+++ b/tests/structured_object_evaluator/test_json_schema_field_converter.py
@@ -11,6 +11,7 @@ from stickler.comparators.numeric import NumericComparator
 from stickler.structured_object_evaluator.models.json_schema_field_converter import (
     JsonSchemaFieldConverter,
 )
+from stickler.structured_object_evaluator.models.structured_model import StructuredModel
 
 
 def _unwrap_optional(field_type):
@@ -20,6 +21,9 @@ def _unwrap_optional(field_type):
     ``None`` default is valid (issue #149). Required fields stay bare. This
     helper lets type assertions target the underlying ``T`` regardless of the
     optional wrapper.
+
+    Mirrors ``StructuredModel._unwrap_optional`` (structured_model.py); kept
+    local for test independence from production internals.
     """
     if typing.get_origin(field_type) is typing.Union:
         args = [a for a in typing.get_args(field_type) if a is not type(None)]
@@ -108,21 +112,11 @@ class TestConvertPropertiesToFields:
         # Required field stays a bare annotation.
         req_type = field_definitions["req_str"][0]
         assert req_type is str
-        assert typing.get_origin(req_type) is not typing.Union
 
         # Each optional field is wrapped in Optional[...] (Union[X, None]).
         for name, inner_check in [
             ("opt_str", lambda t: t is str),
-            (
-                "opt_obj",
-                lambda t: (
-                    __import__(
-                        "stickler.structured_object_evaluator.models.structured_model",
-                        fromlist=["StructuredModel"],
-                    ).StructuredModel
-                    in t.__mro__
-                ),
-            ),
+            ("opt_obj", lambda t: issubclass(t, StructuredModel)),
             ("opt_arr", lambda t: typing.get_origin(t) is list),
         ]:
             field_type = field_definitions[name][0]

--- a/tests/structured_object_evaluator/test_json_schema_integration.py
+++ b/tests/structured_object_evaluator/test_json_schema_integration.py
@@ -158,9 +158,103 @@ class TestEndToEndWorkflow:
         # Test exact match
         score = emp1.compare(emp2)
         assert score == 1.0
-        
+
         result = emp1.compare_with(emp2)
         assert result["overall_score"] == 1.0
+
+
+class TestOptionalFieldNoneFromJson:
+    """Regression tests for issue #149.
+
+    from_json(process_rich_values=True) must accept models where an OPTIONAL
+    JSON-Schema field (absent from ``required``) is omitted from the payload.
+
+    Before the fix, from_json_schema() built optional fields with
+    ``default=None`` but a NON-nullable annotation (bare ``str``). The
+    rich-value path round-trips nested objects through
+    ``from_json(...).model_dump()``, which materializes the ``None`` default
+    and re-validates it against ``str`` -> ValidationError. Plain
+    ``ModelClass(**data)`` never hit this because it does not re-validate the
+    dumped ``None``.
+    """
+
+    def test_optional_nested_field_none_via_from_json_rich_values(self):
+        """Nested object with an OPTIONAL inner field round-trips via from_json.
+
+        Both ``M(**data)`` and ``M.from_json(data, process_rich_values=True)``
+        must succeed and agree when the optional inner field is omitted.
+        """
+        schema = {
+            "type": "object",
+            "properties": {
+                "C": {
+                    "type": "object",
+                    "properties": {
+                        "A": {"type": "string"},
+                        "B": {"type": "string"},  # OPTIONAL (not in required)
+                    },
+                    "required": ["A"],
+                },
+            },
+            "required": ["C"],
+        }
+
+        M = StructuredModel.from_json_schema(schema)
+
+        data = {"C": {"A": "x"}}
+
+        # Plain construction accepts the missing optional field.
+        plain = M(**data)
+        assert plain.C.A == "x"
+        assert plain.C.B is None
+
+        # from_json with rich-value processing must also accept it (the bug).
+        rich = M.from_json(data, process_rich_values=True)
+        assert rich.C.A == "x"
+        assert rich.C.B is None
+
+        # The two paths must agree.
+        assert plain.model_dump() == rich.model_dump()
+
+    def test_optional_primitive_field_none_via_from_json_rich_values(self):
+        """Top-level OPTIONAL primitive field round-trips via from_json."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "required_name": {"type": "string"},
+                "optional_note": {"type": "string"},  # OPTIONAL
+            },
+            "required": ["required_name"],
+        }
+
+        M = StructuredModel.from_json_schema(schema)
+        data = {"required_name": "x"}
+
+        plain = M(**data)
+        rich = M.from_json(data, process_rich_values=True)
+        assert plain.optional_note is None
+        assert rich.optional_note is None
+        assert plain.model_dump() == rich.model_dump()
+
+    def test_optional_array_field_none_via_from_json_rich_values(self):
+        """Top-level OPTIONAL array field round-trips via from_json."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "tags": {"type": "array", "items": {"type": "string"}},  # OPTIONAL
+            },
+            "required": ["id"],
+        }
+
+        M = StructuredModel.from_json_schema(schema)
+        data = {"id": "x"}
+
+        plain = M(**data)
+        rich = M.from_json(data, process_rich_values=True)
+        assert plain.tags is None
+        assert rich.tags is None
+        assert plain.model_dump() == rich.model_dump()
 
 
 class TestComplexNestedStructures:

--- a/tests/structured_object_evaluator/test_json_schema_integration.py
+++ b/tests/structured_object_evaluator/test_json_schema_integration.py
@@ -216,45 +216,214 @@ class TestOptionalFieldNoneFromJson:
         # The two paths must agree.
         assert plain.model_dump() == rich.model_dump()
 
-    def test_optional_primitive_field_none_via_from_json_rich_values(self):
-        """Top-level OPTIONAL primitive field round-trips via from_json."""
+    def test_optional_primitive_nested_in_object_none_via_from_json_rich_values(self):
+        """OPTIONAL primitive INSIDE a nested object round-trips via from_json.
+
+        This nests the optional primitive one level down so it travels the real
+        bug path: ConfigurationHelper._process_nested_structured_data round-trips
+        the nested object through from_json(...).model_dump(), which materializes
+        the None default and re-validates it. A *top-level* optional primitive
+        never re-validates its default, so it would pass even without the fix and
+        would not pin the bug (per @adiadd's review).
+        """
         schema = {
             "type": "object",
             "properties": {
-                "required_name": {"type": "string"},
-                "optional_note": {"type": "string"},  # OPTIONAL
+                "meta": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"},
+                        "note": {"type": "string"},  # OPTIONAL inner primitive
+                    },
+                    "required": ["id"],
+                },
             },
-            "required": ["required_name"],
+            "required": ["meta"],
         }
 
         M = StructuredModel.from_json_schema(schema)
-        data = {"required_name": "x"}
+        data = {"meta": {"id": "x"}}
 
         plain = M(**data)
         rich = M.from_json(data, process_rich_values=True)
-        assert plain.optional_note is None
-        assert rich.optional_note is None
+        assert plain.meta.note is None
+        assert rich.meta.note is None
         assert plain.model_dump() == rich.model_dump()
 
-    def test_optional_array_field_none_via_from_json_rich_values(self):
-        """Top-level OPTIONAL array field round-trips via from_json."""
+    def test_optional_array_nested_in_object_none_via_from_json_rich_values(self):
+        """OPTIONAL array INSIDE a nested object round-trips via from_json.
+
+        Nested so it exercises the re-validation path that genuinely failed
+        pre-fix; a top-level optional array would pass regardless of the fix.
+        """
         schema = {
             "type": "object",
             "properties": {
-                "id": {"type": "string"},
-                "tags": {"type": "array", "items": {"type": "string"}},  # OPTIONAL
+                "container": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"},
+                        # OPTIONAL inner array
+                        "tags": {"type": "array", "items": {"type": "string"}},
+                    },
+                    "required": ["id"],
+                },
             },
-            "required": ["id"],
+            "required": ["container"],
         }
 
         M = StructuredModel.from_json_schema(schema)
-        data = {"id": "x"}
+        data = {"container": {"id": "x"}}
 
         plain = M(**data)
         rich = M.from_json(data, process_rich_values=True)
-        assert plain.tags is None
-        assert rich.tags is None
+        assert plain.container.tags is None
+        assert rich.container.tags is None
         assert plain.model_dump() == rich.model_dump()
+
+    def test_required_field_with_explicit_null_default_round_trips(self):
+        """A REQUIRED field carrying an explicit ``"default": null`` round-trips.
+
+        Per @adiadd's review: the invariant being repaired is "a None default
+        needs a nullable annotation". Keying the widening off ``is_required``
+        alone misses a field that is in ``required`` but declares
+        ``"default": null`` — it keeps a bare annotation + None default and
+        crashes the same way through the rich-value path. The widening condition
+        must therefore be ``not is_required or default is None``.
+        """
+        schema = {
+            "type": "object",
+            "properties": {
+                "C": {
+                    "type": "object",
+                    "properties": {
+                        "A": {"type": "string"},
+                        # REQUIRED, but explicit null default.
+                        "B": {"type": "string", "default": None},
+                    },
+                    "required": ["A", "B"],
+                },
+            },
+            "required": ["C"],
+        }
+
+        M = StructuredModel.from_json_schema(schema)
+        data = {"C": {"A": "x"}}  # B omitted -> its null default materializes
+
+        plain = M(**data)
+        rich = M.from_json(data, process_rich_values=True)
+        assert plain.C.B is None
+        assert rich.C.B is None
+        assert plain.model_dump() == rich.model_dump()
+
+
+class TestOptionalFieldExplicitNullContract:
+    """Documents an intentional, externally observable contract change (#149).
+
+    Widening non-required fields to ``Optional[T]`` means an EXPLICIT ``null``
+    for an optional typed field is now accepted where it previously raised. This
+    is more permissive than strict JSON-Schema semantics (``null`` is invalid for
+    ``"type": "string"``), but it is deliberate: LLM predictions emit explicit
+    nulls, and those should score as a value rather than crash evaluation. The
+    field's ``model_json_schema()`` correspondingly emits ``anyOf: [T, null]``.
+
+    These tests pin that contract so a future change can't silently revert it.
+    """
+
+    def _schema(self):
+        return {
+            "type": "object",
+            "properties": {
+                "a": {"type": "string"},
+                "b": {"type": "string"},  # OPTIONAL
+            },
+            "required": ["a"],
+        }
+
+    def test_explicit_null_accepted_via_plain_construction(self):
+        M = StructuredModel.from_json_schema(self._schema())
+        m = M(**{"a": "x", "b": None})
+        assert m.b is None
+
+    def test_explicit_null_accepted_via_from_json_rich_values(self):
+        M = StructuredModel.from_json_schema(self._schema())
+        m = M.from_json({"a": "x", "b": None}, process_rich_values=True)
+        assert m.b is None
+
+    def test_optional_field_emits_anyof_null_in_model_json_schema(self):
+        M = StructuredModel.from_json_schema(self._schema())
+        b_schema = M.model_json_schema()["properties"]["b"]
+        assert "anyOf" in b_schema
+        types = {entry.get("type") for entry in b_schema["anyOf"]}
+        assert types == {"string", "null"}
+
+
+class TestOptionalNestedBreakdownPreserved:
+    """Regression for issue #149 review (@adiadd): the Optional[T] widening must
+    not silently degrade the comparison metric tree.
+
+    An OPTIONAL nested object inside a list of objects is annotated
+    ``Optional[NestedModel]``. ``is_structured_field_type`` must recognize that
+    shape so ``compare_recursive`` keeps the full nested ``fields`` breakdown for
+    the optional object, rather than collapsing it to flat counts.
+    """
+
+    def test_optional_nested_object_in_list_keeps_nested_breakdown(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "people": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "string"},
+                            "addr": {  # OPTIONAL nested object (absent from required)
+                                "type": "object",
+                                "properties": {
+                                    "city": {"type": "string"},
+                                    "country": {"type": "string"},
+                                },
+                                "required": ["city"],
+                            },
+                        },
+                        "required": ["id"],
+                    },
+                },
+            },
+            "required": ["people"],
+        }
+
+        M = StructuredModel.from_json_schema(schema)
+
+        gt = M(
+            **{
+                "people": [
+                    {"id": "1", "addr": {"city": "NYC", "country": "USA"}},
+                    {"id": "2", "addr": {"city": "LA", "country": "USA"}},
+                ]
+            }
+        )
+        pred = M(
+            **{
+                "people": [
+                    {"id": "1", "addr": {"city": "New York", "country": "USA"}},
+                    {"id": "2", "addr": {"city": "Los Angeles", "country": "USA"}},
+                ]
+            }
+        )
+
+        result = gt.compare_recursive(pred)
+
+        # The optional nested object must retain its per-field breakdown, not
+        # collapse to flat counts.
+        addr = result["fields"]["people"]["fields"]["addr"]
+        assert "fields" in addr, (
+            "optional nested object 'addr' lost its nested breakdown "
+            "(Optional[NestedModel] not recognized as structured)"
+        )
+        assert "city" in addr["fields"]
+        assert "country" in addr["fields"]
 
 
 class TestComplexNestedStructures:


### PR DESCRIPTION
**Issue #, if available:** #149

> Supersedes #150 (same work; branch renamed to follow a `type/slug` convention, so the
> PR had to be reopened — GitHub can't repoint an open PR's head branch). Carries the
> rebase onto current `dev` plus the changes from @adiadd's review on #150.

## Problem

`from_json(process_rich_values=True)` rejects `None` for **optional** fields that plain `ModelClass(**data)` accepts. A model built from a JSON Schema raises `pydantic ValidationError` ("Input should be a valid string ... input_value=None") when an optional field is omitted and rich-value processing is on.

## Root cause

When a JSON-Schema field is optional (absent from `required`), `from_json_schema()` builds a Pydantic field with `default=None` but a **non-nullable** annotation (bare `str`, not `Optional[str]`). Plain construction tolerates the omitted field, but the rich-value path round-trips nested objects through `from_json(...).model_dump()` (`ConfigurationHelper._process_nested_structured_data`). `model_dump()` materializes the `None` default, and re-validation checks it against the bare annotation — which fails. The default-vs-annotation mismatch is the bug.

## Fix

The core fix widens an optional field's annotation to `Optional[T]` so the `None` default is valid. Following @adiadd's review on #150, the widening is made **consistent across every producer and consumer** of the annotation:

- **Producer (single site).** The three widening blocks in `json_schema_field_converter.py` collapse into the sole dispatcher `convert_property_to_field` — the convergence point with #127. The condition is `not is_required or default is None`, so a *required* field that declares an explicit `"default": null` is also widened (the invariant is "a None default needs a nullable annotation").
- **Comparison path.** `ConfigurationHelper.is_structured_field_type` now recognizes `Optional[StructuredModel]` (reusing the existing `_is_optional_structured_model`). Without this, an optional nested object inside a list-of-objects item was routed down the non-hierarchical path and **silently lost its nested metric breakdown** in `compare_recursive` — exactly the population #149 targets.
- **Stickler-config path.** `field_converter.py` (used by `model_from_json`) widens too, closing a round-trip hole: schema → `to_stickler_config` → `model_from_json` previously rebuilt a fixed model back into a broken one.
- **HTML report.** `data_extractors.py` threshold extraction unwraps `Optional[...]` so nested field thresholds no longer vanish from HTML reports for schema-built optional models.

Required fields keep bare annotations.

## Contract note (intentional, documented)

Widening optional fields to `Optional[T]` means an explicit `null` is now **accepted** for an optional typed field (e.g. `{"note": null}` for an optional `string`), where it previously raised, and `model_json_schema()` emits `anyOf: [T, null]` for such fields. This is deliberate — model predictions emit explicit nulls and should score as a value rather than crash evaluation. It is documented in `docs/docs/Advanced/dynamic-models.md` and pinned by tests.

## Testing

- `TestOptionalFieldNoneFromJson` — nested/primitive/array optional fields round-trip through both `M(**data)` and `M.from_json(data, process_rich_values=True)`. The primitive/array cases are **nested one level down** so they exercise the real re-validation path (the previous top-level versions passed even without the fix; per @adiadd they did not pin the bug). Includes a required-field-with-`"default": null` case.
- `TestOptionalNestedBreakdownPreserved` — `compare_recursive` keeps the nested `fields` breakdown for an optional nested object inside a list of objects.
- `TestOptionalFieldExplicitNullContract` — explicit-null acceptance through both construction paths + the `anyOf:[T,null]` schema shape.
- New `test_configuration_helper_optional_structured.py`, `test_field_converter_optional_roundtrip.py`, `test_data_extractors_optional_thresholds.py` for the comparison, stickler-config round-trip, and HTML-threshold fixes respectively.
- Tidied the review nits (redundant assert, obscure `__import__` lambda, stale round-trip comment, helper pointer).

Full suite: **1443 passed, 2 skipped** (pre-existing skips), 0 failures. `ruff check` clean.

## Risk

Low–medium. The changes are additive — they teach consumers to recognize a shape (`Optional[T]`) that was already half-handled elsewhere, and bring annotations into agreement with the `None` defaults that were already being assigned. The single-site refactor is behavior-identical (verified by the existing converter tests).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
