### PR TITLE
chore: add CLAUDE.md importing AGENTS.md for Claude Code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

Adds a root `CLAUDE.md` so Claude Code picks up the existing agent guidance. Claude Code only reads `CLAUDE.md` (not `AGENTS.md`), so this file uses the `@` import syntax to inline the canonical `AGENTS.md` — no content duplication, `AGENTS.md` stays the single source of truth.

## Changes
- `CLAUDE.md` — regular file containing `@AGENTS.md`

## Why an import instead of a symlink
A git symlink (`CLAUDE.md -> AGENTS.md`) works on macOS/Linux but breaks on Windows checkouts, where it materializes as a plain text file literally containing the string `AGENTS.md`. The `@AGENTS.md` import is the pattern documented in the Claude Code memory docs and works cross-platform.

## Notes
- Single-file change; no code or behavior impact.
- On first open, Claude Code shows a one-time approval dialog listing imported files.