### PR TITLE
fix: pin GitHub Actions to commit SHAs and add uv dependency cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# Dependabot version updates.
+# Note: dependabot only reads this file from the default branch (main).
+# Grouped security updates (e.g. the "uv group" PRs) are enabled via repo
+# settings and are independent of this file.
+version: 2
+updates:
+  # Keep SHA-pinned GitHub Actions fresh. Dependabot updates the pinned
+  # commit SHA and the trailing version comment together.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "dev"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 # Dependabot version updates.
-# Note: dependabot only reads this file from the default branch (main).
+# Note: dependabot only reads this file from the repository's default branch
+# (currently `dev`).
 # Grouped security updates (e.g. the "uv group" PRs) are enabled via repo
 # settings and are independent of this file.
 version: 2
@@ -10,6 +11,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Wait 7 days before proposing newly published action versions
+    # (supply-chain cooldown, mirrors [tool.uv].exclude-newer).
+    cooldown:
+      default-days: 7
     target-branch: "dev"
     commit-message:
       prefix: "chore(deps)"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,23 @@
+# GitHub Actions Workflows
+
+CI/CD workflows for the Stickler project.
+
+| Workflow | Trigger | Purpose |
+| --- | --- | --- |
+| `run_pytest.yaml` | push, PR | Test suite with coverage (installs `--extra llm --extra bert`) |
+| `lint.yaml` | push, PR | Ruff lint (non-blocking via `continue-on-error`) |
+| `security.yaml` | push, PR | Bandit + ASH security scans; uploads `security-reports` artifact |
+| `security-pr-comment.yaml` | `workflow_run` after Security Scan | Posts/updates the ASH summary as a PR comment |
+| `docs.yml` | push to `main` (src/docs paths) | Deploys MkDocs site to GitHub Pages |
+| `workflow.yml` | release published | Builds and publishes to PyPI and TestPyPI (trusted publishing via OIDC) |
+
+## Conventions
+
+- **SHA pinning**: all `uses:` references are pinned to full 40-character
+  commit SHAs with a trailing `# vX.Y.Z` comment (supply-chain hardening;
+  mutable tags can be repointed). Dependabot (`.github/dependabot.yml`)
+  bumps the SHA and comment together.
+- **Locked dependencies**: all `uv sync` / `uv run` invocations use
+  `--frozen` so CI resolves exactly what `uv.lock` specifies.
+- **Least privilege**: workflows default to `permissions: contents: read`
+  and grant extra scopes per job only where needed.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,10 +16,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           python-version: "3.12"
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,9 +13,9 @@ jobs:
         python-version: ["3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/run_pytest.yaml
+++ b/.github/workflows/run_pytest.yaml
@@ -13,9 +13,9 @@ jobs:
         python-version: ["3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/security-pr-comment.yaml
+++ b/.github/workflows/security-pr-comment.yaml
@@ -17,14 +17,14 @@ jobs:
       actions: read
     steps:
       - name: Download security-reports artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: security-reports
           path: security-reports
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Post ASH summary to PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -15,9 +15,9 @@ jobs:
         python-version: ["3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -39,7 +39,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: echo "$PR_NUMBER" > pr-number.txt
       - name: Upload Security Reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: security-reports

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -28,7 +28,8 @@ jobs:
           uv run --with "bandit[toml]" bandit -r src/ -f txt
       - name: Install ASH
         run: |
-          uv tool install git+https://github.com/awslabs/automated-security-helper.git@v3.1.2
+          # Mutable git tags can be repointed; pin to the release commit.
+          uv tool install git+https://github.com/awslabs/automated-security-helper.git@e73de85c1db7f443276370c4a6f7501815756780 # v3.1.2
       - name: Run ASH Security Scan
         continue-on-error: true
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,17 +15,17 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         persist-credentials: false
     - name: Set up uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
       with:
         python-version: "3.12"
     - name: Build a binary wheel and a source tarball
       run: uv build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: python-package-distributions
         path: dist/
@@ -42,12 +42,12 @@ jobs:
       id-token: write
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: python-package-distributions
         path: dist/
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
   publish-to-testpypi:
     name: Publish Python distribution to TestPyPI
@@ -61,11 +61,11 @@ jobs:
       id-token: write
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: python-package-distributions
         path: dist/
     - name: Publish distribution to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
       with:
         repository-url: https://test.pypi.org/legacy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,10 @@ docs = [
 
 [tool.uv]
 default-groups = ["dev"]
+# Dependency cooldown: wait 7 days before resolving newly published package
+# versions to mitigate supply-chain attacks via freshly compromised releases.
+# https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns
+exclude-newer = "7 days"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,11 +114,13 @@ docs = [
 ]
 
 [tool.uv]
-default-groups = ["dev"]
 # Dependency cooldown: wait 7 days before resolving newly published package
 # versions to mitigate supply-chain attacks via freshly compromised releases.
 # https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns
+# Note: keep `exclude-newer` as the first key in this table; the semgrep rule
+# package_managers.uv.uv-missing-dependency-cooldown only matches it there.
 exclude-newer = "7 days"
+default-groups = ["dev"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/uv.lock
+++ b/uv.lock
@@ -13,6 +13,10 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[options]
+exclude-newer = "2026-07-07T13:31:42.498833Z"
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION
# Pull Request

## Issue Reference
addresses the ASH security scan findings reported on #169

## Description of Changes
fixes all 19 actionable findings from the ASH/semgrep scan (18 mutable action tag findings plus the missing uv dependency cooldown), and follows up on the first scan of this PR itself (2 remaining semgrep findings plus a copilot catch). every finding was verified against the source before fixing.

### Changes Made
- pinned all 18 `uses:` references across the 6 workflow files to full 40-character commit SHAs, each cross-checked against the action repo's immutable release tags and annotated with a `# vX.Y.Z` comment:
  - `actions/checkout` -> v4.3.1, `astral-sh/setup-uv` -> v5.4.2, `actions/upload-artifact` -> v4.6.2, `actions/download-artifact` -> v4.3.0, `actions/github-script` -> v7.1.0, `pypa/gh-action-pypi-publish` -> v1.14.0
- pinned the ASH install in `security.yaml` to the commit for v3.1.2 (it is a `git+...@tag` install rather than a `uses:`, so the original semgrep findings did not cover it, but it is the same supply-chain class)
- added `exclude-newer = "7 days"` under `[tool.uv]` in `pyproject.toml` so newly published package versions sit out a 7 day cooldown before resolution ([uv docs](https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns)). `uv.lock` picks up the cooldown in its `[options]` block; zero package versions changed. note: `exclude-newer` must be the first key in the `[tool.uv]` table because the semgrep rule only matches it there (verified against the registry rule locally)
- added `.github/dependabot.yml` with a weekly grouped `github-actions` ecosystem so the SHA pins get bumped automatically, with a 7 day `cooldown` block (dependabot's own cooldown, separate from uv's; flagged by `dependabot-missing-cooldown` on the first scan of this PR)
- added `.github/workflows/README.md` documenting the workflows and the pinning/`--frozen`/least-privilege conventions

### Why These Changes Are Needed
mutable tags and branch refs can be silently repointed by the action owner (the tj-actions compromise being the recent example), and fresh package releases are the other common supply-chain vector. SHA pins plus resolution cooldowns close both.

## Testing
- [x] All existing tests pass
- [x] Manual testing completed

1428 passed, 2 skipped locally. `uv lock --check` passes, `uv sync --frozen` works (CI uses `--frozen` everywhere so behavior is unchanged), all workflow YAML parses, and the three relevant semgrep registry rules (`github-actions-mutable-action-tag`, `uv-missing-dependency-cooldown`, `dependabot-missing-cooldown`) run clean locally: 0 findings.

## Additional Notes
stacked PR: `chore/oss-best-practices` (#171) builds on this branch and retargets to `dev` once this merges.
