### PR TITLE
docs: add maintainer handoff artifacts (MAINTAINERS, CODEOWNERS, RELEASING, CHANGELOG, maintainer's guide)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default owners for everything in the repo.
+# Maintainers are automatically requested for review on every PR.
+# See MAINTAINERS.md for the current maintainer list.
+* @sromoam

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 **/*.egg-info/
 .venv/
 .coverage
+.pytest_cache/
 .ash/
 .temp/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - Documentation should be minimal, and only say what needs to be said to communicate how to work with and extend the system.
 
 ## MKDocs Documentation Project
-- An MKDocs documentation project exists at [docs/](./docs/). More information can be found in the [docs/README.md](./docs/README.md) and [docs/AGENTS.md](./docs/AGENTS.md) files.
+- An MKDocs documentation project exists at [docs/](./docs/). More information can be found in the [docs/README.md](./docs/README.md) file.
 
 ## Testing
 - Test documentation and guidelines can be found in [tests/README.md](./tests/README.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,144 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based
+on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Each release links to full notes on the
+[GitHub Releases page](https://github.com/awslabs/stickler/releases).
+
+## [Unreleased]
+
+### Fixed
+
+- Register `BERTComparator` under the correct name in the comparator registry
+  ([#157](https://github.com/awslabs/stickler/pull/157))
+- Resolve ASH security scan findings: top-level workflow permissions, bandit
+  exec suppression ([#156](https://github.com/awslabs/stickler/pull/156))
+
+### Changed
+
+- Dependency bumps via dependabot
+  ([#167](https://github.com/awslabs/stickler/pull/167),
+  [#168](https://github.com/awslabs/stickler/pull/168))
+
+## [0.5.0] - 2026-06-26
+
+### Added
+
+- `DateComparator` with year/range awareness, configurable tolerance, and
+  JSON-config instantiation ([#141](https://github.com/awslabs/stickler/pull/141))
+- Mean Average Precision (mAP) scoring for bounding-box evaluation:
+  `MAPCalculator`, `BBoxMAPAccumulator`
+  ([#151](https://github.com/awslabs/stickler/pull/151))
+- Core comparators importable from the top-level package
+  (`from stickler import ExactComparator`)
+  ([#121](https://github.com/awslabs/stickler/pull/121))
+
+### Fixed
+
+- HTML report rendering and semantic-comparator fallback fixes
+- Script injection hardening in the security workflow
+  ([#154](https://github.com/awslabs/stickler/pull/154))
+
+## [0.4.0] - 2026-05-20
+
+### Added
+
+- Confidence evaluation tooling: calibration metrics (ECE, Brier score,
+  AUROC), `ConfidenceCalculator`, rich-value pattern for carrying confidence
+  through the pipeline ([#98](https://github.com/awslabs/stickler/pull/98))
+- Weight-aware aggregation in `BulkStructuredModelEvaluator`
+  ([#124](https://github.com/awslabs/stickler/pull/124))
+- `SemanticComparator` accepts `model_id` as a plain string
+  ([#116](https://github.com/awslabs/stickler/pull/116))
+
+### Fixed
+
+- Bulk evaluator aggregation fixes ([#124](https://github.com/awslabs/stickler/pull/124))
+- Example notebook repairs ([#98](https://github.com/awslabs/stickler/pull/98))
+
+## [0.3.0] - 2026-04-17
+
+### Added
+
+- DocSplit metrics for packet-splitting evaluation
+  ([#82](https://github.com/awslabs/stickler/pull/82))
+- `StructuredModel` export helpers
+  ([#56](https://github.com/awslabs/stickler/pull/56),
+  [#107](https://github.com/awslabs/stickler/pull/107))
+
+### Fixed
+
+- Single-page group ordering metric
+  ([#95](https://github.com/awslabs/stickler/pull/95))
+- Packaging and distribution fixes for PyPI installs
+  ([#91](https://github.com/awslabs/stickler/pull/91),
+  [#100](https://github.com/awslabs/stickler/pull/100),
+  [#101](https://github.com/awslabs/stickler/pull/101))
+- `ComparableField` None-default regression
+  ([#84](https://github.com/awslabs/stickler/pull/84))
+
+### Changed
+
+- Migrated from conda to [uv](https://docs.astral.sh/uv/) for dependency
+  management ([#97](https://github.com/awslabs/stickler/pull/97))
+
+## [0.2.0] - 2026-03-16
+
+### Added
+
+- Document packet splitting metrics
+  ([#82](https://github.com/awslabs/stickler/pull/82))
+- JSON/model export and import
+  ([#56](https://github.com/awslabs/stickler/pull/56))
+
+### Fixed
+
+- Numeric and structured list comparator fix
+  ([#83](https://github.com/awslabs/stickler/pull/83))
+
+### Changed
+
+- Major documentation restructure
+  ([#86](https://github.com/awslabs/stickler/pull/86))
+
+## [0.1.5] - 2026-02-17
+
+### Added
+
+- Confidence-aware evaluation with AUROC metrics
+  ([#54](https://github.com/awslabs/stickler/pull/54))
+- LLM-powered semantic comparator via AWS Bedrock
+  ([#15](https://github.com/awslabs/stickler/pull/15))
+- Bulk evaluator aggregations with streaming support
+  ([#74](https://github.com/awslabs/stickler/pull/74))
+
+### Fixed
+
+- Security fixes ([#80](https://github.com/awslabs/stickler/pull/80))
+
+## [0.1.4] - 2025-12-23
+
+### Added
+
+- `field_comparisons` parameter for matches and non-matches
+
+### Removed
+
+- `StructuredModelEvaluator.evaluate()` API
+
+## [0.1.3] - 2025-11-18
+
+Initial public release: structured JSON comparison with configurable
+comparators, Hungarian-algorithm list matching, confusion-matrix metrics, and
+HTML reporting.
+
+[Unreleased]: https://github.com/awslabs/stickler/compare/v0.5.0...dev
+[0.5.0]: https://github.com/awslabs/stickler/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/awslabs/stickler/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/awslabs/stickler/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/awslabs/stickler/compare/v0.1.5...v0.2.0
+[0.1.5]: https://github.com/awslabs/stickler/compare/v.0.1.4...v0.1.5
+[0.1.4]: https://github.com/awslabs/stickler/compare/v.0.1.3...v.0.1.4
+[0.1.3]: https://github.com/awslabs/stickler/releases/tag/v.0.1.3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,14 @@ GitHub provides additional document on [forking a repository](https://help.githu
 Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
 
 
+## Maintainers
+
+Current maintainers are listed in [MAINTAINERS.md](MAINTAINERS.md). Maintainer
+workflows (issue triage, review bar, project infrastructure) are documented in
+the [Maintainer's Guide](https://awslabs.github.io/stickler/Getting-Started/Contributing/maintainers-guide/),
+and the release process in [RELEASING.md](RELEASING.md).
+
+
 ## Code of Conduct
 This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
 For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,26 @@
+# Maintainers
+
+## Current maintainers
+
+| Name | GitHub | Affiliation |
+|------|--------|-------------|
+| Spencer Romo | [@sromoam](https://github.com/sromoam) | AWS |
+
+## Emeritus
+
+| Name | GitHub |
+|------|--------|
+| Aditya Addepalli | [@adiadd](https://github.com/adiadd) |
+| Ayushi Haria | [@ayushi1208](https://github.com/ayushi1208) |
+
+## Responsibilities
+
+Maintainers review and merge pull requests, triage issues, and cut releases
+(see [RELEASING.md](RELEASING.md)). Day-to-day maintainer workflows are
+documented in the
+[Maintainer's Guide](https://awslabs.github.io/stickler/Getting-Started/Contributing/maintainers-guide/).
+
+## Becoming a maintainer
+
+Consistent, high-quality contributions (code, reviews, triage) are the path to
+maintainership. Current maintainers nominate and approve new maintainers.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,142 @@
+# Releasing Stickler
+
+How to ship a new version of `stickler-eval` to PyPI. The whole process takes
+about 30 minutes plus CI time.
+
+**Flow:** version bump on `dev` → release PR (`dev` → `main`) → squash merge →
+GitHub Release with tag → automated PyPI publish.
+
+## Prerequisites
+
+- Maintainer access to `awslabs/stickler` (push to `dev`, merge to `main`,
+  create Releases)
+- CI green on `dev` — do not release on a red build
+- [`gh` CLI](https://cli.github.com/) authenticated
+
+## 1. Decide the version
+
+Semantic versioning, judged by *content since the last release*
+(`git log --oneline origin/main..origin/dev` or the
+[compare view](https://github.com/awslabs/stickler/compare/main...dev)):
+
+| Bump | When |
+|------|------|
+| **patch** (0.X.Y → 0.X.Y+1) | Only fixes, dependency bumps, docs — no new public API |
+| **minor** (0.X → 0.X+1.0) | Additive features, no breaking changes (most common) |
+| **major** | Breaking API change, or an explicit "this is stable" decision |
+
+Check for unmerged dependabot security PRs first — consider merging them so
+they ride the same release.
+
+## 2. Bump the version on `dev`
+
+The bump commit goes directly on `dev`, not a feature branch, so it lands
+inside the release squash.
+
+```bash
+git checkout dev && git pull origin dev --ff-only
+```
+
+Edit **both** files (they must always match):
+
+- `pyproject.toml` → `version = "X.Y.Z"`
+- `src/stickler/__init__.py` → `__version__ = "X.Y.Z"`
+
+```bash
+git add pyproject.toml src/stickler/__init__.py
+git commit -m "chore: bump version to X.Y.Z for release"
+git push origin dev
+```
+
+Also add a `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md` (move entries
+out of `[Unreleased]`) in the same commit.
+
+## 3. Open the release PR
+
+```bash
+gh pr create --base main --head dev --title "release(vX.Y.Z): <short summary>"
+```
+
+PR body structure (see past releases [#131](https://github.com/awslabs/stickler/pull/131),
+[#102](https://github.com/awslabs/stickler/pull/102) for examples):
+
+```markdown
+## Summary
+- **feat**: <one bullet per feature, with PR refs (#N)>
+- **fix**: <one bullet per fix, with PR refs>
+- **chore(deps)**: <dependency bumps; name CVEs explicitly>
+- **docs**: <doc-only changes>
+
+## Version
+`<old>` → `<new>` (<bump-type> — <one-line justification>; breaking or not)
+
+## Test plan
+- [ ] CI passes (lint, tests, security)
+- [ ] Verify PyPI publish succeeds after tagging vX.Y.Z
+```
+
+One bullet per merged PR, grouped by conventional-commit type. Get the PR list
+with `gh pr list --state merged --base dev` filtered to PRs merged after the
+previous release tag's date.
+
+## 4. Merge
+
+Wait for CI green, get a review if the branch protection requires one, then
+**squash and merge** into `main`.
+
+After merging, sync `dev` with `main` (the squash creates a new commit on
+`main` that `dev` doesn't have):
+
+```bash
+git checkout main && git pull origin main
+git checkout dev && git merge main && git push origin dev
+```
+
+## 5. Create the GitHub Release
+
+At <https://github.com/awslabs/stickler/releases/new>:
+
+- **Tag**: `vX.Y.Z` (exactly this format — created on publish), target `main`
+- **Title**: `vX.Y.Z release`
+- **Body**: Highlights paragraph, then `### New Features` / `### Bug Fixes` /
+  `### Security & Dependencies` / `### Documentation` / `### What's Changed`
+  sections with PR links. Match the style of the
+  [v0.5.0 release](https://github.com/awslabs/stickler/releases/tag/v0.5.0).
+- Leave "Set as latest release" checked.
+
+> **Careful:** publishing the Release fires the PyPI publish workflow and is
+> **not idempotent** — you cannot re-publish the same version. Get the tag
+> name right the first time.
+
+## 6. Verify the publish
+
+The `workflow.yml` GitHub Action fires on `release: published`: builds with
+`uv build`, publishes to TestPyPI and PyPI via OIDC trusted publishing (no
+API tokens involved — publishing rights are tied to the `release` and
+`testpypi` GitHub environments).
+
+Watch it at <https://github.com/awslabs/stickler/actions>, then confirm:
+
+```bash
+curl -s https://pypi.org/pypi/stickler-eval/json | python3 -c "import sys,json; print(json.load(sys.stdin)['info']['version'])"
+uv venv /tmp/stickler-check && VIRTUAL_ENV=/tmp/stickler-check uv pip install stickler-eval==X.Y.Z
+/tmp/stickler-check/bin/python -c "import stickler; print(stickler.__version__)"
+```
+
+## Troubleshooting
+
+- **Publish workflow failed after the Release was created**: fix the cause,
+  then re-run the failed workflow run from the Actions UI (the release event
+  is still attached). If the version was partially published to PyPI, you must
+  bump to a new patch version — PyPI never allows re-uploading a version.
+- **Version mismatch between `pyproject.toml` and `__init__.py`**: fix both to
+  the target version in a single commit before releasing.
+- **Hotfix without releasing `dev`**: branch from `main`, bump the patch
+  version on the hotfix branch, PR back to `main`, release, then merge `main`
+  into `dev`.
+
+## Historical tag quirks
+
+Tags `v.0.1.3` and `v.0.1.4` have a stray dot (legacy inconsistency), and
+`v1.5.0` is a mistagged duplicate of the v0.1.5 release. All tags from
+`v0.1.5` onward follow `vX.Y.Z` — keep it that way.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -137,6 +137,5 @@ uv venv /tmp/stickler-check && VIRTUAL_ENV=/tmp/stickler-check uv pip install st
 
 ## Historical tag quirks
 
-Tags `v.0.1.3` and `v.0.1.4` have a stray dot (legacy inconsistency), and
-`v1.5.0` is a mistagged duplicate of the v0.1.5 release. All tags from
-`v0.1.5` onward follow `vX.Y.Z` — keep it that way.
+Tags `v.0.1.3` and `v.0.1.4` have a stray dot (legacy inconsistency). All
+tags from `v0.1.5` onward follow `vX.Y.Z` — keep it that way.

--- a/docs/docs/Getting-Started/Contributing/.nav.yml
+++ b/docs/docs/Getting-Started/Contributing/.nav.yml
@@ -5,3 +5,4 @@ nav:
   - testing-guide.md
   - code-style.md
   - pull-request-guide.md
+  - maintainers-guide.md

--- a/docs/docs/Getting-Started/Contributing/maintainers-guide.md
+++ b/docs/docs/Getting-Started/Contributing/maintainers-guide.md
@@ -1,0 +1,99 @@
+# Maintainer's Guide
+
+Everything a maintainer needs that isn't in [CONTRIBUTING](README.md).
+Contributors' docs cover how to write code for Stickler; this page covers how
+to run the project.
+
+## The job
+
+- **Review and merge PRs** into `dev` (see review bar below)
+- **Triage issues** — label, reproduce, close what's stale
+- **Cut releases** — follow
+  [RELEASING.md](https://github.com/awslabs/stickler/blob/main/RELEASING.md)
+  step by step; it's the single source of truth for the release process
+- **Keep CI honest** — a green build must actually mean something
+
+## Review bar
+
+Hold every PR (including your own) to this:
+
+1. CI green — lint, tests, security scans. Don't merge on red.
+2. Tests accompany behavior changes. A fix without a regression test will
+   regress.
+3. Public API changes need docs (docstrings + MkDocs page) and a
+   `CHANGELOG.md` entry under `[Unreleased]`.
+4. Conventional commit titles (`feat:`, `fix:`, `chore:`, ...) — release notes
+   are grouped by them.
+5. When in doubt about a design, ask for an issue/RFC first. Design discussion
+   lives in GitHub issues, not PR threads.
+
+## Branch model
+
+`main` = released code. `dev` = integration branch and default target for all
+PRs. Releases are `dev` → `main` squash merges.
+[Issue #103](https://github.com/awslabs/stickler/issues/103) proposes retiring
+`dev` for GitHub Flow — read it before making structural changes to branching.
+
+## Architecture orientation
+
+Read in this order:
+
+1. [Architecture overview](architecture.md) — component map
+2. `src/stickler/` README files — each package documents itself
+3. [StructuredModel refactoring notes](https://github.com/awslabs/stickler/blob/main/docs/structured_model_REFACTORING.md)
+   — the delegation pattern that decomposes `StructuredModel`, and how far
+   that refactor got
+
+## Known landmines
+
+Things that will surprise you if nobody tells you:
+
+- **`StructuredModel` is still ~1,500 lines.** The delegation refactor
+  ([#133](https://github.com/awslabs/stickler/issues/133)) is unfinished;
+  the refactoring notes above explain the target end state. Related cleanup
+  issues: [#134](https://github.com/awslabs/stickler/issues/134),
+  [#136](https://github.com/awslabs/stickler/issues/136),
+  [#137](https://github.com/awslabs/stickler/issues/137).
+- **Two parallel evaluation paths exist** — `trees/` (ANLSTree) and the
+  `ComparisonEngine`. [#135](https://github.com/awslabs/stickler/issues/135)
+  is the RFC to resolve this. Don't build new features on `trees/`.
+- **Known performance TODO** in
+  `structured_object_evaluator/models/field_comparator.py`: redundant
+  nested-tree traversal on deeply nested models.
+- **Install failures on older GCC** (RHEL/Amazon Linux): see
+  [known issues](../known-issues.md).
+- **PEP 604 unions (`X | None`) are inconsistently handled** in schema export
+  and `from_json` — see [#160](https://github.com/awslabs/stickler/issues/160),
+  [#161](https://github.com/awslabs/stickler/issues/161),
+  [#162](https://github.com/awslabs/stickler/issues/162).
+- **Publishing is not idempotent.** A published GitHub Release fires the PyPI
+  publish workflow; a version can never be re-uploaded. Details and recovery
+  steps in RELEASING.md.
+
+## Infrastructure a maintainer must have access to
+
+| What | Where | Notes |
+|------|-------|-------|
+| PyPI project `stickler-eval` | pypi.org + test.pypi.org | Published via OIDC trusted publishing tied to the `release`/`testpypi` GitHub environments — no API tokens to rotate |
+| GitHub environments & rulesets | repo Settings | `release`, `testpypi` environments; branch protection on `main`/`dev` |
+| Docs hosting | GitHub Pages (`gh-pages` branch) | Deployed automatically by `docs.yml` on push to `main` |
+| Dependabot | `.github/dependabot.yml` | Weekly grouped updates |
+
+## CI map
+
+| Workflow | Trigger | What it does |
+|----------|---------|--------------|
+| `run_pytest.yaml` | push/PR | Test suite with `llm` + `bert` extras |
+| `lint.yaml` | push/PR | Ruff |
+| `security.yaml` + `security-pr-comment.yaml` | push/PR | Bandit + AWS ASH, posts summary comment |
+| `docs.yml` | push to `main` | Builds and deploys MkDocs to GitHub Pages |
+| `workflow.yml` | Release published | Builds and publishes to TestPyPI + PyPI |
+
+## Where decisions live
+
+- **Design discussions / RFCs**: GitHub issues (e.g.
+  [#135](https://github.com/awslabs/stickler/issues/135))
+- **Refactoring rationale**: the refactoring notes linked above
+- **Release history**: `CHANGELOG.md` +
+  [GitHub Releases](https://github.com/awslabs/stickler/releases)
+- **AI-assistant conventions**: `AGENTS.md` files throughout the repo

--- a/docs/docs/Getting-Started/Contributing/maintainers-guide.md
+++ b/docs/docs/Getting-Started/Contributing/maintainers-guide.md
@@ -1,6 +1,7 @@
 # Maintainer's Guide
 
-Everything a maintainer needs that isn't in [CONTRIBUTING](README.md).
+Everything a maintainer needs that isn't in the
+[contributor docs](README.md).
 Contributors' docs cover how to write code for Stickler; this page covers how
 to run the project.
 
@@ -58,8 +59,8 @@ Things that will surprise you if nobody tells you:
   `ComparisonEngine`. [#135](https://github.com/awslabs/stickler/issues/135)
   is the RFC to resolve this. Don't build new features on `trees/`.
 - **Known performance TODO** in
-  `structured_object_evaluator/models/field_comparator.py`: redundant
-  nested-tree traversal on deeply nested models.
+  `src/stickler/structured_object_evaluator/models/field_comparator.py`:
+  redundant nested-tree traversal on deeply nested models.
 - **Install failures on older GCC** (RHEL/Amazon Linux): see
   [known issues](../known-issues.md).
 - **PEP 604 unions (`X | None`) are inconsistently handled** in schema export


### PR DESCRIPTION
## Issue Reference
no linked issue; maintainer-transition prep

## Description of Changes
handoff pass to make project operations survivable without tribal knowledge: who maintains it, how releases ship, what changed per version, and what a new maintainer needs to know.

### Changes Made
- **MAINTAINERS.md**: current maintainer (@sromoam), emeritus, path to maintainership
- **.github/CODEOWNERS**: `* @sromoam` so every PR auto-requests a maintainer review
- **RELEASING.md**: the full release runbook (version bump on dev, release PR, squash merge, GitHub Release, OIDC publish to PyPI, verification, troubleshooting). previously this process lived nowhere in the repo
- **CHANGELOG.md**: keep-a-changelog format, backfilled v0.1.3 through v0.5.0 from release notes, with an `[Unreleased]` section for what's on dev
- **maintainer's guide** (new docs page under Getting-Started/Contributing): review bar, branch model, architecture reading order, known landmines (unfinished StructuredModel delegation refactor, trees/ vs ComparisonEngine duality, PEP 604 gaps), infra access map, CI map
- **fixes**: AGENTS.md pointed at a nonexistent `docs/AGENTS.md`; `.pytest_cache/` added to .gitignore; CONTRIBUTING links to the new maintainer docs

## Testing
- [x] `mkdocs build` passes and the new page renders in the nav
- docs-only change, no source touched