### PR TITLE
fix: guard None elements in remaining nullable object list comparison paths

### DIFF
--- a/src/stickler/structured_object_evaluator/models/evaluator_format_helper.py
+++ b/src/stickler/structured_object_evaluator/models/evaluator_format_helper.py
@@ -201,6 +201,13 @@ class EvaluatorFormatHelper:
                     gt_item = gt_list[gt_idx]
                     pred_item = pred_list[pred_idx]
 
+                    # Nullable object elements (List[Optional[Model]]) may pair a
+                    # None against a model; compare_with would crash on None. The
+                    # pair's score is handled at the list level, so it carries no
+                    # per-item breakdown here.
+                    if gt_item is None or pred_item is None:
+                        continue
+
                     # Compare the items with evaluator format
                     item_comparison = gt_item.compare_with(
                         pred_item, evaluator_format=True, recall_with_fd=recall_with_fd

--- a/src/stickler/structured_object_evaluator/models/structured_list_comparator.py
+++ b/src/stickler/structured_object_evaluator/models/structured_list_comparator.py
@@ -508,6 +508,9 @@ class StructuredListComparator:
                 if gt_idx < len(gt_list) and pred_idx < len(pred_list):
                     gt_item = gt_list[gt_idx]
                     pred_item = pred_list[pred_idx]
+                    # Nullable object elements carry no sub-fields; skip the pair.
+                    if gt_item is None or pred_item is None:
+                        continue
                     gt_sub_value = getattr(gt_item, sub_field_name)
                     pred_sub_value = getattr(pred_item, sub_field_name)
 

--- a/tests/structured_object_evaluator/test_json_schema_field_converter.py
+++ b/tests/structured_object_evaluator/test_json_schema_field_converter.py
@@ -1101,6 +1101,65 @@ class TestNullableTypeListForm:
         assert same.compare_with(gt)["overall_score"] == pytest.approx(1.0)
         assert mismatch.compare_with(gt)["overall_score"] < 1.0
 
+    def test_nullable_object_array_compare_with_none_element_list_subfield(self):
+        """compare_with does not crash when a None-holding list's elements
+        carry a list-valued sub-field (exercises the is_simple_list branch)."""
+        from stickler import StructuredModel
+
+        Model = StructuredModel.from_json_schema(
+            {
+                "type": "object",
+                "properties": {
+                    "people": {
+                        "type": "array",
+                        "items": {
+                            "type": ["object", "null"],
+                            "properties": {
+                                "n": {"type": "string"},
+                                "tags": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                },
+                            },
+                            "required": ["n"],
+                        },
+                    }
+                },
+                "required": ["people"],
+            }
+        )
+
+        gt = Model(people=[{"n": "alice", "tags": ["x"]}, None])
+        same = Model(people=[{"n": "alice", "tags": ["x"]}, None])
+        assert same.compare_with(gt)["overall_score"] == pytest.approx(1.0)
+
+    def test_nullable_object_array_compare_with_none_element_evaluator_format(self):
+        """The evaluator_format=True path also tolerates None list elements."""
+        from stickler import StructuredModel
+
+        Model = StructuredModel.from_json_schema(
+            {
+                "type": "object",
+                "properties": {
+                    "people": {
+                        "type": "array",
+                        "items": {
+                            "type": ["object", "null"],
+                            "properties": {"n": {"type": "string"}},
+                            "required": ["n"],
+                        },
+                    }
+                },
+                "required": ["people"],
+            }
+        )
+
+        gt = Model(people=[{"n": "alice"}, None])
+        same = Model(people=[{"n": "alice"}, None])
+        # Must not raise; produces a metrics dict in evaluator format.
+        result = same.compare_with(gt, evaluator_format=True)
+        assert "overall" in result
+
     @pytest.mark.parametrize(
         "bad_type",
         [


### PR DESCRIPTION
## What

Hotfix for two `AttributeError` crashes in `compare_with()` on `List[Optional[Model]]` values, introduced reachable by #127 (which made nullable object lists constructible from `from_json_schema`). #127 added `None` guards to three comparison branches but missed two.

## The two crashes

Both reproduce on `dev` at c598102 (post-#127):

**1. `is_simple_list` branch (blocking)** — `structured_list_comparator.py`. When a nullable object element carries a list-valued sub-field, a both-`None` matched pair scores 1.0, survives the match-threshold filter, and reaches `getattr(None, sub_field_name)`:

```python
M = StructuredModel.from_json_schema({
    "type": "object",
    "properties": {"people": {"type": "array", "items": {
        "type": ["object", "null"],
        "properties": {"n": {"type": "string"},
                        "tags": {"type": "array", "items": {"type": "string"}}},
        "required": ["n"]}}},
    "required": ["people"]})
gt = M(people=[{"n": "alice", "tags": ["x"]}, None])
gt.compare_with(M(people=[{"n": "alice", "tags": ["x"]}, None]))
# was: AttributeError: 'NoneType' object has no attribute 'tags'
```

**2. `evaluator_format=True` path** — `evaluator_format_helper.py`. The Hungarian matched-pair loop calls `gt_item.compare_with(...)` directly with no `None` guard, so any `None` element crashes:

```python
gt.compare_with(pred, evaluator_format=True)
# was: AttributeError: 'NoneType' object has no attribute 'compare_with'
```

## Fix

Both fixes mirror the guards #127 already added to the sibling branches: a `None` element carries no sub-fields, so the pair is skipped in the per-field breakdown (its score is computed at the list level in `_calculate_struct_list_similarity`, both-`None` -> 1.0, one-`None` -> 0.0). Three lines in the list comparator, a guard in the evaluator-format helper.

## Tests

Two regression tests added, one per crash path (`test_nullable_object_array_compare_with_none_element_list_subfield`, `..._evaluator_format`). Full suite: **1446 passed, 2 skipped**. `ruff check` clean.

## Notes

- These were not new regressions from #127: a hand-written `List[Optional[Sub]]` model crashes identically on pre-#127 `dev`. #127 made the shape reachable via the public API; this closes the gap.
- Addresses the two blocking items tracked in #179. The remaining #179 items (PEP 604 export, round-trip lossiness, dispatcher None-first misroute, docs/changelog) are non-crash follow-ups and stay open.
