### PR TITLE
refactor: rename HungarianHelper to HungarianMatching (earn the seam)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Each release links to full notes on the
 
 ## [Unreleased]
 
+### Changed
+
+- Rename `HungarianHelper` to `HungarianMatching` in a file renamed
+  `hungarian_helper.py` -> `hungarian_matching.py`. Part of the `models/`
+  helper-module consolidation towards #134
+  ([#194](https://github.com/awslabs/stickler/pull/194))
+
 ## [0.6.0] - 2026-07-30
 
 ### Added

--- a/docs/docs/Getting-Started/Contributing/architecture.md
+++ b/docs/docs/Getting-Started/Contributing/architecture.md
@@ -25,7 +25,7 @@ StructuredModel
 │       │   ├── FieldComparator         # Primitives & nested models
 │       │   ├── PrimitiveListComparator # List[str/int/float]
 │       │   └── StructuredListComparator  # List[StructuredModel]
-│       │       ├── HungarianHelper     # Optimal bipartite matching
+│       │       ├── HungarianMatching   # Optimal bipartite matching
 │       │       └── MetricsHelper       # Derived metrics (precision, recall, F1)
 │       ├── NonMatchCollector           # Non-match documentation
 │       ├── FieldComparisonCollector    # Field-level comparison docs
@@ -46,7 +46,7 @@ StructuredModel
 | FieldComparator | `models/field_comparator.py` |
 | PrimitiveListComparator | `models/primitive_list_comparator.py` |
 | StructuredListComparator | `models/structured_list_comparator.py` |
-| HungarianHelper | `models/hungarian_helper.py` |
+| HungarianMatching | `models/hungarian_matching.py` |
 | NonMatchCollector | `models/non_match_collector.py` |
 | FieldComparisonCollector | `models/field_comparison_collector.py` |
 | ConfusionMatrixBuilder | `models/confusion_matrix_builder.py` |

--- a/docs/structured_model_REFACTORING.md
+++ b/docs/structured_model_REFACTORING.md
@@ -68,7 +68,7 @@ Specialized Components (selected — ~36 modules total in models/):
 │   └── models/confidence/            - AUROC and other calibration metrics
 │       used when compare_with(add_confidence_metrics=True, ...)
 └── Pre-existing helpers
-    ├── HungarianHelper, MetricsHelper, ConfigurationHelper, ComparisonHelper
+    ├── MetricsHelper, ConfigurationHelper, ComparisonHelper
     ├── ThresholdHelper, RichValueHelper, NonMatchesHelper, FieldHelper
     ├── ResultHelper, NullHelper, TypeResolver, ComparatorRegistry
     └── PostComparisonAccumulator, ComparisonInfo, ComparisonHelperBase

--- a/src/stickler/structured_object_evaluator/README.md
+++ b/src/stickler/structured_object_evaluator/README.md
@@ -367,7 +367,7 @@ The Structured Object Evaluator has been optimized to eliminate redundant Hungar
 - **Backward Compatibility**: All existing APIs maintained, optimization is transparent to users
 
 **Files Modified:**
-- `hungarian_helper.py`: Added unified `get_complete_matching_info()` method
+- `hungarian_matching.py` (then `hungarian_helper.py`): Added unified `get_complete_matching_info()` method
 - `structured_model.py`: Updated to use single Hungarian matching call
 - `structured_list_comparator.py`: Optimized list comparison logic
 - `comparison_helper.py`: Updated helper methods

--- a/src/stickler/structured_object_evaluator/models/README.md
+++ b/src/stickler/structured_object_evaluator/models/README.md
@@ -21,8 +21,8 @@ its `from_json()` ingestion and `compare_with()` comparison pipeline.
   matrix, non-matches, field comparisons, and optional metrics.
 - `comparison_dispatcher.py`, `field_comparator.py`,
   `primitive_list_comparator.py`, `structured_list_comparator.py`,
-  `hungarian_helper.py` — dispatch and per-type comparison, including Hungarian
-  matching for lists.
+  `hungarian_matching.py` — dispatch and per-type comparison, including
+  Hungarian matching for lists.
 - `field_comparison_collector.py` / `field_comparison_helper.py` — produce the
   `field_comparisons` rows (each carries a GT-side `expected_key` and a
   prediction-side `actual_key`, which diverge for reordered list items).

--- a/src/stickler/structured_object_evaluator/models/comparison_engine.py
+++ b/src/stickler/structured_object_evaluator/models/comparison_engine.py
@@ -513,11 +513,11 @@ class ComparisonEngine:
             ):
                 # Check if list contains StructuredModel instances
                 if gt_val and isinstance(gt_val[0], StructuredModel) and isinstance(gt_val[0].__class__, StructuredModel):
-                    # Import HungarianHelper for matching
-                    from .hungarian_helper import HungarianHelper
+                    # Import HungarianMatching for matching
+                    from .hungarian_matching import HungarianMatching
                     
                     # For lists, we need to match them up properly using Hungarian matching
-                    hungarian_helper = HungarianHelper()
+                    hungarian_helper = HungarianMatching()
                     hungarian_info = hungarian_helper.get_complete_matching_info(
                         gt_val, pred_val
                     )

--- a/src/stickler/structured_object_evaluator/models/comparison_helper.py
+++ b/src/stickler/structured_object_evaluator/models/comparison_helper.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List
 
 from stickler.comparators.base import BaseComparator
 
-from .hungarian_helper import HungarianHelper
+from .hungarian_matching import HungarianMatching
 from .threshold_helper import ThresholdHelper
 
 
@@ -38,8 +38,8 @@ class ComparisonHelper:
         """
         # Empty lists are handled early on immediately.
    
-        # Use HungarianHelper for Hungarian matching operations
-        hungarian_helper = HungarianHelper()
+        # Use HungarianMatching for Hungarian matching operations
+        hungarian_helper = HungarianMatching()
         from .structured_model import StructuredModel
 
         # Use the appropriate comparator based on item types
@@ -49,7 +49,7 @@ class ComparisonHelper:
             isinstance(item, StructuredModel) for item in pred_list[:1]
         ):
             # For StructuredModel lists, we need to use individual comparison scoring for consistency
-            # Use HungarianHelper to get optimal pairings - OPTIMIZED: Single call gets all info
+            # Use HungarianMatching to get optimal pairings - OPTIMIZED: Single call gets all info
             hungarian_info = hungarian_helper.get_complete_matching_info(gt_list, pred_list)
             matched_pairs = hungarian_info["matched_pairs"]
 

--- a/src/stickler/structured_object_evaluator/models/comparison_helper_base.py
+++ b/src/stickler/structured_object_evaluator/models/comparison_helper_base.py
@@ -4,7 +4,7 @@ import math
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
-from .hungarian_helper import HungarianHelper
+from .hungarian_matching import HungarianMatching
 
 DEFAULT_MATCH_THRESHOLD = 0.7
 
@@ -12,7 +12,7 @@ class ComparisonHelperBase(ABC):
     """Base class for collecting and formatting comparison data in StructuredModel comparisons."""
 
     def __init__(self):
-        self.hungarian_helper = HungarianHelper()
+        self.hungarian_helper = HungarianMatching()
 
     @abstractmethod
     def create_entry(self, *args, **kwargs) -> Dict[str, Any]:

--- a/src/stickler/structured_object_evaluator/models/confusion_matrix_calculator.py
+++ b/src/stickler/structured_object_evaluator/models/confusion_matrix_calculator.py
@@ -7,7 +7,7 @@ confusion matrix metrics (TP, FP, TN, FN, FD, FA) for field comparisons.
 from typing import TYPE_CHECKING, Any, Dict, List
 
 from .field_helper import FieldHelper
-from .hungarian_helper import HungarianHelper
+from .hungarian_matching import HungarianMatching
 from .metrics_helper import MetricsHelper
 from .non_matches_helper import NonMatchesHelper
 
@@ -318,10 +318,10 @@ class ConfusionMatrixCalculator:
             # Initialize aggregated counts for this nested field
             total_tp = total_fa = total_fd = total_fp = total_tn = total_fn = 0
 
-            # Use HungarianHelper for Hungarian matching operations - OPTIMIZED: Single call gets all info
-            hungarian_helper = HungarianHelper()
+            # Use HungarianMatching for Hungarian matching operations - OPTIMIZED: Single call gets all info
+            hungarian_helper = HungarianMatching()
 
-            # Use HungarianHelper to get optimal assignments with similarity scores
+            # Use HungarianMatching to get optimal assignments with similarity scores
             assignments = []
             matched_pairs_with_scores = []
             if gt_list and pred_list:

--- a/src/stickler/structured_object_evaluator/models/evaluator_format_helper.py
+++ b/src/stickler/structured_object_evaluator/models/evaluator_format_helper.py
@@ -6,7 +6,7 @@ compatibility and calculating list item metrics.
 
 from typing import Any, Dict, List
 
-from .hungarian_helper import HungarianHelper
+from .hungarian_matching import HungarianMatching
 from .metrics_helper import MetricsHelper
 
 
@@ -186,10 +186,10 @@ class EvaluatorFormatHelper:
         from .structured_model import StructuredModel
 
         if gt_list and isinstance(gt_list[0], StructuredModel):
-            # Use HungarianHelper for Hungarian matching operations
-            hungarian_helper = HungarianHelper()
+            # Use HungarianMatching for Hungarian matching operations
+            hungarian_helper = HungarianMatching()
 
-            # Use HungarianHelper to get optimal assignments - OPTIMIZED: Single call gets all info
+            # Use HungarianMatching to get optimal assignments - OPTIMIZED: Single call gets all info
             hungarian_info = hungarian_helper.get_complete_matching_info(
                 gt_list, pred_list
             )

--- a/src/stickler/structured_object_evaluator/models/hungarian_matching.py
+++ b/src/stickler/structured_object_evaluator/models/hungarian_matching.py
@@ -1,4 +1,4 @@
-"""Hungarian matching helper for StructuredModel comparisons."""
+"""Hungarian matching for StructuredModel list comparisons."""
 
 from typing import Any, Dict, List
 
@@ -6,8 +6,8 @@ from stickler.algorithms.hungarian import HungarianMatcher
 from stickler.comparators.structured import StructuredModelComparator
 
 
-class HungarianHelper:
-    """Helper class for Hungarian matching operations with StructuredModel objects."""
+class HungarianMatching:
+    """Optimal bipartite matching between two lists of StructuredModel objects."""
 
     def __init__(self):
         self.hungarian = HungarianMatcher(StructuredModelComparator())

--- a/src/stickler/structured_object_evaluator/models/structured_list_comparator.py
+++ b/src/stickler/structured_object_evaluator/models/structured_list_comparator.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any, Dict, List
 
 from .comparable_field import ComparableField
 from .comparison_helper import ComparisonHelper
-from .hungarian_helper import HungarianHelper
+from .hungarian_matching import HungarianMatching
 from .metrics_helper import MetricsHelper
 
 if TYPE_CHECKING:
@@ -125,7 +125,7 @@ class StructuredListComparator:
             Tuple of (object_metrics_dict, matched_pairs, matched_gt_indices, matched_pred_indices)
         """
         # Use Hungarian matching for OBJECT-LEVEL counts
-        hungarian_helper = HungarianHelper()
+        hungarian_helper = HungarianMatching()
         hungarian_info = hungarian_helper.get_complete_matching_info(gt_list, pred_list)
         matched_pairs = hungarian_info["matched_pairs"]
 

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -26,7 +26,7 @@ from .comparable_field import ComparableField
 from .comparison_helper import ComparisonHelper
 from .configuration_helper import ConfigurationHelper
 from .evaluator_format_helper import EvaluatorFormatHelper
-from .hungarian_helper import HungarianHelper
+from .hungarian_matching import HungarianMatching
 from .metrics_helper import MetricsHelper
 from .rich_value_helper import RichValueHelper
 
@@ -121,7 +121,7 @@ class StructuredModel(BaseModel):
       - Handles nested StructuredModel recursion
 
     **Existing Helpers (Pre-Refactoring):**
-    - HungarianHelper: Hungarian algorithm for list matching
+    - HungarianMatching: Hungarian algorithm for list matching
     - MetricsHelper: Derived metrics calculation formulas
     - ConfigurationHelper: Field configuration management
     - ComparisonHelper: Comparison utility methods
@@ -815,7 +815,7 @@ class StructuredModel(BaseModel):
             Tuple of (object_metrics_dict, matched_pairs, matched_gt_indices, matched_pred_indices)
         """
         # Use Hungarian matching for OBJECT-LEVEL counts - OPTIMIZED: Single call gets all info
-        hungarian_helper = HungarianHelper()
+        hungarian_helper = HungarianMatching()
         hungarian_info = hungarian_helper.get_complete_matching_info(gt_list, pred_list)
         matched_pairs = hungarian_info["matched_pairs"]
 


### PR DESCRIPTION
## Summary

Contributes to #134 (item from the helper-consolidation treatment table:
`hungarian_helper`, "earn the seam, rename to hungarian_matching.py").
7 of 13 items remain (`field_helper.py` deferred separately due to a
conflicting open PR #183, not counted as done here); not closing the issue.

Unlike the previous items in this series, `HungarianHelper` genuinely holds
state (a constructed `HungarianMatcher` instance), so it isn't a candidate
for demotion to plain functions - it's kept as a class, just renamed away
from the generic `_helper` suffix: `HungarianHelper` -> `HungarianMatching`,
in a file renamed `hungarian_helper.py` -> `hungarian_matching.py`.

- Single method (`get_complete_matching_info`), no dead code found here -
  all 7 callers (`structured_model.py`, `structured_list_comparator.py`,
  `comparison_engine.py`, `confusion_matrix_calculator.py`,
  `comparison_helper_base.py`, `comparison_helper.py`,
  `evaluator_format_helper.py`) actually use it.
- Local variable/attribute names (`hungarian_helper`, `hungarian_info`) are
  left as-is to keep the diff focused on the class/file rename itself.
- Updates the four docs that named the module, including one
  (`structured_object_evaluator/README.md`) not caught by earlier PRs in
  this series - a historical "Files Modified" note from a past
  optimization, now pointing at the current filename.

## Testing

Pure rename, no behavior change: full suite passes unchanged, **1541
passed**, 2 pre-existing unrelated skips. No new tests added - there's no
new formula or invariant here worth pinning, just a name. `ruff check`
clean on all touched files.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your choice.