### PR TITLE
feat(schema): render StructuredModel's true shape for tool specs (#188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,27 @@ Each release links to full notes on the
 
 ### Changed
 
+- `model_json_schema()` now describes the model's shape the way an equivalent
+  plain `BaseModel` would, so a configured `StructuredModel` can drive a
+  Strands agent's structured output without degrading the schema the LLM sees:
+  `required` is derived from the annotation (`shipment_id: str` renders
+  required even though `ComparableField` assigns a `None` default for
+  construction tolerance), required fields no longer widen to
+  `["type", "null"]` or carry a contradictory `default: null`, and comparison
+  configuration (`x-comparison`) is no longer emitted. Verified through
+  Strands' `convert_pydantic_to_tool_spec`: a configured `StructuredModel` and
+  its plain-`BaseModel` twin now produce the same tool spec.
+
+  Field-level `description`, `examples`, and `alias` still reach the rendered
+  schema, and the deliberate export path `to_json_schema()` still carries the
+  comparison configuration as `x-aws-stickler-*` extensions. Runtime behavior
+  is unchanged: predictions that omit fields still construct and score.
+
+  Code that read `x-comparison` out of `model_json_schema()` output should
+  read the field's `json_schema_extra` (as the engine does) or use
+  `to_json_schema()`
+  ([#188](https://github.com/awslabs/stickler/issues/188))
+
 - **Breaking:** the peripheral modules now require their extra. `pandas`,
   `scipy`, `scikit-learn`, and `jinja2` are no longer core dependencies, so
   `pip install stickler-eval` installs the comparison engine and nothing else.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,16 @@ Each release links to full notes on the
 
   Code that read `x-comparison` out of `model_json_schema()` output should
   read the field's `json_schema_extra` (as the engine does) or use
-  `to_json_schema()`
+  `to_json_schema()`.
+
+  Note a side effect: dropping the internal `extra_fields` property means
+  `from_json_schema(M.model_json_schema())` now parses instead of raising
+  `ValueError`. It still does **not** round-trip -- the rebuilt model carries
+  default thresholds, weights and comparators, because a shape-only schema does
+  not describe them. `model_json_schema()` remains documented as not
+  round-trip-capable; use `to_json_schema()` or `to_stickler_config()` to
+  preserve configuration. Tracked in
+  [#214](https://github.com/awslabs/stickler/issues/214)
   ([#188](https://github.com/awslabs/stickler/issues/188))
 
 - **Breaking:** the peripheral modules now require their extra. `pandas`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,11 +77,14 @@ Each release links to full notes on the
   `to_json_schema()`.
 
   Note a side effect: dropping the internal `extra_fields` property means
-  `from_json_schema(M.model_json_schema())` now parses instead of raising
-  `ValueError`. It still does **not** round-trip -- the rebuilt model carries
-  default thresholds, weights and comparators, because a shape-only schema does
-  not describe them. `model_json_schema()` remains documented as not
-  round-trip-capable; use `to_json_schema()` or `to_stickler_config()` to
+  `from_json_schema(M.model_json_schema())` now parses for a model whose fields
+  are all required, where it previously raised `ValueError`. It still does
+  **not** round-trip -- the rebuilt model carries default thresholds, weights
+  and comparators, because a shape-only schema does not describe them. A model
+  with any `Optional` field still raises, on the nullable `anyOf` gap that
+  [#198](https://github.com/awslabs/stickler/pull/198) addresses, so most real
+  models are unaffected either way. `model_json_schema()` remains documented as
+  not round-trip-capable; use `to_json_schema()` or `to_stickler_config()` to
   preserve configuration. Tracked in
   [#214](https://github.com/awslabs/stickler/issues/214)
   ([#188](https://github.com/awslabs/stickler/issues/188))

--- a/docs/docs/Advanced/model-export.md
+++ b/docs/docs/Advanced/model-export.md
@@ -105,11 +105,18 @@ configuration is emitted, so the output matches what an equivalent plain
 `BaseModel` would produce. That is what makes a configured `StructuredModel`
 usable directly as an LLM structured-output schema.
 
-This method is **not** round-trip compatible. It parses without error, but the
-rebuilt model carries default thresholds, weights and comparators rather than
-the original's, because the shape alone does not describe them -- see
-[#214](https://github.com/awslabs/stickler/issues/214). Use `to_json_schema()`
-or `to_stickler_config()` when you need the configuration back.
+This method is **not** round-trip compatible. Use `to_json_schema()` or
+`to_stickler_config()` when you need the configuration back.
+
+Feeding its output to `from_json_schema()` fails or misleads depending on the
+model. A model whose fields are all required parses, but the rebuilt model
+carries default thresholds, weights and comparators, because the shape alone
+does not describe them
+([#214](https://github.com/awslabs/stickler/issues/214)). A model with any
+`Optional` field raises `ValueError: Unsupported JSON Schema type: None`,
+because `Optional` renders as `anyOf: [{"type": ...}, {"type": "null"}]` with
+no top-level `type`
+([#198](https://github.com/awslabs/stickler/pull/198) addresses that gap).
 
 ```python
 schema = Product.model_json_schema()

--- a/docs/docs/Advanced/model-export.md
+++ b/docs/docs/Advanced/model-export.md
@@ -12,7 +12,7 @@ Stickler provides three methods for exporting model schemas. Two support round-t
 |--------|--------|-----------|------------|----------|
 | `to_json_schema()` | JSON Schema + `x-aws-stickler-*` | Yes | `from_json_schema()` | Interoperability, OpenAPI |
 | `to_stickler_config()` | Custom Stickler JSON | Yes | `model_from_json()` | Hand-editing, version control |
-| `model_json_schema()` | Pydantic JSON Schema + `x-comparison` | No | N/A | API docs, runtime inspection |
+| `model_json_schema()` | Pydantic JSON Schema | No | N/A | API docs, LLM tool specs, runtime inspection |
 
 ## Common Workflow: Export, Customize, Re-import
 
@@ -100,11 +100,24 @@ config = Product.to_stickler_config()
 
 ## model_json_schema()
 
-Inherited from Pydantic, extended by Stickler to include `x-comparison` metadata. This method is **not** round-trip compatible -- use it for API documentation and runtime introspection only.
+Inherited from Pydantic. Describes the model's *shape* only: no comparison
+configuration is emitted, so the output matches what an equivalent plain
+`BaseModel` would produce. That is what makes a configured `StructuredModel`
+usable directly as an LLM structured-output schema.
+
+This method is **not** round-trip compatible. It parses without error, but the
+rebuilt model carries default thresholds, weights and comparators rather than
+the original's, because the shape alone does not describe them -- see
+[#214](https://github.com/awslabs/stickler/issues/214). Use `to_json_schema()`
+or `to_stickler_config()` when you need the configuration back.
 
 ```python
 schema = Product.model_json_schema()
-# schema["properties"]["name"]["x-comparison"]["threshold"]  -> 0.8
+# schema["properties"]["name"]["type"]  -> "string"
+
+# For comparison configuration, read the field or use the export methods:
+Product.model_fields["name"].json_schema_extra  # carries the config
+Product.to_json_schema()                        # x-aws-stickler-* extensions
 ```
 
 ## Nested Models and Lists

--- a/docs/docs/Guides/Use-Cases/evaluate-strands-agent.md
+++ b/docs/docs/Guides/Use-Cases/evaluate-strands-agent.md
@@ -15,9 +15,19 @@ invoice = result.structured_output
 # `invoice` is a validated Invoice instance
 ```
 
-The question this guide answers: **how accurate is that output, and do the errors matter?** With `stickler.evaluate` the integration is a single line. You do not write a `StructuredModel`, pick comparators, or annotate anything.
+The question this guide answers: **how accurate is that output, and do the errors matter?**
 
-## The whole integration
+There are two supported ways to wire Stickler into this, and neither is second-class:
+
+| | Flow 1: plain Pydantic | Flow 2: configured `StructuredModel` |
+|---|---|---|
+| agent gets | your existing `BaseModel` | your `StructuredModel`, directly |
+| evaluation | `stickler.evaluate()` infers comparators | your explicit comparators, thresholds, weights |
+| choose it when | you want a baseline in one line | you need per-field control over scoring |
+
+Start with Flow 1; graduate to Flow 2 when you outgrow the inferred defaults. With Flow 1 the integration is a single line — you do not write a `StructuredModel`, pick comparators, or annotate anything.
+
+## Flow 1: the whole integration
 
 ```python
 import stickler
@@ -149,7 +159,51 @@ result.explain()["vendor_name"]
 #  'verdict': 'raw 0.56 < threshold 0.85 -> clipped to 0.0', 'why': [...]}
 ```
 
-"Acme Corporation" vs "Acme Corp" fell below the `0.85` similarity threshold Stickler chose for a name field. If that is too strict for your use case, graduate to a hand-authored [`StructuredModel`](../../Getting-Started/README.md) where you set the comparator, threshold, and weight per field explicitly. `stickler.evaluate` gets you a defensible baseline in one line; the full API is there when you outgrow it.
+"Acme Corporation" vs "Acme Corp" fell below the `0.85` similarity threshold Stickler chose for a name field. If that is too strict for your use case, graduate to a hand-authored [`StructuredModel`](../../Getting-Started/README.md) where you set the comparator, threshold, and weight per field explicitly. `stickler.evaluate` gets you a defensible baseline in one line; the full API is there when you outgrow it. That graduation is Flow 2, below.
+
+## Flow 2: one configured class, two jobs
+
+Because `StructuredModel` extends `pydantic.BaseModel`, the class that carries your comparison configuration can *also* be the agent's `structured_output_model`. Define it once; it drives extraction and evaluation:
+
+```python
+from typing import List, Optional
+
+from stickler import (
+    ComparableField,
+    ExactComparator,
+    NumericComparator,
+    StructuredModel,
+)
+
+
+class LineItem(StructuredModel):
+    product: str = ComparableField()
+    qty: int = ComparableField()
+
+
+class Invoice(StructuredModel):
+    shipment_id: str = ComparableField(
+        comparator=ExactComparator(),                 # IDs must match exactly
+        weight=3.0,                                   # and matter most
+        description="The carrier shipment tracking identifier",
+        examples=["1Z999AA10123456784"],
+    )
+    amount: float = ComparableField(comparator=NumericComparator())
+    line_items: List[LineItem] = ComparableField()
+    notes: Optional[str] = ComparableField(default=None)
+
+
+# The SAME class drives the agent...
+prediction = agent(prompt, structured_output_model=Invoice).structured_output
+
+# ...and the evaluation, with your configured comparators.
+result = ground_truth.compare_with(prediction)
+print(result["overall_score"], result["field_scores"])
+```
+
+The schema the agent receives is clean: `shipment_id`, `amount`, and `line_items` are `required` exactly as a plain `BaseModel` twin would declare them, no comparison metadata rides along, and `description` / `examples` / `alias` reach the model, where they genuinely help extraction. Requiredness in the schema follows your annotations — `notes: Optional[str]` is optional, everything else is required — while evaluation stays tolerant: a prediction that omits a field still constructs and scores, it just scores as missing.
+
+Which fields are required is decided by the **annotation**, so write `Optional[...]` on fields the model may legitimately skip and leave the rest bare. This is ordinary Pydantic; there is nothing Stickler-specific to learn.
 
 ## Requirements
 

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -18,6 +18,7 @@ from typing import (
 )
 
 from pydantic import BaseModel, Field
+from pydantic.json_schema import GenerateJsonSchema
 
 from stickler.comparators.base import BaseComparator
 from stickler.utils.deprecation import warn_once
@@ -29,6 +30,112 @@ from .evaluator_format_helper import EvaluatorFormatHelper
 from .hungarian_helper import HungarianHelper
 from .metrics_helper import MetricsHelper
 from .rich_value_helper import RichValueHelper
+
+# Name of the internal field every StructuredModel carries to hold unmatched
+# input keys. It is not part of a model's data contract and must not appear in
+# an exported JSON Schema.
+_EXTRA_FIELDS_KEY = "extra_fields"
+
+# Core-schema wrappers that sit between a field's `default` wrapper and its
+# actual type. Unwrapped when deciding whether an annotation is Optional.
+_CORE_SCHEMA_WRAPPERS = frozenset(
+    {"function-after", "function-before", "function-wrap", "function-plain"}
+)
+
+
+def _core_schema_is_nullable(schema: Dict[str, Any]) -> bool:
+    """Whether a pydantic core schema describes an Optional annotation."""
+    while schema.get("type") in _CORE_SCHEMA_WRAPPERS:
+        schema = schema.get("schema", {})
+    return schema.get("type") == "nullable"
+
+
+class _AnnotationDrivenJsonSchema(GenerateJsonSchema):
+    """Schema generator that derives `required` from the annotation.
+
+    ``ComparableField`` gives every field ``default=None`` so that model
+    construction tolerates partial predictions (the comparison engine builds
+    instances from prediction JSON that may omit fields). Pydantic reads that
+    default as "optional", so a rendered schema claims nothing is required and
+    downstream consumers (e.g. Strands' ``convert_pydantic_to_tool_spec``)
+    tell the LLM every field may be omitted or null.
+
+    The annotation already says what the user meant: ``shipment_id: str`` is
+    required, ``notes: Optional[str]`` is not. This generator restores that
+    reading for schema purposes only -- a field is required when its
+    annotation is non-Optional and it carries no real default -- without
+    changing runtime construction. Running at generation time (rather than
+    post-processing) means nested models rendered into ``$defs`` get the same
+    treatment.
+    """
+
+    def field_is_required(self, field, total: bool) -> bool:
+        if super().field_is_required(field, total):
+            return True
+        wrapped = field.get("schema", {})
+        if wrapped.get("type") != "default":
+            return False
+        if "default_factory" in wrapped:
+            # A real default (e.g. extra_fields' dict factory): optional.
+            return False
+        if wrapped.get("default") is not None:
+            # An explicit, meaningful default: optional.
+            return False
+        # default=None on a non-Optional annotation is ComparableField's
+        # construction-tolerance sentinel, not a statement that the field is
+        # optional.
+        return not _core_schema_is_nullable(wrapped.get("schema", {}))
+
+
+def _strip_x_comparison(node: Any) -> None:
+    """Recursively remove ``x-comparison`` keys from a rendered schema.
+
+    Comparison configuration (comparator, threshold, weight) is evaluation
+    metadata, not part of the shape ``model_json_schema()`` describes. Leaving
+    it in bloats tool specs sent to LLMs and shows the model the rubric it is
+    about to be graded against. The deliberate export path,
+    ``to_json_schema()``, still carries the configuration as
+    ``x-aws-stickler-*`` extensions.
+    """
+    if isinstance(node, dict):
+        node.pop("x-comparison", None)
+        for value in node.values():
+            _strip_x_comparison(value)
+    elif isinstance(node, list):
+        for item in node:
+            _strip_x_comparison(item)
+
+
+def _drop_null_defaults_for_required(schema_obj: Dict[str, Any]) -> None:
+    """Remove ``default: null`` from properties listed in ``required``.
+
+    Once a field is marked required, a leftover ``default: null`` is
+    contradictory, and schema flatteners (Strands' among them) read it as
+    permission to widen the type to nullable.
+    """
+    required = schema_obj.get("required")
+    properties = schema_obj.get("properties")
+    if not (isinstance(required, list) and isinstance(properties, dict)):
+        return
+    for name in required:
+        prop = properties.get(name)
+        if isinstance(prop, dict) and prop.get("default", ...) is None:
+            del prop["default"]
+
+
+def _strip_extra_fields_property(schema_obj: Dict[str, Any]) -> None:
+    """Remove the internal ``extra_fields`` property from a schema object.
+
+    Operates in place on a single JSON Schema object (a top-level schema or a
+    ``$defs`` entry): drops it from ``properties`` and from ``required``. A
+    no-op when ``extra_fields`` is absent.
+    """
+    properties = schema_obj.get("properties")
+    if isinstance(properties, dict):
+        properties.pop(_EXTRA_FIELDS_KEY, None)
+    required = schema_obj.get("required")
+    if isinstance(required, list) and _EXTRA_FIELDS_KEY in required:
+        schema_obj["required"] = [r for r in required if r != _EXTRA_FIELDS_KEY]
 
 
 class StructuredModel(BaseModel):
@@ -1275,41 +1382,48 @@ class StructuredModel(BaseModel):
 
     @classmethod
     def model_json_schema(cls, **kwargs):
-        """Override to add model-level comparison metadata.
+        """Render the model's shape for external consumers.
 
-        Extends the standard Pydantic JSON schema with comparison metadata
-        at the field level.
+        This is Pydantic's contract for "describe this shape", and it is what
+        schema consumers such as Strands' ``convert_pydantic_to_tool_spec``
+        call. Three corrections are applied to the standard rendering so a
+        configured ``StructuredModel`` describes the same shape as the plain
+        ``BaseModel`` a developer would otherwise write (issue #188):
+
+        - ``required`` is derived from the annotation, so ``shipment_id: str``
+          renders required even though ``ComparableField`` assigns
+          ``default=None`` for construction tolerance, and required fields do
+          not carry a contradictory ``default: null``.
+        - Comparison configuration (``x-comparison``) is not emitted.
+          Evaluation config is not part of the shape; the deliberate export
+          path ``to_json_schema()`` still carries it as ``x-aws-stickler-*``
+          extensions.
+        - The internal ``extra_fields`` property is not emitted (top level or
+          nested ``$defs``); it holds unmatched input keys and is not part of
+          the data contract. This also lets the output round-trip through
+          ``from_json_schema()`` (issue #214).
+
+        Field-level ``description``, ``examples``, and ``alias`` pass through
+        untouched, since those are genuinely useful to a schema consumer.
 
         Args:
             **kwargs: Arguments to pass to the parent method
 
         Returns:
-            JSON schema with added comparison metadata
+            JSON schema describing the model's shape
         """
+        kwargs.setdefault("schema_generator", _AnnotationDrivenJsonSchema)
         schema = super().model_json_schema(**kwargs)
 
-        # Add comparison metadata to each field in the schema
-        for field_name, field_info in cls.model_fields.items():
-            if field_name == "extra_fields":
-                continue
-
-            # Get the schema property for this field
-            if field_name not in schema.get("properties", {}):
-                continue
-
-            field_props = schema["properties"][field_name]
-
-            # Since ComparableField is now always a function, check for json_schema_extra
-            if hasattr(field_info, "json_schema_extra") and callable(
-                field_info.json_schema_extra
-            ):
-                # Fallback: Check for json_schema_extra function
-                temp_schema = {}
-                field_info.json_schema_extra(temp_schema)
-
-                if "x-comparison" in temp_schema:
-                    # Copy the comparison metadata from the temp schema to the real schema
-                    field_props["x-comparison"] = temp_schema["x-comparison"]
+        # `json_schema_extra` attaches `x-comparison` during generation, so the
+        # strip below removes it rather than declining to add it. Comparison
+        # config is stickler's own bookkeeping and has no meaning to a schema
+        # consumer; `to_json_schema()` is the export that deliberately carries
+        # it, as `x-aws-stickler-*`.
+        for schema_obj in (schema, *schema.get("$defs", {}).values()):
+            _strip_extra_fields_property(schema_obj)
+            _drop_null_defaults_for_required(schema_obj)
+        _strip_x_comparison(schema)
 
         return schema
 

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -87,6 +87,29 @@ class _AnnotationDrivenJsonSchema(GenerateJsonSchema):
         return not _core_schema_is_nullable(wrapped.get("schema", {}))
 
 
+
+def _compose_schema_generator(
+    supplied: Optional[Type[GenerateJsonSchema]],
+) -> Type[GenerateJsonSchema]:
+    """Mix the annotation-driven requiredness rule into a caller's generator.
+
+    Returns the mixin alone when nothing was supplied, the caller's class
+    unchanged when it already carries the rule, and otherwise a synthesised
+    subclass putting the mixin first so its ``field_is_required`` wins while
+    every other customisation (``$ref`` templates, naming conventions) is
+    preserved.
+    """
+    if supplied is None:
+        return _AnnotationDrivenJsonSchema
+    if issubclass(supplied, _AnnotationDrivenJsonSchema):
+        return supplied
+    return type(
+        f"AnnotationDriven{supplied.__name__}",
+        (_AnnotationDrivenJsonSchema, supplied),
+        {},
+    )
+
+
 def _strip_x_comparison(node: Any) -> None:
     """Recursively remove ``x-comparison`` keys from a rendered schema.
 
@@ -1412,7 +1435,15 @@ class StructuredModel(BaseModel):
         Returns:
             JSON schema describing the model's shape
         """
-        kwargs.setdefault("schema_generator", _AnnotationDrivenJsonSchema)
+        # Compose with a caller-supplied generator rather than deferring to it.
+        # `schema_generator` is a documented public parameter, and
+        # `setdefault` would leave a caller's class in place -- silently
+        # dropping the requiredness derivation and rendering `required` as
+        # absent again, which is the bug this method exists to fix. The mixin
+        # only overrides `field_is_required`, so it composes with anything.
+        kwargs["schema_generator"] = _compose_schema_generator(
+            kwargs.get("schema_generator")
+        )
         schema = super().model_json_schema(**kwargs)
 
         # `json_schema_extra` attaches `x-comparison` during generation, so the

--- a/tests/structured_object_evaluator/test_comparable_field_fix.py
+++ b/tests/structured_object_evaluator/test_comparable_field_fix.py
@@ -130,7 +130,13 @@ class TestComparableFieldFix:
         )
 
     def test_json_schema_serialization(self):
-        """Test that JSON schema generation preserves comparison metadata."""
+        """Comparison config stays on the field; the rendered schema keeps the alias.
+
+        ``model_json_schema()`` describes the shape only (issue #188): the
+        alias still shapes the rendered properties, and the comparison
+        metadata is read from ``json_schema_extra`` the way the engine reads
+        it.
+        """
 
         class TestModel(StructuredModel):
             name: str = ComparableField(
@@ -140,20 +146,20 @@ class TestComparableFieldFix:
                 comparator=ExactComparator(), threshold=1.0, alias="email_address"
             )
 
-        # Generate JSON schema
+        # Generate JSON schema: the alias shapes the rendered property names,
+        # and comparison metadata does not leak into the rendering.
         schema = TestModel.model_json_schema()
+        assert "email_address" in schema.get("properties", {})  # alias honored
+        assert "x-comparison" not in schema["properties"]["name"]
+        assert "x-comparison" not in schema["properties"]["email_address"]
 
-        # Check that comparison metadata is preserved
-        name_field = schema.get("properties", {}).get("name", {})
-        email_field = schema.get("properties", {}).get(
-            "email_address", {}
-        )  # Note: uses alias
+        def comparison_metadata(field_name):
+            extra = {}
+            TestModel.model_fields[field_name].json_schema_extra(extra)
+            return extra["x-comparison"]
 
-        assert "x-comparison" in name_field, "Name field missing comparison metadata"
-        assert "x-comparison" in email_field, "Email field missing comparison metadata"
-
-        name_comp = name_field["x-comparison"]
-        email_comp = email_field["x-comparison"]
+        name_comp = comparison_metadata("name")
+        email_comp = comparison_metadata("email")
 
         assert name_comp.get("comparator_type") == "LevenshteinComparator"
         assert name_comp.get("threshold") == 0.8

--- a/tests/structured_object_evaluator/test_comparators_schema.py
+++ b/tests/structured_object_evaluator/test_comparators_schema.py
@@ -43,16 +43,28 @@ class SpecializedComparatorModel(StructuredModel):
 
 
 def test_custom_comparator_in_schema():
-    """Test that custom comparators are correctly reflected in the schema."""
-    # Get schema for model with custom comparator
+    """Custom comparators are recorded on the field, not the rendered schema.
+
+    ``model_json_schema()`` describes the shape only (issue #188); the
+    comparison config is read from ``json_schema_extra`` the way the engine
+    reads it.
+    """
+    # The rendered schema must not leak comparison config
     schema = SpecializedComparatorModel.model_json_schema()
+    assert "x-comparison" not in schema["properties"]["standard_field"]
+    assert "x-comparison" not in schema["properties"]["insensitive_field"]
+
+    def comparison_metadata(field_name):
+        extra = {}
+        SpecializedComparatorModel.model_fields[field_name].json_schema_extra(extra)
+        return extra["x-comparison"]
 
     # Check standard field
-    std_comp_info = schema["properties"]["standard_field"]["x-comparison"]
+    std_comp_info = comparison_metadata("standard_field")
     assert std_comp_info["comparator_type"] == "LevenshteinComparator"
     assert std_comp_info["comparator_name"] == "levenshtein"
 
     # Check case insensitive field
-    case_comp_info = schema["properties"]["insensitive_field"]["x-comparison"]
+    case_comp_info = comparison_metadata("insensitive_field")
     assert case_comp_info["comparator_type"] == "CaseInsensitiveComparator"
     assert case_comp_info["comparator_name"] == "case_insensitive"

--- a/tests/structured_object_evaluator/test_model_schema.py
+++ b/tests/structured_object_evaluator/test_model_schema.py
@@ -11,6 +11,7 @@ import json
 from typing import Any, Dict, List, Optional
 
 from pydantic import Field
+from pydantic.json_schema import GenerateJsonSchema
 
 from stickler.comparators.levenshtein import LevenshteinComparator
 
@@ -264,3 +265,53 @@ def test_model_defaults():
     # Check that description is properly set
     assert "description" in default_props
     assert default_props["description"] == "A field with default value"
+
+
+# ---------------------------------------------------------------------------
+# schema_generator composition (#188)
+# ---------------------------------------------------------------------------
+#
+# `schema_generator` is a documented public parameter of
+# `BaseModel.model_json_schema()`. The annotation-driven requiredness rule is a
+# mixin overriding only `field_is_required`, so a caller's generator must be
+# composed with rather than deferred to -- `setdefault` would leave theirs in
+# place and silently drop `required` entirely, which is the bug #188 fixes.
+
+
+class _CallerGenerator(GenerateJsonSchema):
+    """A caller's own generator, standing in for a framework's."""
+
+    def generate(self, schema, mode="validation"):
+        rendered = super().generate(schema, mode=mode)
+        rendered["x-caller-marker"] = True
+        return rendered
+
+
+def test_caller_supplied_generator_keeps_the_requiredness_rule():
+    """The fix must survive a caller passing their own generator."""
+    schema = SimpleTestModel.model_json_schema(schema_generator=_CallerGenerator)
+
+    assert schema.get("required") == ["text"], (
+        "a caller's generator must not silently drop the requiredness derivation"
+    )
+
+
+def test_caller_supplied_generator_is_still_applied():
+    """Composition, not replacement: the caller's customisation survives too."""
+    schema = SimpleTestModel.model_json_schema(schema_generator=_CallerGenerator)
+
+    assert schema.get("x-caller-marker") is True
+
+
+def test_generator_already_carrying_the_rule_is_used_unchanged():
+    """No pointless synthesised subclass when the caller already has the mixin."""
+    from stickler.structured_object_evaluator.models.structured_model import (
+        _AnnotationDrivenJsonSchema,
+        _compose_schema_generator,
+    )
+
+    class Already(_AnnotationDrivenJsonSchema):
+        pass
+
+    assert _compose_schema_generator(Already) is Already
+    assert _compose_schema_generator(None) is _AnnotationDrivenJsonSchema

--- a/tests/structured_object_evaluator/test_model_schema.py
+++ b/tests/structured_object_evaluator/test_model_schema.py
@@ -1,11 +1,14 @@
 """
 Test the JSON schema serialization of StructuredModel classes.
-This verifies that structured models can be correctly serialized to JSON schema
-with all comparison metadata intact.
+
+``model_json_schema()`` describes the model's *shape* for external consumers
+(e.g. tool specs sent to an LLM), so it must NOT carry comparison metadata
+(issue #188). The metadata is still attached to every field and reachable via
+``json_schema_extra`` and the deliberate export path ``to_json_schema()``.
 """
 
 import json
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import Field
 
@@ -13,6 +16,17 @@ from stickler.comparators.levenshtein import LevenshteinComparator
 
 # Import from structured_object_evaluator instead of anls_star_lib
 from stickler.structured_object_evaluator import ComparableField, StructuredModel
+
+
+def _comparison_metadata(model_cls, field_name: str) -> Dict[str, Any]:
+    """Read a field's comparison metadata the way the engine does.
+
+    The metadata lives on the field's ``json_schema_extra`` callable; it is
+    deliberately not rendered into ``model_json_schema()``.
+    """
+    extra: Dict[str, Any] = {}
+    model_cls.model_fields[field_name].json_schema_extra(extra)
+    return extra["x-comparison"]
 
 
 class SimpleTestModel(StructuredModel):
@@ -56,7 +70,7 @@ class NestedTestModel(StructuredModel):
 
 
 def test_simple_model_schema():
-    """Test that a simple model can be serialized to JSON schema with comparison metadata."""
+    """The rendered schema describes the shape; comparison config stays off it."""
     # Get the JSON schema for the simple model
     schema = SimpleTestModel.model_json_schema()
 
@@ -64,19 +78,22 @@ def test_simple_model_schema():
     assert "properties" in schema
     assert "text" in schema["properties"]
 
-    # Check that the text property has comparison metadata
+    # Comparison metadata must NOT leak into the rendered schema (issue #188):
+    # it is evaluation config, not part of the shape, and it would ride into
+    # tool specs sent to LLMs.
     text_props = schema["properties"]["text"]
-    assert "x-comparison" in text_props
+    assert "x-comparison" not in text_props
 
-    # Check that comparison metadata has the expected fields
-    comp_info = text_props["x-comparison"]
+    # The metadata is still attached to the field and readable the way the
+    # comparison engine reads it.
+    comp_info = _comparison_metadata(SimpleTestModel, "text")
     assert comp_info["comparator_type"] == "LevenshteinComparator"
     assert comp_info["threshold"] == 0.7
     assert comp_info["weight"] == 1.0
 
 
 def test_complex_model_schema():
-    """Test that a complex model can be serialized to JSON schema with comparison metadata for all fields."""
+    """Every field keeps its metadata off the rendered schema but readable."""
     # Get the JSON schema for the complex model
     schema = ComplexTestModel.model_json_schema()
 
@@ -86,7 +103,6 @@ def test_complex_model_schema():
         field in schema["properties"] for field in ["id", "name", "description", "tags"]
     )
 
-    # Check that each property has comparison metadata
     fields = {
         "id": {"threshold": 0.9, "weight": 2.0},
         "name": {"threshold": 0.7, "weight": 1.0},
@@ -95,10 +111,11 @@ def test_complex_model_schema():
     }
 
     for field_name, expected_values in fields.items():
-        field_props = schema["properties"][field_name]
-        assert "x-comparison" in field_props
+        # Not rendered (issue #188)...
+        assert "x-comparison" not in schema["properties"][field_name]
 
-        comp_info = field_props["x-comparison"]
+        # ...but still configured on the field.
+        comp_info = _comparison_metadata(ComplexTestModel, field_name)
         assert comp_info["threshold"] == expected_values["threshold"]
         assert comp_info["weight"] == expected_values["weight"]
 
@@ -113,10 +130,9 @@ def test_nested_model_schema():
     assert "title" in schema["properties"]
     assert "simple" in schema["properties"]
 
-    # Check that title has comparison metadata
-    title_props = schema["properties"]["title"]
-    assert "x-comparison" in title_props
-    title_comp = title_props["x-comparison"]
+    # title's comparison config stays off the rendered schema but on the field
+    assert "x-comparison" not in schema["properties"]["title"]
+    title_comp = _comparison_metadata(NestedTestModel, "title")
     assert title_comp["threshold"] == 0.8
     assert title_comp["weight"] == 1.5
 
@@ -133,14 +149,60 @@ def test_schema_serialization():
     schema = ComplexTestModel.model_json_schema()
     json_string = json.dumps(schema)
 
-    # Verify it can be parsed back
+    # Verify it can be parsed back, and that no comparison metadata leaked
+    # anywhere in the document (issue #188).
     parsed_schema = json.loads(json_string)
-    assert parsed_schema["properties"]["id"]["x-comparison"]["threshold"] == 0.9
+    assert "x-comparison" not in json_string
+    assert parsed_schema["properties"]["id"]["type"] == "string"
 
     # Test with nested model as well
     nested_schema = NestedTestModel.model_json_schema()
     nested_json = json.dumps(nested_schema)
     json.loads(nested_json)
+    assert "x-comparison" not in nested_json
+
+
+def test_required_follows_annotation():
+    """`required` derives from the annotation, not ComparableField's default.
+
+    ComparableField assigns ``default=None`` so construction tolerates
+    partial predictions, but that is a runtime concern: for schema purposes
+    ``shipment_id: str`` is required and ``notes: Optional[str]`` is not
+    (issue #188). A field with a real default stays optional.
+    """
+
+    class RequirednessModel(StructuredModel):
+        must_have: str = ComparableField()
+        may_skip: Optional[str] = ComparableField(default=None)
+        has_default: str = ComparableField(default="fallback")
+
+    schema = RequirednessModel.model_json_schema()
+
+    assert schema.get("required") == ["must_have"]
+    # The required field renders its bare type, with no contradictory
+    # default:null and no null-widening.
+    must_have = schema["properties"]["must_have"]
+    assert must_have["type"] == "string"
+    assert "default" not in must_have
+    # The genuinely optional field keeps its nullable rendering and default.
+    may_skip = schema["properties"]["may_skip"]
+    assert {"type": "null"} in may_skip.get("anyOf", [])
+    # The defaulted field keeps its default and stays optional.
+    assert schema["properties"]["has_default"]["default"] == "fallback"
+
+    # Schema requiredness must not leak into runtime: partial construction
+    # still works, because the comparison engine builds models from
+    # prediction JSON that may omit fields.
+    instance = RequirednessModel.from_json({"may_skip": "x"})
+    assert instance.must_have is None
+
+
+def test_nested_model_required_in_defs():
+    """Nested models rendered into $defs get the same required treatment."""
+    schema = NestedTestModel.model_json_schema()
+
+    simple_def = schema["$defs"]["SimpleTestModel"]
+    assert simple_def.get("required") == ["text"]
 
 
 def test_schema_validation_compatibility():
@@ -189,10 +251,10 @@ def test_model_defaults():
         for field in ["required_field", "optional_field", "defaulted_field"]
     )
 
-    # Check that required_field has comparison metadata
-    req_props = schema["properties"]["required_field"]
-    assert "x-comparison" in req_props
-    assert req_props["x-comparison"]["threshold"] == 0.8
+    # required_field's comparison config stays off the rendered schema but on
+    # the field (issue #188).
+    assert "x-comparison" not in schema["properties"]["required_field"]
+    assert _comparison_metadata(DefaultTestModel, "required_field")["threshold"] == 0.8
 
     # Check that the default value is present
     default_props = schema["properties"]["defaulted_field"]

--- a/tests/structured_object_evaluator/test_strands_tool_spec_parity.py
+++ b/tests/structured_object_evaluator/test_strands_tool_spec_parity.py
@@ -1,0 +1,194 @@
+"""Tool-spec parity between StructuredModel and plain BaseModel (issue #188).
+
+``StructuredModel`` extends ``pydantic.BaseModel``, so one configured class
+can drive a Strands agent's structured output *and* carry stickler's
+comparison configuration. That premise only holds if the schema a
+``StructuredModel`` hands to the model matches what an equivalent plain
+``BaseModel`` would send. These tests pin the three degradations from #188:
+
+1. ``required`` disappeared (ComparableField's ``default=None`` made every
+   field optional in Pydantic's eyes).
+2. Types widened (a required ``str`` rendered as ``["string", "null"]``).
+3. Comparison config leaked into the tool spec.
+
+And the property to preserve: ``description``, ``examples``, and ``alias``
+must keep reaching the rendered schema, since those are genuinely useful to
+the model.
+
+The whole module goes through Strands' own ``convert_pydantic_to_tool_spec``
+and skips when strands is not installed (the ``llm`` extra; CI installs it).
+The equivalent schema-shape assertions that need no strands live in
+``test_model_schema.py`` and ``test_structured_model_schema.py``.
+"""
+
+import json
+from typing import List, Optional
+
+import pytest
+from pydantic import BaseModel
+
+from stickler.comparators.exact import ExactComparator
+from stickler.comparators.numeric import NumericComparator
+from stickler.structured_object_evaluator.models.comparable_field import (
+    ComparableField,
+)
+from stickler.structured_object_evaluator.models.structured_model import (
+    StructuredModel,
+)
+
+strands_structured_output = pytest.importorskip(
+    "strands.tools.structured_output",
+    reason="strands-agents not installed (llm extra)",
+)
+convert_pydantic_to_tool_spec = strands_structured_output.convert_pydantic_to_tool_spec
+
+
+# --- Equivalent model pairs -------------------------------------------------
+
+
+class PlainLineItem(BaseModel):
+    product: str
+    qty: int
+
+
+class PlainInvoice(BaseModel):
+    shipment_id: str
+    amount: float
+    line_items: List[PlainLineItem]
+    memo: Optional[str] = None
+
+
+class LineItem(StructuredModel):
+    product: str = ComparableField()
+    qty: int = ComparableField()
+
+
+class Invoice(StructuredModel):
+    shipment_id: str = ComparableField(comparator=ExactComparator(), weight=3.0)
+    amount: float = ComparableField(comparator=NumericComparator())
+    line_items: List[LineItem] = ComparableField()
+    memo: Optional[str] = ComparableField(default=None)
+
+
+def _tool_spec_json(model_cls) -> dict:
+    return convert_pydantic_to_tool_spec(model_cls)["inputSchema"]["json"]
+
+
+class TestToolSpecParity:
+    """Flow 2: a configured StructuredModel sends the same schema as its twin."""
+
+    def test_required_lists_match(self):
+        plain = _tool_spec_json(PlainInvoice)
+        configured = _tool_spec_json(Invoice)
+
+        assert sorted(configured.get("required") or []) == sorted(
+            plain.get("required") or []
+        )
+        # And they are the right fields, not coincidentally-equal empties.
+        assert sorted(plain.get("required") or []) == [
+            "amount",
+            "line_items",
+            "shipment_id",
+        ]
+
+    def test_required_field_types_are_not_null_widened(self):
+        configured = _tool_spec_json(Invoice)
+
+        assert configured["properties"]["shipment_id"]["type"] == "string"
+        assert configured["properties"]["amount"]["type"] == "number"
+
+    def test_optional_field_stays_nullable(self):
+        plain = _tool_spec_json(PlainInvoice)
+        configured = _tool_spec_json(Invoice)
+
+        # memo is genuinely Optional on both models; the annotation, not the
+        # ComparableField default, is what makes it nullable.
+        assert configured["properties"]["memo"]["type"] == plain["properties"][
+            "memo"
+        ]["type"]
+
+    def test_no_comparison_config_in_tool_spec(self):
+        configured = _tool_spec_json(Invoice)
+
+        assert "x-comparison" not in json.dumps(configured)
+
+    def test_payload_size_is_comparable(self):
+        # #188 measured 141% bloat. Identical shape means near-identical size;
+        # allow slack only for the model title/description strings.
+        plain = len(json.dumps(_tool_spec_json(PlainInvoice)))
+        configured = len(json.dumps(_tool_spec_json(Invoice)))
+
+        assert configured <= plain * 1.15, (
+            f"tool spec for the configured model is {configured} chars vs "
+            f"{plain} for the plain twin; comparison metadata is leaking again"
+        )
+
+
+class TestFlowOnePlainPydantic:
+    """Flow 1: plain Pydantic through the tool spec, evaluated by inference."""
+
+    def test_plain_model_tool_spec_and_evaluation(self):
+        import stickler
+
+        spec = _tool_spec_json(PlainInvoice)
+        assert sorted(spec.get("required") or []) == [
+            "amount",
+            "line_items",
+            "shipment_id",
+        ]
+
+        ground_truth = PlainInvoice(
+            shipment_id="SHP-1",
+            amount=10.0,
+            line_items=[PlainLineItem(product="mouse", qty=2)],
+        )
+        prediction = PlainInvoice(
+            shipment_id="SHP-1",
+            amount=10.0,
+            line_items=[PlainLineItem(product="mouse", qty=2)],
+        )
+
+        result = stickler.evaluate(ground_truth, prediction)
+        assert result.overall_score == 1.0
+
+
+class TestFlowTwoConfiguredModel:
+    """Flow 2 end to end: the same class drives the agent and the comparison."""
+
+    def test_configured_comparators_still_honored(self):
+        # The schema fix must not disturb the comparison config. ExactComparator
+        # on shipment_id means a one-character difference scores 0, where the
+        # default Levenshtein would score high.
+        gt = Invoice.from_json(
+            {
+                "shipment_id": "SHP-2024-001",
+                "amount": 10.0,
+                "line_items": [{"product": "mouse", "qty": 2}],
+            }
+        )
+        off_by_one = Invoice.from_json(
+            {
+                "shipment_id": "SHP-2024-002",
+                "amount": 10.0,
+                "line_items": [{"product": "mouse", "qty": 2}],
+            }
+        )
+
+        result = gt.compare_with(off_by_one)
+        assert result["field_scores"]["shipment_id"] == 0.0
+
+    def test_partial_prediction_still_constructs(self):
+        # The schema-only fix must not change runtime tolerance: predictions
+        # that omit fields still construct (the engine depends on this).
+        partial = Invoice.from_json({"shipment_id": "SHP-1"})
+        assert partial.amount is None
+
+        gt = Invoice.from_json(
+            {
+                "shipment_id": "SHP-1",
+                "amount": 10.0,
+                "line_items": [{"product": "mouse", "qty": 2}],
+            }
+        )
+        result = gt.compare_with(partial)
+        assert result["field_scores"]["shipment_id"] == 1.0

--- a/tests/structured_object_evaluator/test_structured_model_comparators.py
+++ b/tests/structured_object_evaluator/test_structured_model_comparators.py
@@ -326,16 +326,28 @@ def test_threshold_effects():
 
 
 def test_custom_comparator_in_schema():
-    """Test that custom comparators are correctly reflected in the schema."""
-    # Get schema for model with custom comparator
+    """Custom comparators are recorded on the field, not the rendered schema.
+
+    ``model_json_schema()`` describes the shape only (issue #188); the
+    comparison config is read from ``json_schema_extra`` the way the engine
+    reads it.
+    """
+    # The rendered schema must not leak comparison config
     schema = SpecializedComparatorModel.model_json_schema()
+    assert "x-comparison" not in schema["properties"]["standard_field"]
+    assert "x-comparison" not in schema["properties"]["insensitive_field"]
+
+    def comparison_metadata(field_name):
+        extra = {}
+        SpecializedComparatorModel.model_fields[field_name].json_schema_extra(extra)
+        return extra["x-comparison"]
 
     # Check standard field
-    std_comp_info = schema["properties"]["standard_field"]["x-comparison"]
+    std_comp_info = comparison_metadata("standard_field")
     assert std_comp_info["comparator_type"] == "LevenshteinComparator"
     assert std_comp_info["comparator_name"] == "levenshtein"
 
     # Check case insensitive field
-    case_comp_info = schema["properties"]["insensitive_field"]["x-comparison"]
+    case_comp_info = comparison_metadata("insensitive_field")
     assert case_comp_info["comparator_type"] == "CaseInsensitiveComparator"
     assert case_comp_info["comparator_name"] == "case_insensitive"

--- a/tests/structured_object_evaluator/test_structured_model_schema.py
+++ b/tests/structured_object_evaluator/test_structured_model_schema.py
@@ -1,15 +1,29 @@
 """
 Test the JSON schema serialization of StructuredModel classes.
-This verifies that structured models can be correctly serialized to JSON schema
-with all comparison metadata intact.
+
+``model_json_schema()`` describes the model's *shape* for external consumers
+(e.g. tool specs sent to an LLM), so it must NOT carry comparison metadata
+(issue #188). The metadata is still attached to every field and reachable via
+``json_schema_extra`` and the deliberate export path ``to_json_schema()``.
 """
 
 import json
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from stickler.comparators.levenshtein import LevenshteinComparator
 from stickler.structured_object_evaluator.models.comparable_field import ComparableField
 from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+
+
+def _comparison_metadata(model_cls, field_name: str) -> Dict[str, Any]:
+    """Read a field's comparison metadata the way the engine does.
+
+    The metadata lives on the field's ``json_schema_extra`` callable; it is
+    deliberately not rendered into ``model_json_schema()``.
+    """
+    extra: Dict[str, Any] = {}
+    model_cls.model_fields[field_name].json_schema_extra(extra)
+    return extra["x-comparison"]
 
 
 class SimpleTestModel(StructuredModel):
@@ -61,12 +75,12 @@ def test_simple_model_schema():
     assert "properties" in schema
     assert "text" in schema["properties"]
 
-    # Check that the text property has comparison metadata
+    # Comparison metadata must NOT leak into the rendered schema (issue #188).
     text_props = schema["properties"]["text"]
-    assert "x-comparison" in text_props
+    assert "x-comparison" not in text_props
 
-    # Check that comparison metadata has the expected fields
-    comp_info = text_props["x-comparison"]
+    # It is still attached to the field, read the way the engine reads it.
+    comp_info = _comparison_metadata(SimpleTestModel, "text")
     assert comp_info["comparator_type"] == "LevenshteinComparator"
     assert comp_info["threshold"] == 0.7
     assert comp_info["weight"] == 1.0
@@ -92,10 +106,10 @@ def test_complex_model_schema():
     }
 
     for field_name, expected_values in fields.items():
-        field_props = schema["properties"][field_name]
-        assert "x-comparison" in field_props
+        # Not rendered (issue #188), but still configured on the field.
+        assert "x-comparison" not in schema["properties"][field_name]
 
-        comp_info = field_props["x-comparison"]
+        comp_info = _comparison_metadata(ComplexTestModel, field_name)
         assert comp_info["threshold"] == expected_values["threshold"]
         assert comp_info["weight"] == expected_values["weight"]
 
@@ -110,10 +124,9 @@ def test_nested_model_schema():
     assert "title" in schema["properties"]
     assert "simple" in schema["properties"]
 
-    # Check that title has comparison metadata
-    title_props = schema["properties"]["title"]
-    assert "x-comparison" in title_props
-    title_comp = title_props["x-comparison"]
+    # title's comparison config stays off the rendered schema but on the field
+    assert "x-comparison" not in schema["properties"]["title"]
+    title_comp = _comparison_metadata(NestedTestModel, "title")
     assert title_comp["threshold"] == 0.8
     assert title_comp["weight"] == 1.5
 
@@ -130,9 +143,11 @@ def test_schema_serialization():
     schema = ComplexTestModel.model_json_schema()
     json_string = json.dumps(schema)
 
-    # Verify it can be parsed back
+    # Verify it can be parsed back, and that no comparison metadata leaked
+    # anywhere in the document (issue #188).
     parsed_schema = json.loads(json_string)
-    assert parsed_schema["properties"]["id"]["x-comparison"]["threshold"] == 0.9
+    assert "x-comparison" not in json_string
+    assert parsed_schema["properties"]["id"]["type"] == "string"
 
     # Test with nested model as well
     nested_schema = NestedTestModel.model_json_schema()


### PR DESCRIPTION
## Issue

Implements #188 (schema-only approach; see "What this deliberately does not do" below).

**No longer stacked.** #217 is closed; its `extra_fields` fix is folded in here, since both changed `model_json_schema()`. Against current `dev` this is a standalone 10-file diff.

One side effect of that fold, documented rather than hidden: dropping the internal `extra_fields` property means `from_json_schema(model_json_schema())` parses for a model whose fields are all required, where it used to raise. It still does **not** round-trip (the rebuilt model carries default thresholds and comparators), and a model with any `Optional` field still raises on the nullable `anyOf` gap that #198 addresses. `model_json_schema()` keeps its documented "Round-trip: No".

## Problem

`StructuredModel` extends `pydantic.BaseModel`, so one configured class should drive a Strands agent's structured output *and* carry comparison config. But the schema it handed the model was materially degraded versus a plain-`BaseModel` twin, measured through Strands' own `convert_pydantic_to_tool_spec`:

| | plain `BaseModel` | `StructuredModel` before | `StructuredModel` after |
|---|---|---|---|
| `required` | `['shipment_id', 'amount']` | **`None`** | `['shipment_id', 'amount']` |
| `shipment_id` type | `"string"` | **`["string", "null"]`** | `"string"` |
| `x-comparison` leak | absent | **every field** | absent |
| payload | 238 chars | **700 chars** | 243 chars |

So reusing your configured class silently sabotaged the extraction: the agent was told nothing is required and null is always acceptable, and it was shown the thresholds it was about to be graded against.

## The key insight

The annotation already says what the user meant: `shipment_id: str` is required, `notes: Optional[str]` is not. `ComparableField`'s `default=None` exists for **construction tolerance** (the engine builds instances from partial prediction JSON), not as a statement about the schema. So the schema can be corrected by changing only what `model_json_schema()` **emits** — no change to runtime construction, no breaking change.

## Changes

1. **`required` derives from the annotation.** A custom `GenerateJsonSchema` marks a field required when its annotation is non-`Optional` and it carries no real default. It runs at generation time, so nested models rendered into `$defs` get the same treatment. An explicit default (`default="x"`) or a genuinely `Optional` annotation keeps the field optional, exactly as in plain Pydantic.
2. **`default: null` dropped from required properties.** It contradicted the requiredness, and schema flatteners (Strands' included) read it as permission to widen the type to nullable.
3. **`x-comparison` no longer emitted.** Evaluation config is not part of the shape. The deliberate export path `to_json_schema()` still carries it as `x-aws-stickler-*`, and the engine reads it from `json_schema_extra`, so nothing internal changes.
4. **`description`, `examples`, `alias` still pass through** — those genuinely help the model. Pinned by tests.

## What this deliberately does not do

Issue #188's part A proposed flipping `ComparableField`'s default to `PydanticUndefined`, making fields required at **runtime**. That would break partial-prediction construction across the engine (~360 call sites in tests alone) — every evaluation where a prediction omits a field would crash. Since the schema symptoms are fully fixable without it, this PR takes the schema-only path and leaves runtime behavior untouched. `test_partial_prediction_still_constructs` pins that explicitly.

## Acceptance criteria from #188

- [x] `convert_pydantic_to_tool_spec(SticklerModel)` and its plain twin produce the same `required` list
- [x] Non-optional annotated fields render as `"string"`, not `["string", "null"]`
- [x] `x-comparison` absent from `model_json_schema()`; still present in `to_json_schema()`
- [x] `description`, `examples`, `alias` still reach the rendered schema
- [x] Flow 1 (plain Pydantic + inference) end-to-end regression test through tool-spec conversion
- [x] Flow 2 (`StructuredModel`) same, plus `compare_with()` assertion that configured comparators are honored
- [x] Internal config reading, HTML reporting (`extract_all_field_thresholds` verified), `from_json_schema()`, `model_from_json()` unaffected: full suite green
- [x] CHANGELOG entry (as `Changed`, not `Breaking` — runtime is untouched; the note tells anyone reading `x-comparison` out of `model_json_schema()` where it went)

## Testing

- New `test_strands_tool_spec_parity.py` (8 tests): parity through the real Strands converter, both flows end to end, payload-size tripwire, partial-construction guard. Skips cleanly when strands isn't installed; CI installs the `llm` extra so it runs there.
- New annotation-requiredness tests in `test_model_schema.py`, including nested `$defs` and the runtime-tolerance guard — these need no strands.
- Existing tests that asserted `x-comparison` **in** `model_json_schema()` output now assert the opposite and read metadata from `json_schema_extra` the way the engine does (5 files, same assertions on the values).
- **Full suite: 1580 passed, 2 skipped.** `ruff check` clean. `mkdocs build` clean.

## Docs (part E)

The Strands guide now presents both flows explicitly: a comparison table up front, Flow 1 (plain Pydantic + `stickler.evaluate`) unchanged, and a new Flow 2 section showing one configured class driving both the agent and `compare_with()`, including the guidance that requiredness follows the annotation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

