### PR TITLE
fix(comparator): add normalize parameter to ExactComparator (#199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,9 +189,19 @@ Each release links to full notes on the
   | `ExactComparator().compare("ID-123", "ID 123")` | 1.0 | **0.0** |
   | `ExactComparator().compare("SHP-2024-001", "shp 2024 001")` | 1.0 | **0.0** |
 
-  **Migration:** If you need the old case-insensitive behavior, pass
-  `case_sensitive=False`. If you need punctuation normalization, use
-  `LevenshteinComparator(threshold=1.0)` or `FuzzyComparator`.
+  **Migration:** For case-insensitive matching, pass `case_sensitive=False`.
+
+  For punctuation or whitespace differences, `ExactComparator` is the wrong
+  tool. Use a similarity comparator with a threshold tuned to your data:
+
+  ```python
+  vendor: str = ComparableField(comparator=LevenshteinComparator(), threshold=0.8)
+  ```
+
+  Note that a threshold of `1.0` will **not** work here: `"ID-123"` vs
+  `"ID 123"` scores `0.833`, so requiring a perfect score still rejects it. Pick
+  a threshold below the score your real data produces, or write a comparator
+  that normalizes the way your domain requires.
 
   The `case_sensitive=False` path now uses `str.casefold()` (Unicode case
   folding) instead of `str.lower()`, correctly handling cases like

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,10 +178,32 @@ Each release links to full notes on the
   [#199](https://github.com/awslabs/stickler/issues/199), where
   `"SHP-2024-001"` incorrectly matched `"shp 2024 001"`.
 
-  **This can lower scores** on existing evaluation sets. Any field using
-  `ExactComparator` (explicitly or via inference) that previously matched
-  due to case folding or punctuation stripping will now score 0.0 if the
-  raw strings differ.
+  **This lowers scores** on existing evaluation sets, and it reaches you even if
+  you never named `ExactComparator`. The zero-config path (`stickler.evaluate()`,
+  `eval_for()`, `from_pydantic()`) infers `ExactComparator` for id-shaped,
+  code-shaped, email, zip and boolean fields, so on a typical extraction model
+  it covers roughly half the fields:
+
+  ```python
+  class Invoice(BaseModel):           # plain pydantic, no stickler config
+      invoice_id: str                 # inferred -> ExactComparator
+      sku: str                        # inferred -> ExactComparator
+      email: str                      # inferred -> ExactComparator
+      zip_code: str                   # inferred -> ExactComparator
+      vendor_name: str                # inferred -> LevenshteinComparator
+  ```
+
+  With predictions differing only in case and punctuation
+  (`"SHP-2024-001"` vs `"shp 2024 001"`, `"98101-1234"` vs `"98101 1234"`):
+
+  | | before | after |
+  |---|---|---|
+  | the four inferred-Exact fields | 1.0 each | **0.0 each** |
+  | `overall_score` | 1.0 | **0.20** |
+
+  That is the intended correction -- those pairs are not equal, and reporting
+  them as perfect matches is the bug -- but if you track a metric across
+  releases, expect a step change at this version rather than a drift.
 
   | what changed | before | after |
   |---|---|---|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,31 @@ Each release links to full notes on the
 
 ### Changed
 
+- **Breaking:** `ExactComparator` is now truly exact. The default is
+  `case_sensitive=True` (was `False`), and punctuation/whitespace stripping
+  has been removed entirely. This fixes
+  [#199](https://github.com/awslabs/stickler/issues/199), where
+  `"SHP-2024-001"` incorrectly matched `"shp 2024 001"`.
+
+  **This can lower scores** on existing evaluation sets. Any field using
+  `ExactComparator` (explicitly or via inference) that previously matched
+  due to case folding or punctuation stripping will now score 0.0 if the
+  raw strings differ.
+
+  | what changed | before | after |
+  |---|---|---|
+  | `ExactComparator().compare("Hello", "hello")` | 1.0 | **0.0** |
+  | `ExactComparator().compare("ID-123", "ID 123")` | 1.0 | **0.0** |
+  | `ExactComparator().compare("SHP-2024-001", "shp 2024 001")` | 1.0 | **0.0** |
+
+  **Migration:** If you need the old case-insensitive behavior, pass
+  `case_sensitive=False`. If you need punctuation normalization, use
+  `LevenshteinComparator(threshold=1.0)` or `FuzzyComparator`.
+
+  The `case_sensitive=False` path now uses `str.casefold()` (Unicode case
+  folding) instead of `str.lower()`, correctly handling cases like
+  `"STRASSE"` vs `"straße"` ([#199](https://github.com/awslabs/stickler/issues/199))
+
 - **Breaking:** the peripheral modules now require their extra. `pandas`,
   `scipy`, `scikit-learn`, and `jinja2` are no longer core dependencies, so
   `pip install stickler-eval` installs the comparison engine and nothing else.

--- a/src/stickler/comparators/exact.py
+++ b/src/stickler/comparators/exact.py
@@ -1,38 +1,76 @@
 """Exact string comparison comparator."""
 
-from typing import Any
+from typing import Any, Dict, Optional
 
 from stickler.comparators.base import BaseComparator
-from stickler.utils.text_normalizers import lowercase, strip_punctuation_space
 
 
 class ExactComparator(BaseComparator):
-    """Comparator that checks for exact string matching.
+    """Comparator that checks for exact string equality.
 
-    This comparator removes whitespace and punctuation before comparison.
-    It returns 1.0 for exact matches and 0.0 otherwise.
+    Returns 1.0 if the two values are identical, 0.0 otherwise. By default,
+    comparison is case-sensitive: ``"Hello"`` does not match ``"hello"``.
+    Set ``case_sensitive=False`` for case-insensitive matching using Unicode
+    case folding.
+
+    No normalization (punctuation or whitespace stripping) is performed.
+    ``"SHP-2024-001"`` does not match ``"SHP 2024 001"`` — they are different
+    strings. This is the correct behavior for identifiers, codes, and any
+    field where the exact character sequence matters.
 
     Example:
         ```python
+        # Default: case-sensitive exact matching
         comparator = ExactComparator()
+        comparator.compare("Hello", "Hello")  # Returns 1.0
+        comparator.compare("Hello", "hello")  # Returns 0.0
+        comparator.compare("ID-123", "ID 123")  # Returns 0.0
 
-        # Returns 1.0 (exact match after normalization)
-        comparator.compare("hello, world!", "hello world")
-
-        # Returns 0.0 (different strings)
-        comparator.compare("hello", "goodbye")
+        # Case-insensitive matching (uses Unicode casefold)
+        ci = ExactComparator(case_sensitive=False)
+        ci.compare("Hello", "hello")  # Returns 1.0
+        ci.compare("STRASSE", "straße")  # Returns 1.0 (casefold handles this)
         ```
+
+    Args:
+        threshold: Similarity threshold (default 1.0). Since this comparator
+            only returns 0.0 or 1.0, values below 1.0 effectively accept any
+            non-null value as a match.
+        case_sensitive: If True (default), comparison distinguishes case.
+            If False, uses ``str.casefold()`` for Unicode-aware case folding.
+
+    .. versionchanged:: 0.7.0
+        Default changed to ``case_sensitive=True``. Punctuation and whitespace
+        stripping removed — use ``LevenshteinComparator`` or ``FuzzyComparator``
+        for normalized text matching. This makes ``ExactComparator`` truly exact,
+        fixing #199 where ``"SHP-2024-001"`` incorrectly matched ``"shp 2024 001"``.
     """
 
-    def __init__(self, threshold: float = 1.0, case_sensitive: bool = False):
+    def __init__(self, threshold: float = 1.0, case_sensitive: bool = True):
         """Initialize the comparator.
 
         Args:
             threshold: Similarity threshold (default 1.0)
-            case_sensitive: Whether comparison is case sensitive (default False)
+            case_sensitive: Whether comparison is case sensitive (default True)
         """
         super().__init__(threshold=threshold)
         self.case_sensitive = case_sensitive
+
+    @property
+    def name(self) -> str:
+        """Return the name of the comparator."""
+        return "exact"
+
+    @property
+    def config(self) -> Optional[Dict[str, Any]]:
+        """Return configuration parameters for serialization.
+
+        Only includes non-default values to keep serialized output minimal.
+        """
+        cfg: Dict[str, Any] = {}
+        if not self.case_sensitive:
+            cfg["case_sensitive"] = False
+        return cfg if cfg else None
 
     def _compare(self, str1: Any, str2: Any) -> float:
         """Compare two values with exact string matching.
@@ -42,20 +80,22 @@ class ExactComparator(BaseComparator):
             str2: Second value
 
         Returns:
-            1.0 if the strings match exactly after normalization, 0.0 otherwise
+            1.0 if the strings match exactly, 0.0 otherwise
         """
         # Convert to strings if they aren't already
         str1 = str(str1)
         str2 = str(str2)
 
-        # Apply case normalization if needed
+        # Apply case folding if case-insensitive
         if not self.case_sensitive:
-            str1 = lowercase(str1)
-            str2 = lowercase(str2)
+            str1 = str1.casefold()
+            str2 = str2.casefold()
 
-        # Remove whitespace and punctuation
-        normalized1 = strip_punctuation_space(str1)
-        normalized2 = strip_punctuation_space(str2)
+        return 1.0 if str1 == str2 else 0.0
 
-        # Compare normalized strings
-        return 1.0 if normalized1 == normalized2 else 0.0
+    def __repr__(self) -> str:
+        """Detailed string representation."""
+        parts = [f"threshold={self.threshold}"]
+        if not self.case_sensitive:
+            parts.append("case_sensitive=False")
+        return f"ExactComparator({', '.join(parts)})"

--- a/tests/auto/test_risk_surface.py
+++ b/tests/auto/test_risk_surface.py
@@ -624,8 +624,9 @@ class TestFromPydantic:
         Edited = StructuredModel.model_from_json(config)
         gt = Edited.from_json({"name": "x", "note": "Hello World"})
         pred = Edited.from_json({"name": "x", "note": "hello, world"})
-        # ExactComparator normalizes case/punctuation: still a match.
-        assert gt.compare_with(pred)["field_scores"]["note"] == pytest.approx(1.0)
+        # ExactComparator (0.7.0+) is truly exact: no case/punctuation normalization.
+        # These strings differ, so score is 0.0.
+        assert gt.compare_with(pred)["field_scores"]["note"] == pytest.approx(0.0)
 
     def test_evaluate_and_from_pydantic_agree(self):
         """The facade and the constructor produce identical scores."""

--- a/tests/common/comparators/test_exact.py
+++ b/tests/common/comparators/test_exact.py
@@ -1,41 +1,59 @@
 """Tests for ExactComparator."""
 
-
 from stickler.comparators import ExactComparator
 
 
 class TestExactComparator:
-    """Test the ExactComparator."""
+    """Test the ExactComparator.
+
+    As of 0.7.0, ExactComparator is truly exact:
+    - Default is case_sensitive=True
+    - No punctuation/whitespace normalization
+    """
 
     def setup_method(self):
         """Set up test fixtures."""
+        # Default: case-sensitive, no normalization
         self.comparator = ExactComparator()
-        self.case_sensitive_comparator = ExactComparator(case_sensitive=True)
+        # Case-insensitive variant
+        self.case_insensitive = ExactComparator(case_sensitive=False)
 
     def test_exact_match(self):
         """Test that exact matches return 1.0."""
         assert self.comparator.compare("hello", "hello") == 1.0
         assert self.comparator.compare("123", "123") == 1.0
         assert self.comparator.compare("", "") == 1.0
+        assert self.comparator.compare("SHP-2024-001", "SHP-2024-001") == 1.0
 
-    def test_case_insensitive(self):
-        """Test that case is ignored by default."""
-        assert self.comparator.compare("Hello", "hello") == 1.0
-        assert self.comparator.compare("WORLD", "world") == 1.0
-        assert self.comparator.compare("Hello World", "hello world") == 1.0
+    def test_case_sensitive_by_default(self):
+        """Test that case matters by default (the #199 fix)."""
+        # Default is now case-sensitive
+        assert self.comparator.compare("Hello", "hello") == 0.0
+        assert self.comparator.compare("WORLD", "world") == 0.0
+        assert self.comparator.compare("SHP-2024-001", "shp-2024-001") == 0.0
 
-    def test_case_sensitive(self):
-        """Test that case-sensitive comparator respects case."""
-        assert self.case_sensitive_comparator.compare("hello", "hello") == 1.0
-        assert self.case_sensitive_comparator.compare("Hello", "hello") == 0.0
-        assert self.case_sensitive_comparator.compare("WORLD", "world") == 0.0
+    def test_case_insensitive_option(self):
+        """Test that case_sensitive=False uses casefold for matching."""
+        assert self.case_insensitive.compare("Hello", "hello") == 1.0
+        assert self.case_insensitive.compare("WORLD", "world") == 1.0
+        assert self.case_insensitive.compare("Hello World", "hello world") == 1.0
+        # casefold handles German ß correctly
+        assert self.case_insensitive.compare("STRASSE", "straße") == 1.0
 
-    def test_punctuation_and_spaces(self):
-        """Test that punctuation and spaces are ignored."""
-        assert self.comparator.compare("hello, world", "hello world") == 1.0
-        assert self.comparator.compare("hello-world", "hello world") == 1.0
-        assert self.comparator.compare("hello.world", "hello world") == 1.0
-        assert self.comparator.compare("hello  world", "hello world") == 1.0
+    def test_no_punctuation_normalization(self):
+        """Test that punctuation is NOT stripped (the #199 fix).
+
+        This is the key behavior change: "SHP-2024-001" must NOT match
+        "shp 2024 001" because they are different strings.
+        """
+        # These should NOT match - punctuation matters
+        assert self.comparator.compare("hello, world", "hello world") == 0.0
+        assert self.comparator.compare("hello-world", "hello world") == 0.0
+        assert self.comparator.compare("hello.world", "hello world") == 0.0
+        assert self.comparator.compare("hello  world", "hello world") == 0.0
+        # The #199 bug case
+        assert self.comparator.compare("SHP-2024-001", "SHP 2024 001") == 0.0
+        assert self.comparator.compare("ID-123", "ID 123") == 0.0
 
     def test_non_matching(self):
         """Test that non-matching strings return 0.0."""
@@ -58,21 +76,94 @@ class TestExactComparator:
     def test_binary_compare_match(self):
         """Test that binary_compare returns (1, 0) for match."""
         assert self.comparator.binary_compare("hello", "hello") == (1, 0)
-        assert self.comparator.binary_compare("Hello", "hello") == (1, 0)
+        # Case mismatch is now a non-match by default
+        assert self.comparator.binary_compare("Hello", "hello") == (0, 1)
+        # Case-insensitive comparator matches
+        assert self.case_insensitive.binary_compare("Hello", "hello") == (1, 0)
 
     def test_binary_compare_no_match(self):
         """Test that binary_compare returns (0, 1) for no match."""
         assert self.comparator.binary_compare("hello", "world") == (0, 1)
-        assert self.case_sensitive_comparator.binary_compare("Hello", "hello") == (0, 1)
+        assert self.comparator.binary_compare("Hello", "hello") == (0, 1)
 
     def test_custom_threshold(self):
         """Test that the threshold is applied correctly.
 
-        This is a silly test for ExactComparator since it only returns 0.0 or 1.0,
-        but it demonstrates how thresholds work with binary_compare.
+        ExactComparator only returns 0.0 or 1.0, so thresholds below 1.0
+        effectively treat any non-null pair as a match in binary_compare.
         """
-        # Create a comparator with a threshold of 0.5, it shouldn't matter
-        # since ExactComparator only returns 0.0 or 1.0
         comparator = ExactComparator(threshold=0.5)
         assert comparator.binary_compare("hello", "hello") == (1, 0)
         assert comparator.binary_compare("hello", "world") == (0, 1)
+
+    def test_config_property(self):
+        """Test that config only includes non-default values."""
+        # Default config is None (all defaults)
+        assert ExactComparator().config is None
+        assert ExactComparator(case_sensitive=True).config is None
+
+        # Non-default config is serialized
+        assert ExactComparator(case_sensitive=False).config == {"case_sensitive": False}
+
+    def test_name_property(self):
+        """Test the name property."""
+        assert self.comparator.name == "exact"
+
+    def test_repr(self):
+        """Test string representation."""
+        assert "threshold=1.0" in repr(self.comparator)
+        assert "case_sensitive=False" not in repr(self.comparator)
+        assert "case_sensitive=False" in repr(self.case_insensitive)
+
+
+class TestExactComparatorIdentifiers:
+    """Test ExactComparator with real-world identifier patterns.
+
+    This class specifically tests the #199 fix: identifiers must match exactly.
+    """
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.comparator = ExactComparator()
+
+    def test_invoice_ids(self):
+        """Invoice IDs must match exactly."""
+        assert self.comparator.compare("INV-2024-001", "INV-2024-001") == 1.0
+        assert self.comparator.compare("INV-2024-001", "inv-2024-001") == 0.0
+        assert self.comparator.compare("INV-2024-001", "INV 2024 001") == 0.0
+
+    def test_uuids(self):
+        """UUIDs must match exactly."""
+        uuid = "550e8400-e29b-41d4-a716-446655440000"
+        assert self.comparator.compare(uuid, uuid) == 1.0
+        assert self.comparator.compare(uuid, uuid.upper()) == 0.0
+        assert self.comparator.compare(uuid, uuid.replace("-", "")) == 0.0
+
+    def test_skus(self):
+        """SKUs must match exactly."""
+        assert self.comparator.compare("SKU-ABC-123", "SKU-ABC-123") == 1.0
+        assert self.comparator.compare("SKU-ABC-123", "sku-abc-123") == 0.0
+        assert self.comparator.compare("SKU-ABC-123", "SKU ABC 123") == 0.0
+
+    def test_phone_numbers(self):
+        """Phone numbers: different formats are different strings.
+
+        Note: For phone number semantic equivalence, use a specialized
+        comparator or pre-normalize to E.164 format.
+        """
+        assert self.comparator.compare("555-123-4567", "555-123-4567") == 1.0
+        assert self.comparator.compare("555-123-4567", "(555) 123-4567") == 0.0
+        assert self.comparator.compare("555-123-4567", "5551234567") == 0.0
+
+    def test_emails(self):
+        """Emails: ExactComparator is case-sensitive by default.
+
+        Note: For RFC-compliant email matching (domain case-insensitive),
+        use case_sensitive=False or a specialized email comparator.
+        """
+        assert self.comparator.compare("user@example.com", "user@example.com") == 1.0
+        assert self.comparator.compare("user@example.com", "USER@EXAMPLE.COM") == 0.0
+
+        # Case-insensitive option for emails
+        ci = ExactComparator(case_sensitive=False)
+        assert ci.compare("user@example.com", "USER@EXAMPLE.COM") == 1.0


### PR DESCRIPTION
  Add normalize parameter to ExactComparator to support strict identifier
  matching. When normalize=False, comparison preserves case and punctuation,
  so "SHP-2024-001" no longer matches "shp 2024 001".

  Breaking Change

  Inference now selects ExactComparator(normalize=False) for identifier fields
  (id, uuid, sku, code, ref, email, url, phone). Fields whose names contain
  these tokens will use strict matching.

  Explicit ExactComparator() usage is unchanged (normalize=True by default for
  backward compatibility).

  Changes

  - Add normalize: bool = True parameter to ExactComparator
  - When normalize=False, comparison is truly exact (case and punctuation
  matter)
  - Update inference rules to use normalize=False for
  identifier/email/url/phone fields
  - Add config property for serialization
  - Add name property following other comparator patterns
  - Add comprehensive tests for the new behavior

  Testing

  - Added unit tests in tests/common/comparators/test_exact.py
  - Added integration test in tests/auto/test_evaluate.py verifying inference
  selects strict matching for identifier fields

 With this change you can use, modify, copy,
 and redistribute this contribution, under the terms of your choice