### PR TITLE
fix(model): ComparableField follows Pydantic optionality semantics (#…

### DIFF
--- a/src/stickler/structured_object_evaluator/models/comparable_field.py
+++ b/src/stickler/structured_object_evaluator/models/comparable_field.py
@@ -8,16 +8,20 @@ import warnings
 from typing import Any, Dict, Optional
 
 from pydantic import Field
+from pydantic.fields import PydanticUndefined
 
 from stickler.comparators.base import BaseComparator
 from stickler.comparators.levenshtein import LevenshteinComparator
+
+# Sentinel to detect "no default provided" vs "default=None"
+_UNSET = PydanticUndefined
 
 
 def ComparableField(
     comparator: Optional[BaseComparator] = None,
     threshold: float = 0.5,
     weight: float = 1.0,
-    default: Any = None,
+    default: Any = _UNSET,
     aggregate: bool = False,
     clip_under_threshold: bool = True,
     # Pydantic Field parameters (all optional, just like Field)
@@ -35,7 +39,8 @@ def ComparableField(
         comparator: Comparator to use for field comparison (default: LevenshteinComparator)
         threshold: Minimum similarity score to consider a match (default: 0.5)
         weight: Weight of this field in overall score calculation (default: 1.0)
-        default: Default value for the field (default: None)
+        default: Default value for the field. If not provided, the field is required.
+            Use ``default=None`` explicitly for optional fields with None default.
         aggregate: DEPRECATED - This parameter is deprecated and will be removed in a future version.
                   Use the new universal 'aggregate' field in compare_with() output instead.
         clip_under_threshold: Whether to zero out scores below threshold (default: True)
@@ -49,8 +54,11 @@ def ComparableField(
 
     Example:
         class MyModel(StructuredModel):
-            # Basic usage (no alias):
+            # Required field (no default):
             name: str = ComparableField(threshold=0.8)
+
+            # Optional field (explicit default=None):
+            nickname: Optional[str] = ComparableField(threshold=0.7, default=None)
 
             # With alias (new feature):
             email: str = ComparableField(
@@ -59,6 +67,12 @@ def ComparableField(
                 description="User's email",
                 examples=["user@example.com"]
             )
+
+    .. versionchanged:: 0.7.0
+        Fields without an explicit ``default=`` are now required, following
+        standard Pydantic semantics. Previously all fields defaulted to None.
+        To migrate existing code, add ``default=None`` to fields that should
+        be optional.
     """
     # Issue deprecation warning if aggregate=True is used
     if aggregate:
@@ -135,15 +149,22 @@ def ComparableField(
         k: v for k, v in field_kwargs.items() if k != "json_schema_extra"
     }
 
-    # Create the Field
-    field = Field(
-        default=default,
-        alias=alias,
-        description=description,
-        examples=examples,
-        json_schema_extra=final_json_schema_extra,
+    # Build Field kwargs, only including default if explicitly provided
+    field_kwargs_final = {
+        "alias": alias,
+        "description": description,
+        "examples": examples,
+        "json_schema_extra": final_json_schema_extra,
         **clean_field_kwargs,
-    )
+    }
+
+    # Only pass default if user explicitly provided one
+    # This is the key fix: PydanticUndefined means "required"
+    if default is not _UNSET:
+        field_kwargs_final["default"] = default
+
+    # Create the Field
+    field = Field(**field_kwargs_final)
 
     return field
 

--- a/tests/structured_object_evaluator/test_bbox_map.py
+++ b/tests/structured_object_evaluator/test_bbox_map.py
@@ -53,7 +53,7 @@ class DocumentField(StructuredModel):
         comparator=LevenshteinComparator(), threshold=0.9
     )
     total_amount: Optional[float] = ComparableField(
-        comparator=NumericComparator(), threshold=0.95
+        comparator=NumericComparator(), threshold=0.95, default=None
     )
 
 

--- a/tests/structured_object_evaluator/test_binary_classification.py
+++ b/tests/structured_object_evaluator/test_binary_classification.py
@@ -24,19 +24,19 @@ class SimpleModel(StructuredModel):
     high_threshold_field: Optional[str] = ComparableField(
         comparator=LevenshteinComparator(),
         threshold=0.9,  # High threshold requires close match
-        weight=1.0,
+        weight=1.0, default=None
     )
 
     # Low threshold field - even partial matches count
     low_threshold_field: Optional[str] = ComparableField(
         comparator=LevenshteinComparator(),
         threshold=0.5,  # Low threshold allows partial matches
-        weight=1.0,
+        weight=1.0, default=None
     )
 
     # Regular field - moderate threshold
     regular_field: Optional[str] = ComparableField(
-        comparator=LevenshteinComparator(), threshold=0.7, weight=1.0
+        comparator=LevenshteinComparator(), threshold=0.7, weight=1.0, default=None
     )
 
 

--- a/tests/structured_object_evaluator/test_classification_logic.py
+++ b/tests/structured_object_evaluator/test_classification_logic.py
@@ -20,13 +20,13 @@ class SimpleModel(StructuredModel):
     """Simple model with basic field types for testing classification logic."""
 
     name: Optional[str] = ComparableField(
-        comparator=LevenshteinComparator(), threshold=0.7, weight=1.0
+        comparator=LevenshteinComparator(), threshold=0.7, weight=1.0, default=None
     )
     count: Optional[int] = ComparableField(
-        comparator=LevenshteinComparator(), threshold=0.9, weight=1.0
+        comparator=LevenshteinComparator(), threshold=0.9, weight=1.0, default=None
     )
     description: Optional[str] = ComparableField(
-        comparator=LevenshteinComparator(), threshold=0.7, weight=1.0
+        comparator=LevenshteinComparator(), threshold=0.7, weight=1.0, default=None
     )
 
 
@@ -34,16 +34,16 @@ class NestedModel(StructuredModel):
     """Model with a nested structured model field."""
 
     id: Optional[str] = ComparableField(
-        comparator=LevenshteinComparator(), threshold=0.9, weight=1.0
+        comparator=LevenshteinComparator(), threshold=0.9, weight=1.0, default=None
     )
-    details: Optional[SimpleModel] = ComparableField(weight=1.0)
+    details: Optional[SimpleModel] = ComparableField(weight=1.0, default=None)
 
 
 class ListModel(StructuredModel):
     """Model with list fields for testing classification logic."""
 
     id: Optional[str] = ComparableField(
-        comparator=LevenshteinComparator(), threshold=0.9, weight=1.0
+        comparator=LevenshteinComparator(), threshold=0.9, weight=1.0, default=None
     )
     tags: Optional[List[str]] = ComparableField(
         comparator=LevenshteinComparator(), threshold=0.7, weight=1.0

--- a/tests/structured_object_evaluator/test_comparable_field_none_default.py
+++ b/tests/structured_object_evaluator/test_comparable_field_none_default.py
@@ -15,8 +15,8 @@ from stickler.structured_object_evaluator.models.structured_model import Structu
 
 
 class TwoFieldModel(StructuredModel):
-    code: Optional[str] = ComparableField(weight=1.0)
-    description: Optional[str] = ComparableField(weight=1.0)
+    code: Optional[str] = ComparableField(weight=1.0, default=None)
+    description: Optional[str] = ComparableField(weight=1.0, default=None)
 
 
 def test_first_field_none_stays_none():

--- a/tests/structured_object_evaluator/test_comparable_field_optionality.py
+++ b/tests/structured_object_evaluator/test_comparable_field_optionality.py
@@ -1,0 +1,188 @@
+"""Tests for ComparableField optionality following Pydantic semantics (#189).
+
+This test verifies that:
+1. Fields without default= are required
+2. Fields with default=None are optional
+3. The JSON schema correctly reflects required vs optional
+4. Model validation enforces required fields
+"""
+
+from typing import Optional
+
+import pytest
+from pydantic import ValidationError
+
+from stickler import ComparableField, StructuredModel
+
+
+class TestComparableFieldOptionality:
+    """Test that ComparableField follows Pydantic optionality semantics."""
+
+    def test_field_without_default_is_required(self):
+        """A field with no default should be required."""
+
+        class Model(StructuredModel):
+            name: str = ComparableField(threshold=0.8)
+
+        # Should raise ValidationError when required field is missing
+        with pytest.raises(ValidationError) as exc_info:
+            Model()
+
+        # Verify the error mentions the missing field
+        assert "name" in str(exc_info.value)
+
+    def test_field_with_default_none_is_optional(self):
+        """A field with default=None should be optional."""
+
+        class Model(StructuredModel):
+            name: Optional[str] = ComparableField(threshold=0.8, default=None)
+
+        # Should work without providing the field
+        m = Model()
+        assert m.name is None
+
+    def test_field_with_explicit_default_value(self):
+        """A field with a non-None default should use that default."""
+
+        class Model(StructuredModel):
+            count: int = ComparableField(threshold=1.0, default=0)
+
+        m = Model()
+        assert m.count == 0
+
+    def test_json_schema_required_list(self):
+        """JSON schema should correctly list required fields."""
+
+        class Model(StructuredModel):
+            required_name: str = ComparableField(threshold=0.8)
+            optional_note: Optional[str] = ComparableField(threshold=0.6, default=None)
+            required_id: str = ComparableField(threshold=1.0)
+
+        schema = Model.model_json_schema()
+
+        # Required fields should be in the required list
+        assert "required_name" in schema["required"]
+        assert "required_id" in schema["required"]
+
+        # Optional fields should NOT be in the required list
+        assert "optional_note" not in schema["required"]
+
+    def test_json_schema_type_rendering(self):
+        """JSON schema types should reflect nullability correctly."""
+
+        class Model(StructuredModel):
+            required_str: str = ComparableField()
+            optional_str: Optional[str] = ComparableField(default=None)
+
+        schema = Model.model_json_schema()
+
+        # Required string should have type "string"
+        assert schema["properties"]["required_str"]["type"] == "string"
+
+        # Optional string should be nullable
+        # (Pydantic renders Optional[str] as anyOf or type: ["string", "null"])
+        opt_schema = schema["properties"]["optional_str"]
+        is_nullable = (
+            opt_schema.get("type") == ["string", "null"]
+            or "anyOf" in opt_schema
+            or opt_schema.get("type") is None  # anyOf without type
+        )
+        assert is_nullable, f"Optional field should be nullable, got: {opt_schema}"
+
+    def test_mixed_required_optional_model(self):
+        """A model with both required and optional fields should work correctly."""
+
+        class Invoice(StructuredModel):
+            invoice_id: str = ComparableField(threshold=1.0)
+            amount: float = ComparableField(threshold=0.95)
+            note: Optional[str] = ComparableField(threshold=0.7, default=None)
+
+        # Valid with all fields
+        inv1 = Invoice(invoice_id="INV-001", amount=100.0, note="Paid")
+        assert inv1.invoice_id == "INV-001"
+        assert inv1.amount == 100.0
+        assert inv1.note == "Paid"
+
+        # Valid with optional field omitted
+        inv2 = Invoice(invoice_id="INV-002", amount=200.0)
+        assert inv2.invoice_id == "INV-002"
+        assert inv2.amount == 200.0
+        assert inv2.note is None
+
+        # Invalid: missing required field
+        with pytest.raises(ValidationError):
+            Invoice(invoice_id="INV-003")  # missing amount
+
+    def test_comparison_with_required_fields(self):
+        """Comparison should work correctly with required fields."""
+
+        class Model(StructuredModel):
+            name: str = ComparableField(threshold=0.8)
+
+        gt = Model(name="Alice")
+        pred = Model(name="Alice")
+
+        result = gt.compare_with(pred)
+        assert result["overall_score"] == pytest.approx(1.0)
+
+    def test_comparison_with_optional_none_values(self):
+        """Comparison should handle optional None values correctly."""
+
+        class Model(StructuredModel):
+            name: str = ComparableField(threshold=0.8)
+            nickname: Optional[str] = ComparableField(threshold=0.7, default=None)
+
+        gt = Model(name="Alice", nickname=None)
+        pred = Model(name="Alice", nickname=None)
+
+        result = gt.compare_with(pred, include_confusion_matrix=True)
+        assert result["overall_score"] == pytest.approx(1.0)
+
+        # Both None should be TN, not causing errors
+        nickname_cm = result["confusion_matrix"]["fields"]["nickname"]["overall"]
+        assert nickname_cm["tn"] == 1
+
+    def test_ellipsis_default_is_required(self):
+        """Using default=... (Ellipsis) should also create a required field."""
+
+        class Model(StructuredModel):
+            name: str = ComparableField(threshold=0.8, default=...)
+
+        with pytest.raises(ValidationError):
+            Model()
+
+        # But providing it should work
+        m = Model(name="test")
+        assert m.name == "test"
+
+
+class TestBackwardCompatibilityMigration:
+    """Tests to help users migrate from the old behavior.
+
+    Before the fix, `name: str = ComparableField()` was optional because
+    ComparableField always passed default=None to Field(). After the fix,
+    it's required. Users who want optional should add `default=None`.
+    """
+
+    def test_old_pattern_now_required(self):
+        """The old pattern without default= is now required."""
+
+        class OldStyleModel(StructuredModel):
+            # This used to be optional (silently defaulted to None)
+            # Now it's required as Pydantic semantics dictate
+            name: str = ComparableField(threshold=0.8)
+
+        # This would have worked before but should fail now
+        with pytest.raises(ValidationError):
+            OldStyleModel()
+
+    def test_migration_pattern(self):
+        """Show how to migrate to make a field optional."""
+
+        class MigratedModel(StructuredModel):
+            # To keep the old behavior, explicitly add default=None
+            name: Optional[str] = ComparableField(threshold=0.8, default=None)
+
+        # Now it works without providing the field
+        m = MigratedModel()
+        assert m.name is None

--- a/tests/structured_object_evaluator/test_confusion_matrix_definitions.py
+++ b/tests/structured_object_evaluator/test_confusion_matrix_definitions.py
@@ -35,7 +35,7 @@ class SimpleModel(StructuredModel):
     """Simple model with basic field types for testing confusion matrix metrics."""
 
     name: Optional[str] = ComparableField(
-        comparator=LevenshteinComparator(), threshold=0.7, weight=1.0
+        comparator=LevenshteinComparator(), threshold=0.7, weight=1.0, default=None
     )
     count: Optional[int] = ComparableField(
         default=None, comparator=ExactComparator(), threshold=1.0, weight=1.0
@@ -51,7 +51,7 @@ class NestedModel(StructuredModel):
     id: str = ComparableField(
         comparator=LevenshteinComparator(), threshold=0.9, weight=1.0
     )
-    details: Optional[SimpleModel] = ComparableField(threshold=0.7, weight=1.0)
+    details: Optional[SimpleModel] = ComparableField(threshold=0.7, weight=1.0, default=None)
 
 
 class ListModel(StructuredModel):

--- a/tests/structured_object_evaluator/test_confusion_matrix_metrics.py
+++ b/tests/structured_object_evaluator/test_confusion_matrix_metrics.py
@@ -23,10 +23,10 @@ class SimpleModel(StructuredModel):
         comparator=LevenshteinComparator(), threshold=0.7, weight=1.0
     )
     count: Optional[int] = ComparableField(
-        comparator=LevenshteinComparator(), threshold=0.9, weight=1.0
+        comparator=LevenshteinComparator(), threshold=0.9, weight=1.0, default=None
     )
     description: Optional[str] = ComparableField(
-        comparator=LevenshteinComparator(), threshold=0.7, weight=1.0
+        comparator=LevenshteinComparator(), threshold=0.7, weight=1.0, default=None
     )
 
 
@@ -38,7 +38,7 @@ class NestedModel(StructuredModel):
     id: str = ComparableField(
         comparator=LevenshteinComparator(), threshold=0.9, weight=1.0
     )
-    details: Optional[SimpleModel] = ComparableField(threshold=0.7, weight=1.0)
+    details: Optional[SimpleModel] = ComparableField(threshold=0.7, weight=1.0, default=None)
 
 
 class ListModel(StructuredModel):

--- a/tests/structured_object_evaluator/test_correct_classification_definitions.py
+++ b/tests/structured_object_evaluator/test_correct_classification_definitions.py
@@ -27,10 +27,10 @@ class SimpleModel(StructuredModel):
         comparator=LevenshteinComparator(), threshold=0.7, weight=1.0
     )
     count: Optional[int] = ComparableField(
-        comparator=LevenshteinComparator(), threshold=0.9, weight=1.0
+        comparator=LevenshteinComparator(), threshold=0.9, weight=1.0, default=None
     )
     description: Optional[str] = ComparableField(
-        comparator=LevenshteinComparator(), threshold=0.7, weight=1.0
+        comparator=LevenshteinComparator(), threshold=0.7, weight=1.0, default=None
     )
 
 

--- a/tests/structured_object_evaluator/test_deep_nesting_6_levels.py
+++ b/tests/structured_object_evaluator/test_deep_nesting_6_levels.py
@@ -41,7 +41,7 @@ class Subtask(StructuredModel):
         comparator=LevenshteinComparator(), threshold=0.8, weight=1.5
     )
     description: Optional[str] = ComparableField(
-        comparator=LevenshteinComparator(), threshold=0.7, weight=1.0
+        comparator=LevenshteinComparator(), threshold=0.7, weight=1.0, default=None
     )
     completed: bool = ComparableField(
         comparator=ExactComparator(), threshold=1.0, weight=1.0
@@ -70,7 +70,7 @@ class Task(StructuredModel):
         comparator=ExactComparator(), threshold=1.0, weight=1.0
     )
     subtasks: List[Subtask] = ComparableField(weight=1.0)
-    main_subtask: Optional[Subtask] = ComparableField(threshold=0.8, weight=1.0)
+    main_subtask: Optional[Subtask] = ComparableField(threshold=0.8, weight=1.0, default=None)
 
 
 # Level 4: Project
@@ -92,7 +92,7 @@ class Project(StructuredModel):
         comparator=LevenshteinComparator(), threshold=0.9, weight=1.0
     )
     tasks: List[Task] = ComparableField(weight=1.5)
-    critical_task: Optional[Task] = ComparableField(threshold=0.8, weight=2.0)
+    critical_task: Optional[Task] = ComparableField(threshold=0.8, weight=2.0, default=None)
 
 
 # Level 3: Team
@@ -112,7 +112,7 @@ class Team(StructuredModel):
         comparator=LevenshteinComparator(), threshold=0.8, weight=1.0
     )
     projects: List[Project] = ComparableField(weight=2.0)
-    flagship_project: Optional[Project] = ComparableField(threshold=0.8, weight=2.0)
+    flagship_project: Optional[Project] = ComparableField(threshold=0.8, weight=2.0, default=None)
 
 
 # Level 2: Department
@@ -134,7 +134,7 @@ class Department(StructuredModel):
         comparator=ExactComparator(), threshold=0.95, weight=2.0
     )
     teams: List[Team] = ComparableField(weight=2.0)
-    primary_team: Optional[Team] = ComparableField(threshold=0.8, weight=2.0)
+    primary_team: Optional[Team] = ComparableField(threshold=0.8, weight=2.0, default=None)
 
 
 # Level 1: Company (top level)
@@ -156,7 +156,7 @@ class Company(StructuredModel):
         comparator=LevenshteinComparator(), threshold=0.8, weight=1.0
     )
     departments: List[Department] = ComparableField(weight=2.0)
-    main_department: Optional[Department] = ComparableField(threshold=0.8, weight=2.0)
+    main_department: Optional[Department] = ComparableField(threshold=0.8, weight=2.0, default=None)
 
 
 class TestDeepNesting6Levels:

--- a/tests/structured_object_evaluator/test_double_nested_objects.py
+++ b/tests/structured_object_evaluator/test_double_nested_objects.py
@@ -23,7 +23,7 @@ class ContactInfo(StructuredModel):
 
     email: str = ComparableField(comparator=LevenshteinComparator(), threshold=0.9)
     phone: Optional[str] = ComparableField(
-        comparator=LevenshteinComparator(), threshold=0.9
+        comparator=LevenshteinComparator(), threshold=0.9, default=None
     )
 
 
@@ -36,9 +36,9 @@ class Address(StructuredModel):
     city: str = ComparableField(comparator=LevenshteinComparator(), threshold=0.9)
     state: str = ComparableField(comparator=LevenshteinComparator(), threshold=0.9)
     zip_code: Optional[str] = ComparableField(
-        comparator=LevenshteinComparator(), threshold=0.9
+        comparator=LevenshteinComparator(), threshold=0.9, default=None
     )
-    contact_info: Optional[ContactInfo] = ComparableField()  # Double-nested field
+    contact_info: Optional[ContactInfo] = ComparableField(default=None)  # Double-nested field
 
 
 class Person(StructuredModel):

--- a/tests/structured_object_evaluator/test_edge_cases.py
+++ b/tests/structured_object_evaluator/test_edge_cases.py
@@ -20,7 +20,7 @@ class Person(StructuredModel):
     )
     age: Optional[int] = Field(None)
     email: Optional[str] = ComparableField(
-        comparator=LevenshteinComparator(), threshold=0.9, weight=1.0
+        comparator=LevenshteinComparator(), threshold=0.9, weight=1.0, default=None
     )
 
 

--- a/tests/structured_object_evaluator/test_field_comparison_collection.py
+++ b/tests/structured_object_evaluator/test_field_comparison_collection.py
@@ -34,7 +34,7 @@ class SimpleModel(StructuredModel):
         comparator=ExactComparator(), threshold=1.0, weight=1.0
     )
     score: Optional[float] = ComparableField(
-        comparator=NumericComparator(absolute_tolerance=0.02), threshold=1.0, weight=1.5
+        comparator=NumericComparator(absolute_tolerance=0.02), threshold=1.0, weight=1.5, default=None
     )
 
 

--- a/tests/structured_object_evaluator/test_model_schema.py
+++ b/tests/structured_object_evaluator/test_model_schema.py
@@ -35,7 +35,7 @@ class ComplexTestModel(StructuredModel):
     )
 
     description: Optional[str] = ComparableField(
-        comparator=LevenshteinComparator(), threshold=0.5, weight=0.5
+        comparator=LevenshteinComparator(), threshold=0.5, weight=0.5, default=None
     )
 
     tags: List[str] = ComparableField(

--- a/tests/structured_object_evaluator/test_nesting_performance_diagnostic.py
+++ b/tests/structured_object_evaluator/test_nesting_performance_diagnostic.py
@@ -43,7 +43,7 @@ class Container(StructuredModel):
         comparator=LevenshteinComparator(), threshold=0.8, weight=1.0
     )
     items: List[SimpleItem] = ComparableField(weight=1.0)
-    main_item: Optional[SimpleItem] = ComparableField(threshold=0.8, weight=1.0)
+    main_item: Optional[SimpleItem] = ComparableField(threshold=0.8, weight=1.0, default=None)
 
 
 # Level 3: Contains Level 2
@@ -58,7 +58,7 @@ class Group(StructuredModel):
         comparator=LevenshteinComparator(), threshold=0.8, weight=1.0
     )
     containers: List[Container] = ComparableField(weight=1.0)
-    primary_container: Optional[Container] = ComparableField(threshold=0.8, weight=1.0)
+    primary_container: Optional[Container] = ComparableField(threshold=0.8, weight=1.0, default=None)
 
 
 # Level 4: Contains Level 3
@@ -73,7 +73,7 @@ class Department(StructuredModel):
         comparator=LevenshteinComparator(), threshold=0.8, weight=1.0
     )
     groups: List[Group] = ComparableField(weight=1.0)
-    main_group: Optional[Group] = ComparableField(threshold=0.8, weight=1.0)
+    main_group: Optional[Group] = ComparableField(threshold=0.8, weight=1.0, default=None)
 
 
 def create_simple_item(base_id: int, variation: str = "base") -> SimpleItem:

--- a/tests/structured_object_evaluator/test_non_match_documentation.py
+++ b/tests/structured_object_evaluator/test_non_match_documentation.py
@@ -25,7 +25,7 @@ class Address(StructuredModel):
     city: str = ComparableField(comparator=LevenshteinComparator(), threshold=0.9)
     state: str = ComparableField(comparator=LevenshteinComparator(), threshold=0.9)
     zip_code: Optional[str] = ComparableField(
-        comparator=LevenshteinComparator(), threshold=0.9
+        comparator=LevenshteinComparator(), threshold=0.9, default=None
     )
 
 

--- a/tests/structured_object_evaluator/test_none_handling_edge_cases.py
+++ b/tests/structured_object_evaluator/test_none_handling_edge_cases.py
@@ -31,7 +31,7 @@ class Document(StructuredModel):
     )
     transactions: Optional[List[Transaction]] = ComparableField(weight=1.0)
     total_amount: Optional[float] = ComparableField(
-        comparator=LevenshteinComparator(), threshold=0.9, weight=1.0
+        comparator=LevenshteinComparator(), threshold=0.9, weight=1.0, default=None
     )
 
 

--- a/tests/structured_object_evaluator/test_phase1_functionality.py
+++ b/tests/structured_object_evaluator/test_phase1_functionality.py
@@ -22,7 +22,7 @@ class Phase1TestModel(StructuredModel):
     age: Optional[int] = ComparableField(
         comparator=ExactComparator(),
         threshold=1.0,
-        weight=0.5,
+        weight=0.5, default=None
     )
 
     tags: Optional[List[str]] = ComparableField(

--- a/tests/structured_object_evaluator/test_publication_record_nested_metrics.py
+++ b/tests/structured_object_evaluator/test_publication_record_nested_metrics.py
@@ -18,10 +18,10 @@ from stickler.structured_object_evaluator.models.structured_model import Structu
 # Define the models for the test
 class Person(StructuredModel):
     Type: Optional[str] = ComparableField(
-        comparator=ExactComparator(), threshold=1.0, weight=1.0
+        comparator=ExactComparator(), threshold=1.0, weight=1.0, default=None
     )
     Name: Optional[str] = ComparableField(
-        comparator=ExactComparator(), threshold=1.0, weight=1.0
+        comparator=ExactComparator(), threshold=1.0, weight=1.0, default=None
     )
 
     match_threshold = 0.8
@@ -29,13 +29,13 @@ class Person(StructuredModel):
 
 class BookInfo(StructuredModel):
     pages: Optional[str] = ComparableField(
-        comparator=ExactComparator(), threshold=1.0, weight=1.0
+        comparator=ExactComparator(), threshold=1.0, weight=1.0, default=None
     )
     author: Optional[str] = ComparableField(
-        comparator=ExactComparator(), threshold=1.0, weight=1.0
+        comparator=ExactComparator(), threshold=1.0, weight=1.0, default=None
     )
     weight: Optional[str] = ComparableField(
-        comparator=ExactComparator(), threshold=1.0, weight=1.0
+        comparator=ExactComparator(), threshold=1.0, weight=1.0, default=None
     )
 
     match_threshold = 0.8
@@ -43,13 +43,13 @@ class BookInfo(StructuredModel):
 
 class Reference(StructuredModel):
     Volume: Optional[str] = ComparableField(
-        comparator=ExactComparator(), threshold=1.0, weight=1.0
+        comparator=ExactComparator(), threshold=1.0, weight=1.0, default=None
     )
     Page: Optional[str] = ComparableField(
-        comparator=ExactComparator(), threshold=1.0, weight=1.0
+        comparator=ExactComparator(), threshold=1.0, weight=1.0, default=None
     )
     Publication: Optional[str] = ComparableField(
-        comparator=ExactComparator(), threshold=1.0, weight=1.0
+        comparator=ExactComparator(), threshold=1.0, weight=1.0, default=None
     )
 
     match_threshold = 0.8
@@ -57,7 +57,7 @@ class Reference(StructuredModel):
 
 class PublicationRecord(StructuredModel):
     record_id: Optional[str] = ComparableField(
-        comparator=ExactComparator(), threshold=1.0, weight=1.0
+        comparator=ExactComparator(), threshold=1.0, weight=1.0, default=None
     )
 
     people: Optional[List[Person]] = ComparableField(weight=1.0)
@@ -67,27 +67,27 @@ class PublicationRecord(StructuredModel):
     references: Optional[List[Reference]] = ComparableField(weight=1.0)
 
     State: Optional[str] = ComparableField(
-        comparator=ExactComparator(), threshold=1.0, weight=1.0
+        comparator=ExactComparator(), threshold=1.0, weight=1.0, default=None
     )
 
     County: Optional[str] = ComparableField(
-        comparator=ExactComparator(), threshold=1.0, weight=1.0
+        comparator=ExactComparator(), threshold=1.0, weight=1.0, default=None
     )
 
     Edition: Optional[str] = ComparableField(
-        comparator=ExactComparator(), threshold=1.0, weight=1.0
+        comparator=ExactComparator(), threshold=1.0, weight=1.0, default=None
     )
 
     Title: Optional[str] = ComparableField(
-        comparator=ExactComparator(), threshold=1.0, weight=1.0
+        comparator=ExactComparator(), threshold=1.0, weight=1.0, default=None
     )
 
     Date: Optional[str] = ComparableField(
-        comparator=ExactComparator(), threshold=1.0, weight=1.0
+        comparator=ExactComparator(), threshold=1.0, weight=1.0, default=None
     )
 
     Price: Optional[str] = ComparableField(
-        comparator=ExactComparator(), threshold=1.0, weight=1.0
+        comparator=ExactComparator(), threshold=1.0, weight=1.0, default=None
     )
 
 

--- a/tests/structured_object_evaluator/test_structured_model_schema.py
+++ b/tests/structured_object_evaluator/test_structured_model_schema.py
@@ -32,7 +32,7 @@ class ComplexTestModel(StructuredModel):
     )
 
     description: Optional[str] = ComparableField(
-        comparator=LevenshteinComparator(), threshold=0.5, weight=0.5
+        comparator=LevenshteinComparator(), threshold=0.5, weight=0.5, default=None
     )
 
     tags: List[str] = ComparableField(

--- a/tests/structured_object_evaluator/test_structured_model_scoring.py
+++ b/tests/structured_object_evaluator/test_structured_model_scoring.py
@@ -18,7 +18,7 @@ class SimpleModel(StructuredModel):
     """Simple model to test basic scoring."""
 
     text: Optional[str] = ComparableField(
-        comparator=LevenshteinComparator(), threshold=0.7, weight=1.0
+        comparator=LevenshteinComparator(), threshold=0.7, weight=1.0, default=None
     )
 
 

--- a/tests/structured_object_evaluator/test_structured_model_simple.py
+++ b/tests/structured_object_evaluator/test_structured_model_simple.py
@@ -22,7 +22,7 @@ class SimpleTestModel(StructuredModel):
     age: Optional[int] = ComparableField(
         comparator=ExactComparator(),
         threshold=1.0,
-        weight=0.5,
+        weight=0.5, default=None
     )
 
 

--- a/tests/structured_object_evaluator/test_unordered_list_scoring.py
+++ b/tests/structured_object_evaluator/test_unordered_list_scoring.py
@@ -18,7 +18,7 @@ class SimpleItem(StructuredModel):
     name: str = ComparableField(comparator=LevenshteinComparator(), threshold=0.7)
 
     value: Optional[str] = ComparableField(
-        comparator=LevenshteinComparator(), threshold=0.7
+        comparator=LevenshteinComparator(), threshold=0.7, default=None
     )
 
 


### PR DESCRIPTION
  Issue #, if available: #189

  Description of changes:

  Summary

  Fix ComparableField to follow Pydantic optionality semantics. Fields without
  an explicit default= parameter are now required, matching standard Pydantic
  behavior.

  Breaking Change

  ComparableField() without an explicit default= parameter now creates a
  required field. Previously, all fields silently defaulted to None, making
  every field optional regardless of the type annotation.

  Migration

  # Fields that should be optional need explicit default=None:
  # Before:
  name: Optional[str] = ComparableField()
  # After:
  name: Optional[str] = ComparableField(default=None)

  # Fields that should be required need no change:
  name: str = ComparableField()  # Now correctly required

  Why This Matters

  This is the highest-value fix in 0.7.0. It was a validation bug, not just a
  schema-rendering issue, and enables StructuredModel to work correctly as a
  Strands structured-output model.

  Changes

  - Use PydanticUndefined sentinel to detect "no default provided"
  - Only pass default to Field() when explicitly provided by user
  - Add comprehensive tests for required vs optional behavior
  - Update 21 existing test files to add explicit default=None
  - Add migration guidance in docstring

  Testing

  - Added
  tests/structured_object_evaluator/test_comparable_field_optionality.py
  - Updated 21 existing test files