### PR TITLE
fix(hungarian): align the single-item fast path with the general path (#224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,44 @@ Each release links to full notes on the
 
 ### Fixed
 
+- The Hungarian single-item shortcut now classifies pairs the same way the
+  general multi-item path does, so a confusion-matrix result no longer depends
+  on how many items happen to be in a list. Previously a 1-vs-1 comparison at
+  zero similarity was reported as FN + FA where a 2-vs-2 reported FD, and the
+  shortcut gated on `score > 0` instead of `match_threshold`, so any non-zero
+  similarity counted as a true positive however far below threshold it was.
+
+  This makes the 1-vs-1 case follow the two documented rules it was the sole
+  violator of: a pair the algorithm assigns is a match, and `match_threshold`
+  splits matched pairs into TP and FD without un-matching them
+  ([Hungarian matching](https://awslabs.github.io/stickler/Advanced/hungarian-matching/));
+  and a below-threshold pair is treated as atomic, with no field-by-field
+  breakdown
+  ([Threshold-gated evaluation](https://awslabs.github.io/stickler/Advanced/threshold-gated-evaluation/)).
+
+  **This moves metrics, and the default moves them upward.** A 1-vs-1 list
+  that is completely wrong now reports FD where it previously reported
+  FN + FA. `recall_with_fd` defaults to `False`, which excludes FD from the
+  recall denominator, so reclassifying FN as FD *raises* reported recall for
+  an unchanged prediction:
+
+  | three single-item list fields, one wholly wrong | before | after |
+  |---|---|---|
+  | `tp` / `fa` / `fd` / `fn` | 2 / 1 / 0 / 1 | 2 / 0 / 1 / 0 |
+  | `cm_recall` | 0.667 | **1.000** |
+  | `cm_f1` | 0.667 | 0.800 |
+  | `cm_accuracy` | 0.500 | 0.667 |
+
+  Multi-item lists already behaved this way, so this is the 1-vs-1 case
+  becoming consistent rather than a new policy. Set `recall_with_fd=True` to
+  count false discoveries against recall.
+
+  A 1-vs-1 list whose pair falls below threshold also no longer emits
+  sub-field entries under `confusion_matrix.fields.<list>.fields`, matching
+  what multi-item lists already did. Code reading a nested sub-field key
+  should treat it as absent rather than assuming it exists
+  ([#224](https://github.com/awslabs/stickler/issues/224))
+
 - Handle `None` consistently across all comparators. `None` is a missing
   value and no longer compares equal to an empty string: `(None, "")` now
   scores `0.0` everywhere, and `(None, None)` scores `1.0` everywhere.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,10 +54,38 @@ Each release links to full notes on the
   becoming consistent rather than a new policy. Set `recall_with_fd=True` to
   count false discoveries against recall.
 
-  A 1-vs-1 list whose pair falls below threshold also no longer emits
-  sub-field entries under `confusion_matrix.fields.<list>.fields`, matching
-  what multi-item lists already did. Code reading a nested sub-field key
-  should treat it as absent rather than assuming it exists
+  **Two result shapes change for a below-threshold 1-vs-1 list**, both to
+  match what multi-item lists already produced:
+
+  `confusion_matrix.fields.<list>.fields` is now empty, where it previously
+  carried an entry per sub-field. Reading a sub-field key directly raises
+  `KeyError`:
+
+  ```python
+  cm["fields"]["lines"]["fields"]["sku"]   # KeyError: 'sku'
+  ```
+
+  Use `.get()`, or read the object-level counts at
+  `cm["fields"]["lines"]["overall"]`, which record the FD. This follows the
+  documented threshold-gating rule: below the threshold the pairing is
+  spurious, so no field-by-field breakdown is generated
+  ([Threshold-gated evaluation](https://awslabs.github.io/stickler/Advanced/threshold-gated-evaluation/)).
+
+  `non_matches` (from `document_non_matches=True`) changes in the opposite
+  direction, from two object-level records to one field-level record per
+  sub-field:
+
+  | | before | after |
+  |---|---|---|
+  | `field_path` | `lines[0]`, `lines[0]` | `lines[0].sku`, `lines[0].desc` |
+  | `non_match_type` | `false_negative`, `false_alarm` | `false_discovery` (both) |
+  | `ground_truth_value` | the whole object dict | the scalar field value |
+  | `similarity_score` | `None` | the pair's score |
+
+  Code that groups non-matches by `non_match_type` to count misses, or that
+  parses `field_path` expecting an object-level path for FN/FA records, needs
+  updating: a single-line-item document that previously produced one FN and
+  one FA now produces false discoveries at the field level
   ([#224](https://github.com/awslabs/stickler/issues/224))
 
 - Handle `None` consistently across all comparators. `None` is a missing

--- a/docs/docs/Advanced/hungarian-matching.md
+++ b/docs/docs/Advanced/hungarian-matching.md
@@ -42,9 +42,30 @@ pair and is therefore FD, not FN + FA. Only items with no partner at all
 become FN or FA. This holds identically for a one-item list and a hundred-item
 one; see `tests/common/algorithms/test_hungarian_path_parity.py`.
 
+### FD and recall
+
 Whether an FD counts against recall is a separate decision, controlled by
 `recall_with_fd` (see
 [Understanding Results](../Guides/Evaluation/understanding-results.md)).
+
+This is worth understanding before comparing recall across versions or
+thresholds, because **the default excludes FD from the recall denominator**:
+
+| `recall_with_fd` | recall | effect |
+|---|---|---|
+| `False` (default) | `TP / (TP + FN)` | an FD is invisible to recall |
+| `True` | `TP / (TP + FN + FD)` | an FD counts as a miss |
+
+A wrong-but-paired prediction is an FD, not an FN, so under the default it is
+absent from the recall denominator entirely. The effect shows up when a
+document mixes right and wrong fields: three single-item list fields with one
+wholly wrong scores recall `0.667` if that field is FN + FA, but `1.000` if it
+is an FD, because the FD leaves both numerator and denominator untouched.
+Precision is unaffected either way, since FD is part of FP.
+
+Raising `match_threshold` moves pairs from TP to FD, which *raises* default
+recall while lowering precision. If you track recall over time, set
+`recall_with_fd=True` so that a false discovery counts against it.
 
 ## Concrete Example: Transaction Matching
 

--- a/docs/docs/Advanced/hungarian-matching.md
+++ b/docs/docs/Advanced/hungarian-matching.md
@@ -35,6 +35,17 @@ Each matched pair is classified using `StructuredModel.match_threshold`:
 | GT item unmatched | **FN** | No |
 | Pred item unmatched | **FA** | No |
 
+The threshold splits matched pairs into TP and FD; it does not un-match them.
+A pair the algorithm assigned is a match, so **similarity magnitude never
+changes the classification** -- a pair at similarity `0.0` is still an assigned
+pair and is therefore FD, not FN + FA. Only items with no partner at all
+become FN or FA. This holds identically for a one-item list and a hundred-item
+one; see `tests/common/algorithms/test_hungarian_path_parity.py`.
+
+Whether an FD counts against recall is a separate decision, controlled by
+`recall_with_fd` (see
+[Understanding Results](../Guides/Evaluation/understanding-results.md)).
+
 ## Concrete Example: Transaction Matching
 
 ### Model Definition

--- a/docs/docs/Advanced/hungarian-matching.md
+++ b/docs/docs/Advanced/hungarian-matching.md
@@ -63,9 +63,23 @@ wholly wrong scores recall `0.667` if that field is FN + FA, but `1.000` if it
 is an FD, because the FD leaves both numerator and denominator untouched.
 Precision is unaffected either way, since FD is part of FP.
 
-Raising `match_threshold` moves pairs from TP to FD, which *raises* default
-recall while lowering precision. If you track recall over time, set
-`recall_with_fd=True` so that a false discovery counts against it.
+Two different moves are easy to conflate here, and they push recall in
+opposite directions:
+
+| move | numerator | denominator | default recall |
+|---|---|---|---|
+| TP → FD (raise `match_threshold`) | `-1` | `-1` | falls, or stays equal |
+| FN → FD (what changed for 1-vs-1 lists) | unchanged | `-1` | **rises** |
+
+Raising `match_threshold` moves pairs from TP to FD, which lowers both default
+recall and precision. The move that *raises* default recall is reclassifying an
+unmatched item (FN) as a matched-but-below-threshold pair (FD), because that
+drops a denominator term while leaving the numerator alone. That is the change
+1-vs-1 lists saw in
+[#224](https://github.com/awslabs/stickler/issues/224).
+
+Either way an FD is invisible to default recall, which is the reason to set
+`recall_with_fd=True` if you track recall over time.
 
 ## Concrete Example: Transaction Matching
 

--- a/docs/docs/Advanced/threshold-gated-evaluation.md
+++ b/docs/docs/Advanced/threshold-gated-evaluation.md
@@ -25,6 +25,26 @@ For each matched pair, compare the similarity score against `StructuredModel.mat
 - **similarity >= threshold** -- **TP**: recurse into nested fields
 - **similarity < threshold** -- **FD**: stop recursion, treat as atomic
 
+!!! warning "Do not set a list field's `threshold` to `0.0`"
+    The comparison is `>=`, so a threshold of `0.0` is satisfied by *every*
+    score including `0.0` itself. Every pair the algorithm assigns becomes a
+    true positive, and a wholly wrong prediction reports perfect metrics:
+
+    ```python
+    class Doc(StructuredModel):
+        tags: List[str] = ComparableField(comparator=ExactComparator(), threshold=0.0)
+
+    Doc(tags=["X"]).compare_with(Doc(tags=["A"]), include_confusion_matrix=True)
+    # tp=1, fa=0, fn=0 -- recall, precision, F1 and accuracy all 1.000
+    ```
+
+    Use a small positive threshold instead if the intent is "accept weak
+    matches." `0.0` means "accept everything," which is rarely what a
+    threshold is for. Note that Stickler uses `match_threshold=0.0`
+    internally as a deliberate capture-all sentinel when it needs every pair
+    for scoring, and reclassifies those pairs itself rather than reading
+    their `tp`.
+
 ### 3. Unmatched Items
 
 - **GT extras** -- **FN**: stop recursion

--- a/src/stickler/algorithms/hungarian.py
+++ b/src/stickler/algorithms/hungarian.py
@@ -200,6 +200,23 @@ class HungarianMatcher:
                 - precision: Precision score
                 - recall: Recall score
                 - f1: F1 score
+
+        Note:
+            ``fn`` and ``fp`` here are **threshold-based, not
+            partnering-based**: they are ``len(list) - tp``, so a pair that
+            appears in ``matched_pairs`` but scored below ``match_threshold``
+            is counted in both. A below-threshold pair is therefore reported
+            as matched *and* as fn/fp by this function, at every list length.
+
+            The FD split -- "matched but below threshold" as distinct from
+            "no partner at all" -- happens downstream in
+            :class:`StructuredListComparator`, which reads ``matched_pairs``
+            and reclassifies. Callers wanting FD semantics should do the same
+            rather than reading ``fn``/``fp`` from here.
+
+            ``match_threshold=0.0`` is used elsewhere as a capture-all
+            sentinel. Every score satisfies ``>= 0.0``, so ``tp`` then counts
+            pairs rather than true positives and must not be read.
         """
         # Prepare lists
         prepared_list1, prepared_list2 = self._prepare_lists(list1, list2)
@@ -216,6 +233,11 @@ class HungarianMatcher:
         # (StructuredListComparator) classifies a below-threshold matched pair
         # as FD. Whether an FD counts against recall is the `recall_with_fd`
         # knob's job, not this function's.
+        #
+        # `fn`/`fp` below mirror the general path's `len(list) - tp`, which
+        # means a below-threshold pair is reported as matched and as fn/fp at
+        # the same time. That is pre-existing at every list length, not a
+        # property of this shortcut; see the Note in the docstring above.
         if len(prepared_list1) == 1 and len(prepared_list2) == 1:
             # Directly compare the single items
             if hasattr(self.comparator, "compare"):

--- a/src/stickler/algorithms/hungarian.py
+++ b/src/stickler/algorithms/hungarian.py
@@ -204,7 +204,18 @@ class HungarianMatcher:
         # Prepare lists
         prepared_list1, prepared_list2 = self._prepare_lists(list1, list2)
 
-        # Handle simple case efficiently: single items
+        # Handle simple case efficiently: single items.
+        #
+        # This shortcut must classify exactly as the general path below, or the
+        # same situation gets a different confusion-matrix result depending on
+        # how many items happen to be in the list. One assignment exists (the
+        # only possible one), so the pair is always matched; `match_threshold`
+        # then decides TP versus below-threshold, exactly as the general path
+        # does. Similarity magnitude does not un-match a pair -- a pair at 0.0
+        # is still the assignment the algorithm made, and downstream
+        # (StructuredListComparator) classifies a below-threshold matched pair
+        # as FD. Whether an FD counts against recall is the `recall_with_fd`
+        # knob's job, not this function's.
         if len(prepared_list1) == 1 and len(prepared_list2) == 1:
             # Directly compare the single items
             if hasattr(self.comparator, "compare"):
@@ -212,26 +223,19 @@ class HungarianMatcher:
             else:
                 score = self.comparator(prepared_list1[0], prepared_list2[0])
 
-            if score > 0:
-                return {
-                    "matched_pairs": [(0, 0, score)],
-                    "tp": 1,
-                    "fp": 0,
-                    "fn": 0,
-                    "precision": 1.0,
-                    "recall": 1.0,
-                    "f1": 1.0,
-                }
-            else:
-                return {
-                    "matched_pairs": [],
-                    "tp": 0,
-                    "fp": 1,
-                    "fn": 1,
-                    "precision": 0.0,
-                    "recall": 0.0,
-                    "f1": 0.0,
-                }
+            is_tp = score >= self.match_threshold
+            tp = 1 if is_tp else 0
+            return {
+                # Always a matched pair: the assignment exists regardless of
+                # similarity, so downstream sees FD rather than FN+FA.
+                "matched_pairs": [(0, 0, score)],
+                "tp": tp,
+                "fp": 1 - tp,
+                "fn": 1 - tp,
+                "precision": float(tp),
+                "recall": float(tp),
+                "f1": float(tp),
+            }
 
         # Handle empty lists
         if not prepared_list1 and not prepared_list2:

--- a/src/stickler/structured_object_evaluator/models/comparison_helper.py
+++ b/src/stickler/structured_object_evaluator/models/comparison_helper.py
@@ -91,7 +91,13 @@ class ComparisonHelper:
             from stickler.algorithms.hungarian import HungarianMatcher
 
             # CRITICAL FIX: Use match_threshold=0.0 to capture ALL matches, not just those above threshold
-            # This allows us to keep track of partial matches for scoring
+            # This allows us to keep track of partial matches for scoring.
+            #
+            # `0.0` is a capture-all sentinel: only `matched_pairs` is read
+            # below, and classification happens against
+            # `classification_threshold` instead. Do not read `tp`/`fp`/`fn`
+            # from a matcher built this way -- every pair satisfies
+            # `score >= 0.0`, so its `tp` counts pairs, not true positives.
             hungarian = HungarianMatcher(comparator, match_threshold=0.0)
             classification_threshold = threshold
 

--- a/tests/common/algorithms/test_hungarian_path_parity.py
+++ b/tests/common/algorithms/test_hungarian_path_parity.py
@@ -1,0 +1,142 @@
+"""The single-item shortcut must classify exactly like the general path (#224).
+
+``HungarianMatcher.calculate_metrics`` has a fast path for ``len == 1`` on both
+sides that bypasses the assignment algorithm. Nothing pinned that it agreed
+with the general multi-item path, and it did not: a zero-similarity 1-vs-1 pair
+was dropped (yielding FN + FA instead of FD), and the shortcut gated on
+``score > 0`` instead of ``score >= match_threshold``, so any non-zero
+similarity counted as a true positive no matter how far below threshold.
+
+The documented contract (``docs/docs/Advanced/hungarian-matching.md``) is:
+
+- a pair the algorithm assigns is matched; ``match_threshold`` splits matched
+  pairs into TP (``>=``) and FD (``<``), it does not un-match them
+- unmatched GT items are FN, unmatched Pred items are FA
+- equal-length lists pair every element, so only TP and FD are possible
+
+These tests pin that contract against list length, which is the property that
+would have caught #224.
+"""
+
+import pytest
+
+from stickler.algorithms import HungarianMatcher
+from stickler.comparators.levenshtein import LevenshteinComparator
+
+# Values with zero pairwise Levenshtein similarity (no shared characters).
+DISSIMILAR_GT = ["AAA", "BBB", "CCC"]
+DISSIMILAR_PRED = ["XXX", "YYY", "ZZZ"]
+
+
+def _matcher(threshold: float) -> HungarianMatcher:
+    return HungarianMatcher(
+        comparator=LevenshteinComparator(), match_threshold=threshold
+    )
+
+
+class TestZeroSimilarityIsAMatchedPair:
+    """A zero-similarity assignment is still an assignment."""
+
+    @pytest.mark.parametrize("n", [1, 2, 3])
+    def test_zero_similarity_pairs_are_kept_at_every_length(self, n):
+        """The pair stays in ``matched_pairs`` regardless of list length.
+
+        Dropping it is what made a 1-item list report FN + FA where a 2-item
+        list reported FD for the identical situation.
+        """
+        result = _matcher(0.5).calculate_metrics(
+            DISSIMILAR_GT[:n], DISSIMILAR_PRED[:n]
+        )
+
+        assert len(result["matched_pairs"]) == n
+        assert all(score == 0.0 for _, _, score in result["matched_pairs"])
+
+    @pytest.mark.parametrize("n", [1, 2, 3])
+    def test_zero_similarity_counts_are_length_independent(self, n):
+        """n unrelated pairs produce the same per-pair counts at any n."""
+        result = _matcher(0.5).calculate_metrics(
+            DISSIMILAR_GT[:n], DISSIMILAR_PRED[:n]
+        )
+
+        # Below threshold, so no true positives; fp/fn reflect the n pairs.
+        assert result["tp"] == 0
+        assert result["fp"] == n
+        assert result["fn"] == n
+
+    def test_single_item_agrees_with_multi_item(self):
+        """The regression in one assertion: 1-vs-1 must scale to 2-vs-2."""
+        one = _matcher(0.5).calculate_metrics(DISSIMILAR_GT[:1], DISSIMILAR_PRED[:1])
+        two = _matcher(0.5).calculate_metrics(DISSIMILAR_GT[:2], DISSIMILAR_PRED[:2])
+
+        assert len(one["matched_pairs"]) == 1
+        assert len(two["matched_pairs"]) == 2
+        assert (one["tp"], one["fp"], one["fn"]) == (0, 1, 1)
+        assert (two["tp"], two["fp"], two["fn"]) == (0, 2, 2)
+
+
+class TestFastPathHonorsMatchThreshold:
+    """The shortcut must gate on ``match_threshold``, not on ``score > 0``."""
+
+    def test_below_threshold_single_pair_is_not_a_true_positive(self):
+        """``score > 0`` gating made any non-zero similarity a TP."""
+        # "abc" vs "abd" is ~0.667 similar: above 0.5, below 0.9.
+        result = _matcher(0.9).calculate_metrics(["abc"], ["abd"])
+
+        assert result["matched_pairs"][0][2] == pytest.approx(0.667, abs=1e-3)
+        assert result["tp"] == 0, "a below-threshold pair is not a true positive"
+
+    def test_above_threshold_single_pair_is_a_true_positive(self):
+        result = _matcher(0.5).calculate_metrics(["abc"], ["abd"])
+
+        assert result["tp"] == 1
+
+    @pytest.mark.parametrize("threshold", [0.1, 0.5, 0.66, 0.7, 0.9, 1.0])
+    def test_single_and_multi_item_agree_across_thresholds(self, threshold):
+        """Same pair, same verdict, whether or not a second pair is present.
+
+        The second pair is identical on both sides, so it is always a TP and
+        contributes a known constant; the pair under test is what varies.
+        """
+        single = _matcher(threshold).calculate_metrics(["abc"], ["abd"])
+        multi = _matcher(threshold).calculate_metrics(["abc", "QQQ"], ["abd", "QQQ"])
+
+        # Subtract the guaranteed-TP second pair to isolate the shared pair.
+        assert single["tp"] == multi["tp"] - 1
+
+    def test_exactly_at_threshold_is_a_true_positive(self):
+        """The boundary is inclusive (``>=``), matching the general path."""
+        identical = _matcher(1.0).calculate_metrics(["abc"], ["abc"])
+
+        assert identical["matched_pairs"][0][2] == 1.0
+        assert identical["tp"] == 1
+
+
+class TestUnmatchedItemsAreFnAndFa:
+    """Extras on the GT side are FN; extras on the Pred side are FA."""
+
+    def test_extra_ground_truth_items_are_false_negatives(self):
+        result = _matcher(0.5).calculate_metrics(["abc", "QQQ"], ["abc"])
+
+        assert result["tp"] == 1
+        assert result["fn"] == 1, "the unpaired GT item is a false negative"
+        assert result["fp"] == 0
+
+    def test_extra_prediction_items_are_false_alarms(self):
+        result = _matcher(0.5).calculate_metrics(["abc"], ["abc", "QQQ"])
+
+        assert result["tp"] == 1
+        assert result["fp"] == 1, "the unpaired prediction item is a false alarm"
+        assert result["fn"] == 0
+
+    def test_equal_length_lists_produce_no_unmatched_items(self):
+        """Documented invariant: equal length means only TP and FD are possible.
+
+        With every pair below threshold, fp/fn come from below-threshold pairs
+        rather than from unmatched items -- there are none to be had.
+        """
+        result = _matcher(0.9).calculate_metrics(
+            ["abc", "def"], ["abd", "deg"]
+        )
+
+        assert len(result["matched_pairs"]) == 2, "every element is paired"
+        assert result["tp"] == 0

--- a/tests/common/algorithms/test_hungarian_path_parity.py
+++ b/tests/common/algorithms/test_hungarian_path_parity.py
@@ -53,7 +53,21 @@ class TestZeroSimilarityIsAMatchedPair:
 
     @pytest.mark.parametrize("n", [1, 2, 3])
     def test_zero_similarity_counts_are_length_independent(self, n):
-        """n unrelated pairs produce the same per-pair counts at any n."""
+        """n unrelated pairs produce the same per-pair counts at any n.
+
+        The ``fp``/``fn`` values here are **descriptive of today, not the
+        intended contract**. ``calculate_metrics`` derives them as
+        ``len(list) - tp``, so a pair that is present in ``matched_pairs``
+        is also counted in ``fn`` -- matched and missing at the same time.
+        That is pre-existing at every list length and is what this test
+        holds constant across ``n``.
+
+        What #224 is about is the *length independence*, not the values: a
+        1-item list must not classify differently from a 2-item one. If the
+        ``fn`` semantics are ever separated from the threshold (an explicit
+        ``fd`` key, as ``ComparisonHelper.unordered_list_metrics``
+        produces), update these numbers -- do not read them as a guarantee.
+        """
         result = _matcher(0.5).calculate_metrics(
             DISSIMILAR_GT[:n], DISSIMILAR_PRED[:n]
         )
@@ -90,7 +104,7 @@ class TestFastPathHonorsMatchThreshold:
 
         assert result["tp"] == 1
 
-    @pytest.mark.parametrize("threshold", [0.1, 0.5, 0.66, 0.7, 0.9, 1.0])
+    @pytest.mark.parametrize("threshold", [0.0, 0.1, 0.5, 0.66, 0.7, 0.9, 1.0])
     def test_single_and_multi_item_agree_across_thresholds(self, threshold):
         """Same pair, same verdict, whether or not a second pair is present.
 
@@ -109,6 +123,28 @@ class TestFastPathHonorsMatchThreshold:
 
         assert identical["matched_pairs"][0][2] == 1.0
         assert identical["tp"] == 1
+
+    @pytest.mark.parametrize("n", [1, 2, 3])
+    def test_threshold_zero_makes_every_pair_a_true_positive(self, n):
+        """``match_threshold=0.0`` is a capture-all sentinel, at any length.
+
+        Because the gate is ``>=``, a zero-similarity pair satisfies a zero
+        threshold, so ``tp`` counts *pairs* rather than true positives. This
+        pins that the shortcut and the general path agree on the boundary --
+        the point of #224 -- and documents the trap.
+
+        ``ComparisonHelper.compare_unordered_lists`` builds a matcher this way
+        deliberately to capture all pairs for scoring, and reads only
+        ``matched_pairs``, reclassifying against its own
+        ``classification_threshold``. Nothing should read ``tp`` from a
+        matcher constructed with ``0.0``.
+        """
+        result = _matcher(0.0).calculate_metrics(DISSIMILAR_GT[:n], DISSIMILAR_PRED[:n])
+
+        assert all(score == 0.0 for _, _, score in result["matched_pairs"])
+        assert result["tp"] == n, "every pair clears a zero threshold"
+        assert result["fp"] == 0
+        assert result["fn"] == 0
 
 
 class TestUnmatchedItemsAreFnAndFa:

--- a/tests/structured_object_evaluator/test_non_match_documentation.py
+++ b/tests/structured_object_evaluator/test_non_match_documentation.py
@@ -7,6 +7,9 @@ functionality, which captures detailed information about false positives and fal
 
 from typing import List, Optional
 
+import pytest
+
+from stickler.comparators.exact import ExactComparator
 from stickler.comparators.levenshtein import LevenshteinComparator
 from stickler.structured_object_evaluator import (
     ComparableField,
@@ -133,3 +136,78 @@ def test_non_match_documentation_disabled():
     assert "non_matches" not in result or len(result.get("non_matches", [])) == 0, (
         "Expected no non-matches to be documented"
     )
+
+
+# ---------------------------------------------------------------------------
+# Result-shape parity across list length (#224)
+# ---------------------------------------------------------------------------
+#
+# A below-threshold pair in a List[StructuredModel] must be documented the
+# same way whether the list holds one item or several. Before #224 the 1-vs-1
+# case was the odd one out: the fast path dropped the pair, so it surfaced as
+# an object-level FN plus an object-level FA instead of field-level false
+# discoveries. These pin the shape at n=1 against n=2 so the two cannot drift
+# apart again.
+
+
+class _Line(StructuredModel):
+    match_threshold = 0.7
+
+    sku: str = ComparableField(comparator=ExactComparator(), threshold=1.0, weight=1.0)
+    desc: str = ComparableField(comparator=ExactComparator(), threshold=1.0, weight=1.0)
+
+
+class _Invoice(StructuredModel):
+    lines: List[_Line] = ComparableField(weight=1.0)
+
+
+def _wholly_wrong(n: int):
+    """n line items, none of which match on any field."""
+    gt = _Invoice(lines=[_Line(sku=f"A{i}", desc=f"Widget{i}") for i in range(n)])
+    pred = _Invoice(lines=[_Line(sku=f"Z{i}", desc=f"Gadget{i}") for i in range(n)])
+    return gt, pred
+
+
+@pytest.mark.parametrize("n", [1, 2, 3])
+def test_below_threshold_pairs_are_field_level_false_discoveries(n):
+    """Every sub-field of every below-threshold pair is documented as an FD."""
+    gt, pred = _wholly_wrong(n)
+
+    non_matches = gt.compare_with(pred, document_non_matches=True)["non_matches"]
+
+    # One record per sub-field per pair -- not one per object.
+    assert len(non_matches) == 2 * n
+    assert all(
+        nm["non_match_type"] == NonMatchType.FALSE_DISCOVERY for nm in non_matches
+    ), "an assigned pair below threshold is a false discovery, not FN + FA"
+
+    # Paths address the field, not the object: `lines[0].sku`, not `lines[0]`.
+    assert {nm["field_path"] for nm in non_matches} == {
+        f"lines[{i}].{field}" for i in range(n) for field in ("sku", "desc")
+    }
+
+    # Scalars, not the whole object dict.
+    assert all(
+        isinstance(nm["ground_truth_value"], str) for nm in non_matches
+    ), "field-level records carry the field value"
+
+
+def test_non_match_shape_is_independent_of_list_length():
+    """The per-pair record shape at n=1 matches n=2 exactly.
+
+    This is the #224 property: classification must not depend on how many
+    items happen to be in the list.
+    """
+    keys_by_n = {}
+    for n in (1, 2):
+        gt, pred = _wholly_wrong(n)
+        non_matches = gt.compare_with(pred, document_non_matches=True)["non_matches"]
+
+        # Compare the first pair's records, which both cases share.
+        first_pair = [nm for nm in non_matches if nm["field_path"].startswith("lines[0]")]
+        keys_by_n[n] = sorted(
+            (nm["field_path"], nm["non_match_type"], sorted(nm.keys()))
+            for nm in first_pair
+        )
+
+    assert keys_by_n[1] == keys_by_n[2]

--- a/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
+++ b/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
@@ -148,12 +148,12 @@ def test_simple_list_extra_elements():
 
 
 def test_simple_list_no_match():
-    """Completely different elements — objects don't match, classified at object level.
+    """Completely different elements — a below-threshold matched pair is FD.
 
-    With match_threshold=0.3 and completely different single-character tags,
-    the object similarity is ~0 which is below even 0.3. The objects get
-    paired by Hungarian but classified as unmatched (FN + FA) because the
-    similarity is effectively zero.
+    The objects share no aligning tags, so similarity is ~0, below the 0.3
+    match_threshold. Hungarian still assigns the pair (it is the only possible
+    assignment), so the threshold splits it into FD rather than un-matching it
+    into FN + FA. Similarity magnitude does not change that; see issue #224.
     """
     gt = TaggedContainer(items=[TaggedItem(tags=["X", "Y"])])
     pred = TaggedContainer(items=[TaggedItem(tags=["A", "B"])])
@@ -161,9 +161,10 @@ def test_simple_list_no_match():
     result = gt.compare_with(pred, include_confusion_matrix=True)
     obj_metrics = _overall(result["confusion_matrix"], "items")
 
-    # Objects are so different they end up unmatched: 1 FN (GT) + 1 FA (pred)
-    assert obj_metrics["fn"] == 1
-    assert obj_metrics["fa"] == 1
+    # One assigned pair, below threshold: one FD, no FN/FA.
+    assert obj_metrics["fd"] == 1
+    assert obj_metrics["fn"] == 0
+    assert obj_metrics["fa"] == 0
 
 
 # ---------------------------------------------------------------------------
@@ -222,17 +223,27 @@ def test_simple_list_alongside_primitive_field():
 
 
 def test_empty_simple_list_within_structured_list():
-    """Empty simple lists on both sides — objects with only empty fields
-    get similarity 0 and don't match, so field-level metrics are all zeros.
-    This is pre-existing behavior for objects whose only field is an empty list."""
+    """Empty simple lists on both sides — the pair is matched, below threshold.
+
+    Pre-existing oddity, unchanged by issue #224: an object whose only field is
+    an empty list gets list-path similarity 0.0, even though comparing the two
+    objects directly scores 1.0 (they are identical). Because similarity is
+    below ``match_threshold``, the assigned pair classifies as FD.
+
+    The FD-vs-FN+FA part is the #224 convention. The 0.0 similarity for two
+    identical objects is a separate bug and is deliberately not addressed here;
+    when it is fixed this pair should become a TP (or a list-level TN).
+    """
     gt = Invoice(LineItems=[LineItemsInfo(LineItemDays=[])])
     pred = Invoice(LineItems=[LineItemsInfo(LineItemDays=[])])
 
     result = gt.compare_with(pred, include_confusion_matrix=True)
     obj_metrics = _overall(result["confusion_matrix"], "LineItems")
 
-    # Objects with only empty-list fields get similarity 0 → unmatched
-    assert obj_metrics["fn"] + obj_metrics["fa"] >= 1
+    # One assigned pair, below threshold: FD, not unmatched.
+    assert obj_metrics["fd"] == 1
+    assert obj_metrics["fn"] == 0
+    assert obj_metrics["fa"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
+++ b/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
@@ -223,16 +223,19 @@ def test_simple_list_alongside_primitive_field():
 
 
 def test_empty_simple_list_within_structured_list():
-    """Empty simple lists on both sides — the pair is matched, below threshold.
+    """Empty simple lists on both sides — the pair is assigned, not unmatched.
 
-    Pre-existing oddity, unchanged by issue #224: an object whose only field is
-    an empty list gets list-path similarity 0.0, even though comparing the two
-    objects directly scores 1.0 (they are identical). Because similarity is
-    below ``match_threshold``, the assigned pair classifies as FD.
+    This asserts only the #224 property: an assigned pair is not reported as
+    FN + FA. It deliberately does *not* pin how the pair is classified.
 
-    The FD-vs-FN+FA part is the #224 convention. The 0.0 similarity for two
-    identical objects is a separate bug and is deliberately not addressed here;
-    when it is fixed this pair should become a TP (or a list-level TN).
+    An object whose only field is an empty list gets list-path similarity 0.0
+    even though the two objects are identical, which is a separate pre-existing
+    bug. That leaves the result internally contradictory here -- the comparison
+    reports ``overall_score == 1.0`` (a perfect match) while the pair scores
+    below ``match_threshold`` and so classifies as FD. Pinning ``fd == 1``
+    would cement that contradiction into the suite and have to be undone when
+    the similarity bug is fixed, at which point this pair should become a TP or
+    a list-level TN.
     """
     gt = Invoice(LineItems=[LineItemsInfo(LineItemDays=[])])
     pred = Invoice(LineItems=[LineItemsInfo(LineItemDays=[])])
@@ -240,10 +243,12 @@ def test_empty_simple_list_within_structured_list():
     result = gt.compare_with(pred, include_confusion_matrix=True)
     obj_metrics = _overall(result["confusion_matrix"], "LineItems")
 
-    # One assigned pair, below threshold: FD, not unmatched.
-    assert obj_metrics["fd"] == 1
+    # The #224 property: the pair is assigned, so neither side is orphaned.
     assert obj_metrics["fn"] == 0
     assert obj_metrics["fa"] == 0
+
+    # Whichever way the pair is classified, it is counted exactly once.
+    assert obj_metrics["tp"] + obj_metrics["fd"] + obj_metrics["tn"] == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Issue

Fixes #224.

## Problem

`HungarianMatcher.calculate_metrics` has a shortcut for `len == 1` on both sides that bypasses the assignment algorithm. Nothing pinned that it agreed with the general multi-item path, and it didn't — in two ways.

**1. A zero-similarity pair was dropped, yielding FN + FA instead of FD.**

Two GT items vs two unrelated prediction items, at `match_threshold=0.5`:

| lists | tp | fn | fa | fd |
|---|---|---|---|---|
| 2 vs 2 (general path) | 0 | 0 | 0 | **2** |
| 1 vs 1 (fast path) | 0 | **1** | **1** | 0 |

Identical situation, different classification, purely because of list length.

**2. The shortcut ignored `match_threshold` entirely.**

It gated on `score > 0` instead of `score >= self.match_threshold`:

```python
m = HungarianMatcher(comparator=LevenshteinComparator(), match_threshold=0.9)

m.calculate_metrics(["abc"], ["abd"])                # sim 0.667, below threshold
# -> tp=1   (should be 0)

m.calculate_metrics(["abc", "QQQ"], ["abd", "QQQ"])  # same pair, general path
# -> tp=1   (only the QQQ pair; the 0.667 pair correctly excluded)
```

So a single-item list silently over-reported accuracy — the failure direction hardest for a user to notice.

## The docs were already right

`docs/docs/Advanced/hungarian-matching.md:32-36` and `:153-154` have said this all along:

> `similarity >= match_threshold` → **TP**; `similarity < match_threshold` → **FD**
> GT item unmatched → **FN**; Pred item unmatched → **FA**
> Equal length — every element gets paired. Only TP and FD are possible.

Neither doc mentions a single-item exception or a zero-similarity carve-out. So this isn't a convention change — it's the code being brought into line with documented behavior.

## Fix

The shortcut now always returns the assigned pair and counts `tp` only at or above `match_threshold`. A pair the algorithm assigned is a match; the threshold splits matched pairs into TP and FD without un-matching them; similarity magnitude is irrelevant to that. Whether an FD counts against recall stays `recall_with_fd`'s job.

Verified consistent at every length:

```
1 item each, all similarity 0.0: {'tp': 0, 'fn': 0, 'fa': 0, 'fd': 1}
2 items each:                    {'tp': 0, 'fn': 0, 'fa': 0, 'fd': 2}
3 items each:                    {'tp': 0, 'fn': 0, 'fa': 0, 'fd': 3}
```

## Tests

New `tests/common/algorithms/test_hungarian_path_parity.py`, 19 tests. The organising property is **classification must not depend on list length**, which is what would have caught this:

- zero-similarity pairs kept in `matched_pairs` at n=1,2,3
- counts length-independent at n=1,2,3
- below-threshold single pair is not a TP; above-threshold is
- single vs multi agree across thresholds 0.1 / 0.5 / 0.66 / 0.7 / 0.9 / 1.0
- boundary is inclusive (`>=`)
- extra GT items → FN, extra Pred items → FA, equal-length → no unmatched items

**Verified load-bearing:** with the fix reverted, 6 of the 19 fail.

**Full suite: 1589 passed, 2 skipped.** `ruff check` clean.

## Behavior changes to be aware of

Two existing tests in `test_simple_list_in_structured_list.py` asserted the old FN + FA outcome and now assert FD. Both are the intended change, but one is worth a look: `test_empty_simple_list_within_structured_list` brushes against a **separate pre-existing bug** — an object whose only field is an empty list gets list-path similarity `0.0`, even though comparing the two objects directly scores `1.0` (they're identical). That's untouched here; I noted it in the test docstring rather than quietly rewriting the assertion. When that's fixed the pair should become a TP or a list-level TN.

Also updated `hungarian-matching.md` to say explicitly that similarity magnitude cannot un-match a pair. The table stated the rule but left that implication unstated, which is how the carve-out survived.

## Scope

Deliberately narrow, and independent of the aggregate-metrics work in #115 / #172 — this can land on its own. @hayleypark this is the one-place decision you proposed on #115 (settle match/no-match right after Hungarian matching and have everything downstream follow); it lands the FD convention on both paths so you can pin assertions once.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
