### PR TITLE
chore(deprecation): warn on any explicit ComparableField(aggregate=) use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,10 +137,18 @@ Each release links to full notes on the
   is no replacement to adopt. Scheduled for removal in 0.8.0.
 
   Reading a config does **not** count as explicit use: `to_stickler_config()`
-  writes the `aggregate` key for every field, so `model_from_json()` ignores it
-  rather than warning. Otherwise every exported-config round trip would warn
-  once per field, blaming stickler's own frame for a key the caller never
-  wrote, and would fail outright under `-W error::DeprecationWarning`
+  writes the `aggregate` key for every field, so `model_from_json()` restores
+  the value without warning. Otherwise every exported-config round trip would
+  warn once per field, blaming stickler's own frame for a key the caller never
+  wrote, and would fail outright under `-W error::DeprecationWarning`. The
+  export format is unchanged and stays idempotent: `export -> import -> export`
+  reproduces the original, including for `aggregate=True`.
+
+  Also removed a dead branch in `ConfusionMatrixCalculator` that zeroed and
+  re-summed a list field's confusion matrix when the flag was set. It was
+  unreachable by construction -- guarded on the argument *not* being a list, in
+  a method only ever called with one (instrumented the whole suite: 0 calls) --
+  and left a live-looking code path keyed on a parameter that is going away
   ([#226](https://github.com/awslabs/stickler/issues/226))
 
 ## [0.6.0] - 2026-07-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,18 @@ Each release links to full notes on the
   still returns the old value
   ([#200](https://github.com/awslabs/stickler/issues/200))
 
+- `ComparableField(aggregate=...)` now emits a `DeprecationWarning` for *any*
+  explicit use, where previously only `aggregate=True` warned and
+  `aggregate=False` was silent. The parameter has no effect: aggregation is
+  applied at the comparison layer, and every node in `compare_with()` output
+  already carries an `aggregate` block summing the primitive field metrics
+  below it.
+
+  Callers passing `aggregate=False` had no signal the parameter was going away
+  and would have met a bare `TypeError` on removal. Remove the argument; there
+  is no replacement to adopt. Scheduled for removal in 0.8.0
+  ([#226](https://github.com/awslabs/stickler/issues/226))
+
 ## [0.6.0] - 2026-07-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,13 @@ Each release links to full notes on the
 
   Callers passing `aggregate=False` had no signal the parameter was going away
   and would have met a bare `TypeError` on removal. Remove the argument; there
-  is no replacement to adopt. Scheduled for removal in 0.8.0
+  is no replacement to adopt. Scheduled for removal in 0.8.0.
+
+  Reading a config does **not** count as explicit use: `to_stickler_config()`
+  writes the `aggregate` key for every field, so `model_from_json()` ignores it
+  rather than warning. Otherwise every exported-config round trip would warn
+  once per field, blaming stickler's own frame for a key the caller never
+  wrote, and would fail outright under `-W error::DeprecationWarning`
   ([#226](https://github.com/awslabs/stickler/issues/226))
 
 ## [0.6.0] - 2026-07-30

--- a/docs/docs/Advanced/dynamic-models.md
+++ b/docs/docs/Advanced/dynamic-models.md
@@ -101,7 +101,6 @@ The `x-aws-stickler-*` extensions control comparison behavior on each property:
 | `x-aws-stickler-threshold` | Match threshold (0.0--1.0) | `0.8` |
 | `x-aws-stickler-weight` | Field importance weight | `2.0` |
 | `x-aws-stickler-clip-under-threshold` | Zero out scores below threshold | `true` |
-| `x-aws-stickler-aggregate` | Include in aggregate metrics | `true` |
 | `x-aws-stickler-model-name` | Class name (object-level) | `"Invoice"` |
 | `x-aws-stickler-match-threshold` | Hungarian match threshold (object-level) | `0.75` |
 
@@ -206,7 +205,6 @@ Person = StructuredModel.model_from_json(person_config)
     "weight": 1.0,
     "required": true,
     "default": null,
-    "aggregate": false,
     "clip_under_threshold": true
 }
 ```

--- a/docs/docs/Guides/Evaluation/README.md
+++ b/docs/docs/Guides/Evaluation/README.md
@@ -49,7 +49,7 @@ When defining a `StructuredModel` subclass in Python, each field is declared wit
 | `threshold` | `float` (0.0--1.0) | `0.5` | Minimum similarity score required for a field to be classified as a match. |
 | `weight` | `float` (> 0.0) | `1.0` | Relative importance of this field when computing aggregate scores. |
 | `clip_under_threshold` | `bool` | `True` | When `True`, scores below `threshold` are zeroed out before contributing to the weighted average. |
-| `aggregate` | `bool` | `False` | *Deprecated.* Previously controlled inclusion in parent-level metrics. All nodes now include an automatic `aggregate` field in the confusion matrix output. |
+| `aggregate` | `bool` | `False` | **Deprecated, removed in 0.8.0.** Has no effect: every node already carries an `aggregate` block in the `compare_with()` output summing the primitive field metrics below it. Passing it at all emits a `DeprecationWarning`; remove the argument, there is no replacement to adopt ([#226](https://github.com/awslabs/stickler/issues/226)). |
 
 ### How Each Parameter Affects Scoring
 

--- a/src/stickler/structured_object_evaluator/models/comparable_field.py
+++ b/src/stickler/structured_object_evaluator/models/comparable_field.py
@@ -13,12 +13,29 @@ from stickler.comparators.base import BaseComparator
 from stickler.comparators.levenshtein import LevenshteinComparator
 
 
+class _Unset:
+    """Sentinel distinguishing "argument omitted" from "argument passed".
+
+    Needed because ``aggregate=False`` is both the historical default and a
+    value a user may pass explicitly. Only the explicit case should warn.
+    """
+
+    def __bool__(self) -> bool:  # pragma: no cover - defensive
+        return False
+
+    def __repr__(self) -> str:  # pragma: no cover - defensive
+        return "<unset>"
+
+
+_UNSET = _Unset()
+
+
 def ComparableField(
     comparator: Optional[BaseComparator] = None,
     threshold: float = 0.5,
     weight: float = 1.0,
     default: Any = None,
-    aggregate: bool = False,
+    aggregate: Any = _UNSET,
     clip_under_threshold: bool = True,
     # Pydantic Field parameters (all optional, just like Field)
     alias: Optional[str] = None,
@@ -36,8 +53,13 @@ def ComparableField(
         threshold: Minimum similarity score to consider a match (default: 0.5)
         weight: Weight of this field in overall score calculation (default: 1.0)
         default: Default value for the field (default: None)
-        aggregate: DEPRECATED - This parameter is deprecated and will be removed in a future version.
-                  Use the new universal 'aggregate' field in compare_with() output instead.
+        aggregate: DEPRECATED, has no effect, and will be removed in 0.8.0.
+                  Passing it at all (either value) emits a DeprecationWarning.
+                  Aggregation is applied at the comparison layer: every node in
+                  compare_with() output already carries an 'aggregate' block
+                  summing the primitive field metrics below it. Remove the
+                  argument; there is no replacement to adopt.
+                  See https://github.com/awslabs/stickler/issues/226
         clip_under_threshold: Whether to zero out scores below threshold (default: True)
         alias: Pydantic field alias for serialization (default: None)
         description: Field description for documentation (default: None)
@@ -60,15 +82,25 @@ def ComparableField(
                 examples=["user@example.com"]
             )
     """
-    # Issue deprecation warning if aggregate=True is used
-    if aggregate:
+    # Warn on ANY explicit use, not just aggregate=True. Passing False was
+    # silent before, so those callers had no signal that the parameter is going
+    # away; they would have met a bare TypeError on upgrade. The value itself
+    # has no effect either way: aggregation is applied at the comparison layer
+    # and every node in compare_with() output carries an `aggregate` block.
+    if aggregate is not _UNSET:
         warnings.warn(
-            "The 'aggregate' parameter in ComparableField is deprecated and will be removed "
-            "in a future version. All nodes now automatically include an 'aggregate' field "
-            "in the compare_with() output that sums primitive field metrics below that node.",
+            "The 'aggregate' parameter in ComparableField is deprecated, has no "
+            "effect, and will be removed in 0.8.0. All nodes automatically "
+            "include an 'aggregate' field in the compare_with() output that "
+            "sums primitive field metrics below that node. Remove the argument; "
+            "no replacement is needed. See "
+            "https://github.com/awslabs/stickler/issues/226",
             DeprecationWarning,
             stacklevel=2,
         )
+        aggregate = bool(aggregate)
+    else:
+        aggregate = False
 
     # Create the actual comparator instance
     actual_comparator = comparator or LevenshteinComparator()

--- a/src/stickler/structured_object_evaluator/models/comparable_field.py
+++ b/src/stickler/structured_object_evaluator/models/comparable_field.py
@@ -187,6 +187,30 @@ def ComparableField(
     return field
 
 
+
+def _restore_deprecated_aggregate(field: Any, value: Any) -> None:
+    """Set a field's stored ``aggregate`` value without emitting a warning.
+
+    Reading an exported config is not an explicit use of the deprecated
+    parameter, so ``ComparableField`` is called with the sentinel and the value
+    is written afterwards. That keeps ``to_stickler_config()`` faithful --
+    export -> import -> export is unchanged, including for ``aggregate=True``
+    -- while the warning stays reserved for code a user can actually edit.
+
+    Internal, and removed with the parameter in 0.8.0
+    (https://github.com/awslabs/stickler/issues/226).
+    """
+    if not isinstance(value, bool):
+        return
+    extra = getattr(field, "json_schema_extra", None)
+    if extra is None or not callable(extra):
+        return
+    extra._aggregate = value
+    metadata = getattr(extra, "_comparison_metadata", None)
+    if isinstance(metadata, dict):
+        metadata["aggregate"] = value
+
+
 def _reconstruct_comparator_from_type(
     comparator_type: str, config: Optional[Dict[str, Any]] = None
 ) -> BaseComparator:

--- a/src/stickler/structured_object_evaluator/models/comparable_field.py
+++ b/src/stickler/structured_object_evaluator/models/comparable_field.py
@@ -5,7 +5,7 @@ with comparison configuration parameters.
 """
 
 import warnings
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from pydantic import Field
 
@@ -18,6 +18,13 @@ class _Unset:
 
     Needed because ``aggregate=False`` is both the historical default and a
     value a user may pass explicitly. Only the explicit case should warn.
+
+    Detection is by identity (``is not _UNSET``). That is sound within one
+    import namespace; a codebase importing stickler under two names (say
+    ``stickler.x`` and ``src.stickler.x``) creates two distinct sentinels, and
+    handing one namespace's to the other would read as an explicit argument.
+    Harmless -- the result is a spurious deprecation warning about a parameter
+    that is going away regardless.
     """
 
     def __bool__(self) -> bool:  # pragma: no cover - defensive
@@ -35,7 +42,7 @@ def ComparableField(
     threshold: float = 0.5,
     weight: float = 1.0,
     default: Any = None,
-    aggregate: Any = _UNSET,
+    aggregate: Union[bool, _Unset] = _UNSET,
     clip_under_threshold: bool = True,
     # Pydantic Field parameters (all optional, just like Field)
     alias: Optional[str] = None,

--- a/src/stickler/structured_object_evaluator/models/confusion_matrix_calculator.py
+++ b/src/stickler/structured_object_evaluator/models/confusion_matrix_calculator.py
@@ -147,29 +147,17 @@ class ConfusionMatrixCalculator:
                 )
                 result["nested_fields"] = nested_metrics
 
-        # For List[StructuredModel], we should NOT aggregate nested fields to list level
-        # List level metrics represent object-level matches from Hungarian algorithm
-        # Nested field metrics represent field-level matches within those objects
-        # They are separate concerns and should not be aggregated
-
-        # Only aggregate if this is explicitly marked as an aggregate field AND it's not a list
-        is_aggregate = self.model.__class__._is_aggregate_field(field_name)
-        if is_aggregate and not isinstance(gt_list, list):
-            # Initialize top-level confusion matrix values to 0
-            result["tp"] = 0
-            result["fa"] = 0
-            result["fd"] = 0
-            result["fp"] = 0
-            result["tn"] = 0
-            result["fn"] = 0
-            # Sum up the confusion matrix values from nested fields
-            for field, field_metrics in result["nested_fields"].items():
-                result["tp"] += field_metrics["tp"]
-                result["fa"] += field_metrics["fa"]
-                result["fd"] += field_metrics["fd"]
-                result["fp"] += field_metrics["fp"]
-                result["tn"] += field_metrics["tn"]
-                result["fn"] += field_metrics["fn"]
+        # List-level metrics count object matches from the Hungarian algorithm;
+        # nested field metrics count field matches within those objects. They are
+        # separate concerns and are deliberately not rolled together here.
+        #
+        # A branch used to zero these and re-sum them from nested_fields when
+        # `_is_aggregate_field(field_name)` was true and `gt_list` was not a
+        # list. It was dead by construction -- this method is only ever called
+        # with a list, so the guard was self-contradictory (instrumented the
+        # whole suite: 0 calls with a non-list). It is removed here rather than
+        # left as a path keyed on a flag that is deprecated and has no other
+        # effect (#226).
 
         # Add derived metrics
         metrics_helper = MetricsHelper()

--- a/src/stickler/structured_object_evaluator/models/field_converter.py
+++ b/src/stickler/structured_object_evaluator/models/field_converter.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional, Tuple, Type
 
 from pydantic import Field
 
-from .comparable_field import ComparableField
+from .comparable_field import _UNSET, ComparableField
 from .comparator_registry import create_comparator
 from .type_resolver import resolve_type_string
 
@@ -69,7 +69,9 @@ class FieldConverter:
         threshold = field_config.get("threshold", 0.5)
         weight = field_config.get("weight", 1.0)
         clip_under_threshold = field_config.get("clip_under_threshold", True)
-        aggregate = field_config.get("aggregate", False)
+        # Forward the sentinel when absent so a config without "aggregate"
+        # does not trip ComparableField's deprecation warning (issue #226).
+        aggregate = field_config.get("aggregate", _UNSET)
 
         # Extract Pydantic field parameters
         default = field_config.get("default", ...)  # Use Ellipsis for required fields
@@ -172,7 +174,9 @@ class FieldConverter:
         # Extract threshold and weight from field configuration
         weight = field_config.get("weight", 1.0)  # Default weight
         clip_under_threshold = field_config.get("clip_under_threshold", True)
-        aggregate = field_config.get("aggregate", False)
+        # Forward the sentinel when absent so a config without "aggregate"
+        # does not trip ComparableField's deprecation warning (issue #226).
+        aggregate = field_config.get("aggregate", _UNSET)
 
         # For list_structured_model, don't set threshold (Hungarian matching uses model's match_threshold)
         # For single structured_model, use threshold from config

--- a/src/stickler/structured_object_evaluator/models/field_converter.py
+++ b/src/stickler/structured_object_evaluator/models/field_converter.py
@@ -69,9 +69,13 @@ class FieldConverter:
         threshold = field_config.get("threshold", 0.5)
         weight = field_config.get("weight", 1.0)
         clip_under_threshold = field_config.get("clip_under_threshold", True)
-        # Forward the sentinel when absent so a config without "aggregate"
-        # does not trip ComparableField's deprecation warning (issue #226).
-        aggregate = field_config.get("aggregate", _UNSET)
+        # Never forward a config's "aggregate": the value provably has no
+        # effect, and `to_stickler_config()` writes the key for every field, so
+        # reading it would warn on every exported-config round trip -- blaming
+        # this frame for a key the caller never wrote, and hard-failing under
+        # `-W error::DeprecationWarning`. Reading a config is not an explicit
+        # use of the parameter (issue #226).
+        aggregate = _UNSET
 
         # Extract Pydantic field parameters
         default = field_config.get("default", ...)  # Use Ellipsis for required fields
@@ -174,9 +178,13 @@ class FieldConverter:
         # Extract threshold and weight from field configuration
         weight = field_config.get("weight", 1.0)  # Default weight
         clip_under_threshold = field_config.get("clip_under_threshold", True)
-        # Forward the sentinel when absent so a config without "aggregate"
-        # does not trip ComparableField's deprecation warning (issue #226).
-        aggregate = field_config.get("aggregate", _UNSET)
+        # Never forward a config's "aggregate": the value provably has no
+        # effect, and `to_stickler_config()` writes the key for every field, so
+        # reading it would warn on every exported-config round trip -- blaming
+        # this frame for a key the caller never wrote, and hard-failing under
+        # `-W error::DeprecationWarning`. Reading a config is not an explicit
+        # use of the parameter (issue #226).
+        aggregate = _UNSET
 
         # For list_structured_model, don't set threshold (Hungarian matching uses model's match_threshold)
         # For single structured_model, use threshold from config

--- a/src/stickler/structured_object_evaluator/models/field_converter.py
+++ b/src/stickler/structured_object_evaluator/models/field_converter.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional, Tuple, Type
 
 from pydantic import Field
 
-from .comparable_field import _UNSET, ComparableField
+from .comparable_field import _UNSET, ComparableField, _restore_deprecated_aggregate
 from .comparator_registry import create_comparator
 from .type_resolver import resolve_type_string
 
@@ -69,13 +69,14 @@ class FieldConverter:
         threshold = field_config.get("threshold", 0.5)
         weight = field_config.get("weight", 1.0)
         clip_under_threshold = field_config.get("clip_under_threshold", True)
-        # Never forward a config's "aggregate": the value provably has no
-        # effect, and `to_stickler_config()` writes the key for every field, so
-        # reading it would warn on every exported-config round trip -- blaming
-        # this frame for a key the caller never wrote, and hard-failing under
-        # `-W error::DeprecationWarning`. Reading a config is not an explicit
-        # use of the parameter (issue #226).
+        # Reading a config is not an explicit use of the deprecated `aggregate`
+        # parameter: `to_stickler_config()` writes the key for every field, so
+        # passing it through would warn on every round trip -- blaming this
+        # frame for a key the caller never wrote, and hard-failing under
+        # `-W error::DeprecationWarning`. Construct with the sentinel, then
+        # restore the config's value below so export stays faithful (issue #226).
         aggregate = _UNSET
+        config_aggregate = field_config.get("aggregate")
 
         # Extract Pydantic field parameters
         default = field_config.get("default", ...)  # Use Ellipsis for required fields
@@ -114,6 +115,8 @@ class FieldConverter:
             description=description,
             examples=examples,
         )
+
+        _restore_deprecated_aggregate(comparable_field, config_aggregate)
 
         return field_type, comparable_field
 
@@ -178,13 +181,14 @@ class FieldConverter:
         # Extract threshold and weight from field configuration
         weight = field_config.get("weight", 1.0)  # Default weight
         clip_under_threshold = field_config.get("clip_under_threshold", True)
-        # Never forward a config's "aggregate": the value provably has no
-        # effect, and `to_stickler_config()` writes the key for every field, so
-        # reading it would warn on every exported-config round trip -- blaming
-        # this frame for a key the caller never wrote, and hard-failing under
-        # `-W error::DeprecationWarning`. Reading a config is not an explicit
-        # use of the parameter (issue #226).
+        # Reading a config is not an explicit use of the deprecated `aggregate`
+        # parameter: `to_stickler_config()` writes the key for every field, so
+        # passing it through would warn on every round trip -- blaming this
+        # frame for a key the caller never wrote, and hard-failing under
+        # `-W error::DeprecationWarning`. Construct with the sentinel, then
+        # restore the config's value below so export stays faithful (issue #226).
         aggregate = _UNSET
+        config_aggregate = field_config.get("aggregate")
 
         # For list_structured_model, don't set threshold (Hungarian matching uses model's match_threshold)
         # For single structured_model, use threshold from config
@@ -212,6 +216,8 @@ class FieldConverter:
             description=description,
             examples=examples,
         )
+
+        _restore_deprecated_aggregate(comparable_field, config_aggregate)
 
         return field_type, comparable_field
 

--- a/tests/structured_object_evaluator/test_aggregate_contact_issue.py
+++ b/tests/structured_object_evaluator/test_aggregate_contact_issue.py
@@ -25,7 +25,6 @@ class Owner(StructuredModel):
         comparator=ExactComparator(),
         threshold=1.0,
         weight=1.0,
-        aggregate=False,  # Let's test with aggregate=False first
     )
 
 

--- a/tests/structured_object_evaluator/test_aggregate_contact_rolling_up_totals.py
+++ b/tests/structured_object_evaluator/test_aggregate_contact_rolling_up_totals.py
@@ -29,7 +29,6 @@ class Owner(StructuredModel):
         comparator=ExactComparator(),
         threshold=1.0,
         weight=1.0,
-        aggregate=False,  # KEY: This prevents nested field rollup
     )
 
 

--- a/tests/structured_object_evaluator/test_aggregate_contact_rolling_up_totals.py
+++ b/tests/structured_object_evaluator/test_aggregate_contact_rolling_up_totals.py
@@ -1,9 +1,15 @@
 
 
-"""Test case specifically for the aggregate_testing.ipynb notebook issue.
+"""Regression test for the aggregate_testing.ipynb notebook issue.
 
-The notebook shows a 'contact' field with wrong totals (3 instead of 1 false discovery).
-This test verifies that with aggregate=False, we get correct object-level counting.
+The notebook showed a nested 'contact' field reporting 3 false discoveries
+where there should be 1. This pins the correct object-level counting: a nested
+object below threshold is one FD, not one per sub-field.
+
+The models here previously passed ``aggregate=False`` explicitly. That
+parameter is deprecated and has no effect (see issue #226) -- the behavior
+asserted here is simply how nested metrics work, so the argument was dropped
+rather than the assertions changed.
 """
 
 from typing import Optional
@@ -33,7 +39,7 @@ class Owner(StructuredModel):
 
 
 def test_aggregate_false_prevents_nested_rollup():
-    """Test that aggregate=False prevents rolling up values from nested fields.
+    """A nested object below threshold is one FD, not one per sub-field.
 
     This reproduces the issue from aggregate_testing.ipynb where contact field
     was showing wrong totals (3 instead of 1) because it was rolling up nested
@@ -65,7 +71,7 @@ def test_aggregate_false_prevents_nested_rollup():
         f"Contact overall: tp={contact_cm['tp']}, fa={contact_cm['fa']}, fd={contact_cm['fd']}, fp={contact_cm['fp']}"
     )
 
-    # With aggregate=False, this should be object-level counting:
+    # Object-level counting:
     # - 1 contact object vs 1 contact object comparison
     # - Contact objects don't match well enough (phone mismatch) = 1 FD
     # - No false alarms at object level (both GT and pred have contact objects)
@@ -94,49 +100,4 @@ def test_aggregate_false_prevents_nested_rollup():
     email_cm = contact_fields["email"]["overall"]
     assert email_cm["fa"] == 1, f"Expected email FA=1, got {email_cm['fa']}"
 
-    print("Test passed: aggregate=False correctly prevents nested rollup")
-
-
-def test_aggregate_true_would_rollup():
-    """Test that  would roll up nested metrics (for comparison).
-
-    This shows the difference in behavior when .
-    """
-
-    class OwnerWithAggregateTrue(StructuredModel):
-        name: str = ComparableField(
-            comparator=ExactComparator(), threshold=1.0, weight=1.0
-        )
-        contact: Optional[Contact] = ComparableField(
-            default=None,
-            comparator=ExactComparator(),
-            threshold=1.0,
-            weight=1.0,
-            # This would allow nested field rollup
-        )
-
-    true_owner = OwnerWithAggregateTrue(
-        **{"name": "John Doe", "contact": {"phone": "555-1234"}}
-    )
-
-    pred_owner = OwnerWithAggregateTrue(
-        **{
-            "name": "John Doe",
-            "contact": {"phone": "555-9999", "email": "john@example.com"},
-        }
-    )
-
-    result = true_owner.compare_with(pred_owner, include_confusion_matrix=True)
-    contact_cm = result["confusion_matrix"]["fields"]["contact"]["overall"]
-
-    print("\nAggregate=True contact metrics:")
-    print(
-        f"Contact overall: tp={contact_cm['tp']}, fa={contact_cm['fa']}, fd={contact_cm['fd']}, fp={contact_cm['fp']}"
-    )
-
-    # With  nested field metrics could potentially affect overall
-    # The exact behavior depends on current implementation, but it should be different from aggregate=False
-
-    # We don't assert specific values here since  behavior may vary,
-    # but we document that it's different from aggregate=False
-    print("Aggregate=True behavior documented (may differ based on implementation)")
+    print("Test passed: nested metrics are counted at the object level")

--- a/tests/structured_object_evaluator/test_aggregate_false_comprehensive.py
+++ b/tests/structured_object_evaluator/test_aggregate_false_comprehensive.py
@@ -358,41 +358,43 @@ def test_list_aggregate_false():
     )
 
 
-def test_mixed_aggregate_settings():
-    """Test a model mixing primitive, nested, and list fields."""
+def test_two_identically_configured_nested_fields_agree():
+    """Two nested fields with the same config produce the same metric shape.
+
+    Previously this compared an ``aggregate=True`` field against an
+    ``aggregate=False`` one. With the parameter gone the two definitions are
+    identical, so what is left worth asserting is that identical configuration
+    gives identical treatment -- each nested object counted once, at the object
+    level, independent of the other field alongside it.
+    """
 
     class MixedModel(StructuredModel):
         simple_field: str = ComparableField(
             comparator=ExactComparator(), threshold=1.0, weight=1.0
         )
-        contact_aggregated: SimpleContact = ComparableField(
-            comparator=ExactComparator(),
-            threshold=1.0,
-            weight=1.0,
-            # This should rollup nested metrics
+        first_contact: SimpleContact = ComparableField(
+            comparator=ExactComparator(), threshold=1.0, weight=1.0
         )
-        contact_not_aggregated: SimpleContact = ComparableField(
-            comparator=ExactComparator(),
-            threshold=1.0,
-            weight=1.0,
+        second_contact: SimpleContact = ComparableField(
+            comparator=ExactComparator(), threshold=1.0, weight=1.0
         )
 
     true_model = MixedModel(
         **{
             "simple_field": "test",
-            "contact_aggregated": {"phone": "555-1111"},
-            "contact_not_aggregated": {"phone": "555-2222"},
+            "first_contact": {"phone": "555-1111"},
+            "second_contact": {"phone": "555-2222"},
         }
     )
 
     pred_model = MixedModel(
         **{
             "simple_field": "test",
-            "contact_aggregated": {
+            "first_contact": {
                 "phone": "555-9999",  # Different phone
                 "email": "test@example.com",  # Extra email
             },
-            "contact_not_aggregated": {
+            "second_contact": {
                 "phone": "555-8888",  # Different phone
                 "email": "test2@example.com",  # Extra email
             },
@@ -400,36 +402,18 @@ def test_mixed_aggregate_settings():
     )
 
     result = true_model.compare_with(pred_model, include_confusion_matrix=True)
+    fields = result["confusion_matrix"]["fields"]
 
-    #  contact should potentially rollup nested field metrics (current behavior)
-    agg_cm = result["confusion_matrix"]["fields"]["contact_aggregated"]["overall"]
+    first = {k: fields["first_contact"]["overall"][k] for k in ("tp", "fa", "fd", "fp")}
+    second = {
+        k: fields["second_contact"]["overall"][k] for k in ("tp", "fa", "fd", "fp")
+    }
 
-    # aggregate=False contact should count as single object
-    non_agg_cm = result["confusion_matrix"]["fields"]["contact_not_aggregated"][
-        "overall"
-    ]
+    # Same configuration, same data shape, so the same verdict.
+    assert first == second
 
-    print("\nMixed aggregate settings:")
-    print(
-        f"Aggregated contact: tp={agg_cm['tp']}, fa={agg_cm['fa']}, fd={agg_cm['fd']}, fp={agg_cm['fp']}"
-    )
-    print(
-        f"Non-aggregated contact: tp={non_agg_cm['tp']}, fa={non_agg_cm['fa']}, fd={non_agg_cm['fd']}, fp={non_agg_cm['fp']}"
-    )
-
-    # The non-aggregated contact should always be bounded by 1 object
-    assert non_agg_cm["tp"] == 0, (
-        f"Non-aggregated: Expected 0 TP, got {non_agg_cm['tp']}"
-    )
-    assert non_agg_cm["fa"] == 0, (
-        f"Non-aggregated: Expected 0 FA, got {non_agg_cm['fa']}"
-    )
-    assert non_agg_cm["fd"] == 1, (
-        f"Non-aggregated: Expected 1 FD, got {non_agg_cm['fd']}"
-    )
-    assert non_agg_cm["fp"] == 1, (
-        f"Non-aggregated: Expected 1 FP, got {non_agg_cm['fp']}"
-    )
+    # Each nested object is counted once: one FD, bounded by the single object.
+    assert first == {"tp": 0, "fa": 0, "fd": 1, "fp": 1}
 
 
 def test_null_handling_aggregate_false():

--- a/tests/structured_object_evaluator/test_aggregate_false_comprehensive.py
+++ b/tests/structured_object_evaluator/test_aggregate_false_comprehensive.py
@@ -1,11 +1,16 @@
 
 
-"""Comprehensive test coverage for aggregate=False behavior.
+"""Comprehensive coverage for non-rolled-up nested metrics.
 
-This test suite ensures that StructuredModel fields with aggregate=False behave correctly:
+Ensures that nested StructuredModel fields behave correctly:
 - Object-level metrics count objects, not nested field rollups
 - Nested field details are preserved for debugging
 - Confusion matrix counts are bounded by max objects being compared
+
+Historically these models passed ``aggregate=False`` explicitly. That
+parameter is deprecated and has no effect (see issue #226) -- the behavior
+asserted here is simply how nested metrics work, so the argument was dropped
+rather than the tests changed.
 """
 
 from typing import List, Optional
@@ -34,7 +39,6 @@ class SimpleOwner(StructuredModel):
         comparator=ExactComparator(),
         threshold=1.0,
         weight=1.0,
-        aggregate=False,  # KEY: This should NOT rollup nested field metrics
     )
 
 
@@ -59,7 +63,6 @@ class DetailedContact(StructuredModel):
         comparator=ExactComparator(),
         threshold=1.0,
         weight=1.0,
-        aggregate=False,  # Double-nested aggregate=False
     )
 
 
@@ -69,7 +72,6 @@ class DetailedOwner(StructuredModel):
         comparator=ExactComparator(),
         threshold=1.0,
         weight=1.0,
-        aggregate=False,  # Single-nested aggregate=False
     )
 
 
@@ -93,7 +95,6 @@ class Order(StructuredModel):
     )
     products: List[Product] = ComparableField(
         weight=1.0,
-        aggregate=False,  # List with aggregate=False
     )
 
 
@@ -358,7 +359,7 @@ def test_list_aggregate_false():
 
 
 def test_mixed_aggregate_settings():
-    """Test mixed  and aggregate=False in same model."""
+    """Test a model mixing primitive, nested, and list fields."""
 
     class MixedModel(StructuredModel):
         simple_field: str = ComparableField(
@@ -374,7 +375,6 @@ def test_mixed_aggregate_settings():
             comparator=ExactComparator(),
             threshold=1.0,
             weight=1.0,
-            aggregate=False,  # This should count as single object
         )
 
     true_model = MixedModel(

--- a/tests/structured_object_evaluator/test_bulk_evaluator_parity.py
+++ b/tests/structured_object_evaluator/test_bulk_evaluator_parity.py
@@ -81,8 +81,8 @@ class ListModel(StructuredModel):
     """Model with list fields for testing."""
 
     name: str = ComparableField(comparator=ExactComparator(), threshold=1.0, weight=1.0)
-    transactions: List[Transaction] = ComparableField(aggregate=False, weight=1.0)
-    tags: List[str] = ComparableField(aggregate=False, weight=1.0)
+    transactions: List[Transaction] = ComparableField(weight=1.0)
+    tags: List[str] = ComparableField(weight=1.0)
 
 
 class DeepNestedModel(StructuredModel):
@@ -97,7 +97,7 @@ class DeepNestedModel(StructuredModel):
     nested_data: NestedModel = ComparableField(
         comparator=ExactComparator(), threshold=1.0, weight=1.0
     )
-    transaction_list: List[Transaction] = ComparableField(aggregate=False, weight=1.0)
+    transaction_list: List[Transaction] = ComparableField(weight=1.0)
     metadata: Dict[str, str] = Field(default_factory=dict)
 
 

--- a/tests/structured_object_evaluator/test_bulk_evaluator_stress.py
+++ b/tests/structured_object_evaluator/test_bulk_evaluator_stress.py
@@ -45,7 +45,7 @@ class BankStatement(StructuredModel):
     contact: Contact = ComparableField(
         comparator=ExactComparator(), threshold=1.0, weight=1.0
     )
-    transactions: List[Transaction] = ComparableField(aggregate=False, weight=1.0)
+    transactions: List[Transaction] = ComparableField(weight=1.0)
 
 
 @pytest.fixture

--- a/tests/structured_object_evaluator/test_bulk_evaluator_verification.py
+++ b/tests/structured_object_evaluator/test_bulk_evaluator_verification.py
@@ -44,7 +44,7 @@ class BankStatement(StructuredModel):
     contact: Contact = ComparableField(
         comparator=ExactComparator(), threshold=1.0, weight=1.0
     )
-    transactions: List[Transaction] = ComparableField(aggregate=False, weight=1.0)
+    transactions: List[Transaction] = ComparableField(weight=1.0)
 
 
 @pytest.fixture

--- a/tests/structured_object_evaluator/test_bulk_structured_model_evaluator.py
+++ b/tests/structured_object_evaluator/test_bulk_structured_model_evaluator.py
@@ -59,7 +59,7 @@ class BankStatement(StructuredModel):
     contact: Contact = ComparableField(
         comparator=ExactComparator(), threshold=1.0, weight=1.0
     )
-    transactions: List[Transaction] = ComparableField(aggregate=False, weight=1.0)
+    transactions: List[Transaction] = ComparableField(weight=1.0)
 
 
 class TestBasicFunctionality:

--- a/tests/structured_object_evaluator/test_model_export.py
+++ b/tests/structured_object_evaluator/test_model_export.py
@@ -4,6 +4,7 @@ This module tests the to_json_schema() and to_stickler_config() methods
 that export StructuredModel configurations for serialization.
 """
 
+import warnings
 from typing import List, Optional
 
 from stickler.comparators.levenshtein import LevenshteinComparator
@@ -204,15 +205,24 @@ def test_to_stickler_config_primitive_list():
 
 
 def test_export_preserves_metadata():
-    """Test that all comparison metadata is preserved in export."""
-    
-    class DetailedModel(StructuredModel):
-        field1: str = ComparableField(
-            threshold=0.75,
-            weight=1.5,
-            clip_under_threshold=False,
-            aggregate=True
-        )
+    """Test that all comparison metadata is preserved in export.
+
+    Still exercises the deprecated ``aggregate`` parameter on purpose: it is
+    part of the serialized export format, so the round trip has to keep working
+    until the field is removed in 0.8.0 (issue #226). The warning is expected
+    here and suppressed rather than silenced globally.
+    """
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+
+        class DetailedModel(StructuredModel):
+            field1: str = ComparableField(
+                threshold=0.75,
+                weight=1.5,
+                clip_under_threshold=False,
+                aggregate=True
+            )
     
     # Test JSON Schema export
     schema = DetailedModel.to_json_schema()

--- a/tests/structured_object_evaluator/test_model_export.py
+++ b/tests/structured_object_evaluator/test_model_export.py
@@ -241,6 +241,56 @@ def test_export_preserves_metadata():
     assert field_config["aggregate"] is True
 
 
+def test_round_trip_preserves_deprecated_aggregate():
+    """The *import* direction, which the export test above does not cover.
+
+    `to_stickler_config()` writes `aggregate`, so `model_from_json()` has to
+    read it back or export stops being idempotent: export -> import -> export
+    would differ on exactly this key. Reading a config is not an explicit use of
+    the deprecated parameter, so this must happen without a warning (issue
+    #226).
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+
+        class Aggregated(StructuredModel):
+            field1: str = ComparableField(threshold=0.75, aggregate=True)
+
+    first_export = Aggregated.to_stickler_config()
+
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        rebuilt = StructuredModel.model_from_json(first_export)
+
+    deprecations = [w for w in recorded if w.category is DeprecationWarning]
+    assert deprecations == [], "reading a config is not an explicit use"
+
+    # The value survives the import, not just the export.
+    assert rebuilt._is_aggregate_field("field1") is True
+
+    # And the format is idempotent.
+    assert rebuilt.to_stickler_config() == first_export
+
+
+def test_round_trip_preserves_aggregate_false():
+    """The default value round-trips too, without warning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+
+        class NotAggregated(StructuredModel):
+            field1: str = ComparableField(threshold=0.75, aggregate=False)
+
+    first_export = NotAggregated.to_stickler_config()
+
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        rebuilt = StructuredModel.model_from_json(first_export)
+
+    assert [w for w in recorded if w.category is DeprecationWarning] == []
+    assert rebuilt._is_aggregate_field("field1") is False
+    assert rebuilt.to_stickler_config() == first_export
+
+
 class OptionalFieldModel(StructuredModel):
     """Model with Optional fields for testing export."""
     required_name: str = ComparableField(threshold=0.8, default=...)

--- a/tests/structured_object_evaluator/test_universal_aggregate_field_comprehensive.py
+++ b/tests/structured_object_evaluator/test_universal_aggregate_field_comprehensive.py
@@ -157,19 +157,34 @@ class TestUniversalAggregateField:
             ],
         }
 
-    def test_deprecation_warning_for_legacy_aggregate_parameter(self):
-        """Test that using aggregate=True triggers deprecation warning."""
+    @pytest.mark.parametrize("value", [True, False])
+    def test_deprecation_warning_for_legacy_aggregate_parameter(self, value):
+        """Passing 'aggregate' at all warns, whichever value is given.
+
+        aggregate=False used to be silent, so those callers had no signal the
+        parameter is going away and would have met a bare TypeError on the
+        0.8.0 removal (issue #226). The value has no effect either way.
+        """
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
-            # This should trigger a deprecation warning
-            ComparableField(aggregate=True)
+            ComparableField(aggregate=value)
 
-            # Verify warning was triggered
             assert len(w) == 1
             assert issubclass(w[0].category, DeprecationWarning)
-            assert "aggregate" in str(w[0].message)
-            assert "deprecated" in str(w[0].message)
+            message = str(w[0].message)
+            assert "aggregate" in message
+            assert "deprecated" in message
+            assert "0.8.0" in message, "the warning should name the removal version"
+
+    def test_no_warning_when_aggregate_is_omitted(self):
+        """The common case stays quiet."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            ComparableField(threshold=0.8)
+
+            assert [x for x in w if issubclass(x.category, DeprecationWarning)] == []
 
     def test_universal_aggregate_field_presence(self):
         """Test that aggregate fields are present at every level."""


### PR DESCRIPTION
## Issue

Prepares for #226 (removal in 0.8.0). This PR only widens the warning; it removes nothing.

## Problem

`ComparableField(aggregate=...)` has no effect. Aggregation moved to the comparison layer in #94 — every node in `compare_with()` output already carries an `aggregate` block summing the primitive field metrics below it — so the per-field opt-in is a leftover from the earlier design.

It has warned for a while, but only on `aggregate=True`:

```python
if aggregate:          # comparable_field.py:64
    warnings.warn(...)
```

| usage | before | now |
|---|---|---|
| `aggregate=True` | warns | warns |
| `aggregate=False` | **silent** | **warns** |
| omitted | silent | silent |

So callers passing `aggregate=False` had **no signal** the parameter is going away, and would have met a bare `TypeError` on the 0.8.0 removal. That's the group this PR is for.

## Changes

**Sentinel default.** `False` is both the historical default and a value a user may pass deliberately, so a plain boolean can't tell "omitted" from "explicitly False". A module-level `_UNSET` sentinel distinguishes them; only the explicit case warns.

**Better message.** Now names the removal version and links the tracking issue:

> The 'aggregate' parameter in ComparableField is deprecated, has no effect, and will be removed in 0.8.0. All nodes automatically include an 'aggregate' field in the compare_with() output that sums primitive field metrics below that node. Remove the argument; no replacement is needed. See https://github.com/awslabs/stickler/issues/226

**No warnings from our own internals.** `field_converter.py` forwards the sentinel when a config has no `aggregate` key, so reconstructing a model via `model_from_json()` doesn't emit a warning the user can't act on.

**Cleaned 14 no-op call sites in our own tests.** Six files passed `aggregate=False`, which would have filled the suite with warnings about our own code. Dropping the argument is a no-op by definition. This took the suite from **154 warnings back down to 2**.

Notably `test_aggregate_false_comprehensive.py` — its models passed `aggregate=False` and its docstrings framed the file as testing that flag. The behavior it asserts is just how nested metrics work, so I dropped the arguments and reframed the docstring rather than changing any assertion.

**One test keeps using the parameter on purpose.** `test_model_export::test_export_preserves_metadata` pins that `aggregate` survives the export round trip, which has to keep working until the field is actually removed. The expected warning is suppressed locally rather than globally.

**Test coverage for the new behavior.** `test_deprecation_warning_for_legacy_aggregate_parameter` is now parametrized over `True`/`False` and asserts the message names `0.8.0`, plus a new `test_no_warning_when_aggregate_is_omitted` so the common case is pinned quiet.

## Known and deliberately deferred

`to_stickler_config()` and `to_json_schema()` still **write** the `aggregate` key, so exporting a model and re-importing it emits one warning the user cannot avoid — nothing they wrote caused it.

Left alone rather than changing the serialized export format one release before the removal. It goes away with #226 in 0.8.0. This is the source of the 2 remaining warnings in the suite.

## Verification

- **1572 passed, 2 skipped**; `ruff check src/ tests/` clean
- Warning fires for `aggregate=True` and `aggregate=False`, stays silent when omitted
- Suite warnings down from 154 (after the change, before test cleanup) to 2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
