### PR TITLE
docs: publish _compare docstrings and repair the docs build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,23 @@ Each release links to full notes on the
   before any comparator runs
   ([#200](https://github.com/awslabs/stickler/issues/200))
 
+- Restore per-comparator method documentation on the published API reference.
+  mkdocstrings hides single-underscore members by default, so moving the
+  extension point to `_compare()` dropped every comparator's `Args`, `Returns`
+  and `Raises` detail from the site, leaving only the base class. The
+  comparator page now renders all 12 `_compare` entries again
+  ([#228](https://github.com/awslabs/stickler/issues/228))
+
+- Fix the documentation build, which failed on `mkdocs build` with
+  `Could not collect 'stickler.comparators.BERTComparator'`. `BERTComparator`
+  and `LLMComparator` are exposed lazily through the package `__getattr__` so
+  that `import stickler` does not pull `torch`/`transformers` or
+  `strands`/`boto3`; griffe resolves identifiers statically and cannot see a
+  name that exists only at attribute-access time. The API reference now
+  addresses both by their defining module. This broke the docs deploy for any
+  push to `main` touching `src/` or `docs/`
+  ([#228](https://github.com/awslabs/stickler/issues/228))
+
 ### Changed
 
 - **Breaking:** the peripheral modules now require their extra. `pandas`,

--- a/docs/docs/API-Reference/comparators.md
+++ b/docs/docs/API-Reference/comparators.md
@@ -33,7 +33,12 @@
     options:
       heading_level: 2
 
-::: stickler.comparators.BERTComparator
+<!-- BERTComparator and LLMComparator are addressed by their defining module
+     rather than through the package. Both are exposed lazily via the package
+     __getattr__ so that importing stickler does not pull torch/transformers or
+     strands/boto3, and griffe resolves identifiers statically, so it cannot
+     see a name that only exists at attribute-access time. -->
+::: stickler.comparators.bert.BERTComparator
     options:
       heading_level: 2
 
@@ -41,7 +46,7 @@
     options:
       heading_level: 2
 
-::: stickler.comparators.LLMComparator
+::: stickler.comparators.llm.LLMComparator
     options:
       heading_level: 2
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -62,6 +62,11 @@ plugins:
               docstring_style: google
               show_root_heading: true
               show_source: true
+              # mkdocstrings hides single-underscore members by default, which
+              # would drop every comparator's `_compare` -- the method whose
+              # docstring carries the per-comparator Args, Returns and Raises.
+              # Keep the default exclusion and re-admit that one name.
+              filters: ["!^_[^_]", "^_compare$"]
 
 extra_javascript:
   # Workaround for site_url breaking mermaid rendering; see the following for more info:

--- a/src/stickler/comparators/llm.py
+++ b/src/stickler/comparators/llm.py
@@ -211,7 +211,6 @@ class LLMComparator(BaseComparator):
                 - 0.0 if an error occurs during comparison
 
         Note:
-            - None values: Returns 1.0 if both are None, 0.0 if only one is None
             - Error handling: Returns 0.0 for any exceptions during LLM calls
             - Cost consideration: Each call incurs API costs and latency
 
@@ -221,8 +220,6 @@ class LLMComparator(BaseComparator):
             1.0
             >>> comparator.compare("apple", "orange")
             0.0
-            >>> comparator.compare(None, None)
-            1.0
         """
         # Format the prompt with your values
         formatted_prompt = self.prompt_template.render(


### PR DESCRIPTION
# Pull Request

## Issue Reference
Closes #228

## Description of Changes

Two documentation defects, both found while reviewing #209. Docs and docstrings only, no behavior change.

### 1. `_compare` docstrings stopped being published

The `compare()` → `_compare()` rename moved every comparator's behavior docstring onto a single-underscore method. mkdocstrings excludes those by default (`_DEFAULT_FILTERS = ["!^_[^_]"]`), so the per-comparator `Args`, `Returns` and `Raises` detail silently stopped reaching the site.

Measured by building the comparator API reference and counting anchors:

| | `compare` entries |
|---|---|
| before the rename | 8 |
| after the rename | 1 (`BaseComparator.compare` only) |
| this PR | 12 |

Fix is one line in `docs/mkdocs.yml`, keeping the default exclusion and re-admitting the single name so nothing else private leaks in:

```yaml
filters: ["!^_[^_]", "^_compare$"]
```

#228 raised promoting the semantics into the **class** docstrings as an alternative. I went with the filter after reading both. The class docstrings already carry the configuration matrix and are substantial (`DateComparator` is 34 lines, `BBoxIoUComparator` 27); what `_compare` holds is per-call signature reference, including Levenshtein's `TypeError` on dict input. That belongs on the method, and `DateComparator._compare` is a one-line pointer to the class docs, so there is nothing to promote.

### 2. The docs build was already broken on `dev`

Found while verifying the above. `mkdocs build` fails outright:

```
ERROR - Could not collect 'stickler.comparators.BERTComparator'
Aborted with a BuildError!
```

`BERTComparator` and `LLMComparator` are exposed lazily through the package `__getattr__` so `import stickler` does not pull `torch`/`transformers` or `strands`/`boto3`. griffe resolves identifiers statically, so it cannot see a name that exists only at attribute-access time. The API reference now addresses both by their defining module.

Not caused by #209. Confirmed present on `origin/dev` and absent on `origin/main`, so it arrived with the lazy-import work in #187/#201 and would have failed the next docs deploy from `main`. `.github/workflows/docs.yml` runs `mkdocs gh-deploy --force` on any push to `main` touching `src/` or `docs/`, so this was a release blocker for 0.7.0.

One consequence worth noting: the anchors for these two become `stickler.comparators.bert.BERTComparator` rather than `stickler.comparators.BERTComparator`, so any existing deep link to them breaks. `preload_modules` does not avoid this, since the name still is not statically resolvable on the package. The other ten are unchanged.

### 3. Stale `None` note on `LLMComparator._compare`

Dropped the `None` note and the `compare(None, None)` example. Both are true of the public `compare()` but misfiled on the method whose contract is that it never receives `None`, and it was the last docstring still telling an implementer to think about `None` inside `_compare`.

## Testing

Docs verified in the CI environment exactly (`uv sync --group docs --frozen`, matching `.github/workflows/docs.yml`):

- `mkdocs build` clean, no errors
- 12 `_compare` entries render
- spot-checked the rendered HTML for content that exists nowhere else: `DateComparator`'s tier system, `BBoxIoUComparator`'s IoU semantics, `NumericComparator`'s tolerance behavior, and `LevenshteinComparator`'s dict `TypeError` under `Raises`
- confirmed the removed `None` note does not appear in the output

Suite: **1632 passed, 10 skipped**. `ruff check src/ tests/` clean.

## Reviewers
@vawsgit — both findings are yours from the #209 review.

## Checklist
- [x] Code follows the project's coding standards
- [x] Self-review of code completed
- [x] Documentation updated (if applicable)
- [ ] Tests added/updated for new functionality (docs-only change)
- [x] All existing tests pass
- [x] Ready for review
