### PR TITLE
feat(thresholds): warn when a threshold is exactly 0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,14 @@ Each release links to full notes on the
   and the numbers look ideal, which makes it the hardest misconfiguration to
   notice.
 
-  The warning claims precision only. Recall survives unmatched extras, since
-  an unpaired ground-truth item is still an FN: 2 ground-truth objects against
-  1 prediction at `match_threshold=0.0` gives precision `1.0` but recall
-  `0.5`. For a `match_threshold` the message is also conditional, because the
+  The warning names what is invariant -- no false discovery can be reported,
+  since FD means "compared and scored below threshold" and nothing scores below
+  `0.0` -- rather than claiming a metric outcome. Perfect precision and perfect
+  recall are both false in reachable cases, symmetrically: an unmatched
+  prediction is still an FA (2 ground-truth objects vs 3 predictions gives
+  precision `0.667`) and an unmatched ground-truth item is still an FN (2 vs 1
+  gives recall `0.5`), because unmatched items are not subject to any
+  threshold. For a `match_threshold` the message is also conditional, since the
   value is only read when the model is compared as a `List[StructuredModel]`
   element and is inert otherwise.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ Each release links to full notes on the
 
 ### Added
 
+- A `UserWarning` when a field `threshold` or a model `match_threshold` is set
+  to exactly `0.0`. The threshold test is `>=`, so `0.0` is satisfied by every
+  score including `0.0` itself: every compared pair counts as a true positive
+  and a wholly incorrect prediction reports perfect precision, recall, F1 and
+  accuracy. Nothing errors and the numbers look ideal, which makes it the
+  hardest misconfiguration to notice.
+
+  Only exactly `0.0` warns. `0.01` already classifies correctly, so this is a
+  single misbehaving value rather than a "low thresholds are risky" heuristic.
+  The warning names the site, suggests a small positive value, and links to the
+  threshold documentation. It fires once per configured site, so a bulk run
+  does not emit one per document.
+
+  Covers hand-written classes and config-driven models, including
+  `match_threshold` supplied through `model_from_json()`, which the factory
+  assigns after class creation. Stickler's own internal use of
+  `match_threshold=0.0` as a capture-all sentinel does not warn
+  ([#234](https://github.com/awslabs/stickler/issues/234))
+
 - Support for Python 3.10 and 3.11, and testing through 3.14. `requires-python`
   moves from `>=3.12` to `>=3.10`, with trove classifiers for 3.10-3.14 and a
   CI matrix covering every version claimed, so the floor is enforced rather

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,17 @@ Each release links to full notes on the
 
 - A `UserWarning` when a field `threshold` or a model `match_threshold` is set
   to exactly `0.0`. The threshold test is `>=`, so `0.0` is satisfied by every
-  score including `0.0` itself: every compared pair counts as a true positive
-  and a wholly incorrect prediction reports perfect precision, recall, F1 and
-  accuracy. Nothing errors and the numbers look ideal, which makes it the
-  hardest misconfiguration to notice.
+  score including `0.0` itself: every compared pair counts as a true positive,
+  and a wholly incorrect prediction reports perfect precision. Nothing errors
+  and the numbers look ideal, which makes it the hardest misconfiguration to
+  notice.
+
+  The warning claims precision only. Recall survives unmatched extras, since
+  an unpaired ground-truth item is still an FN: 2 ground-truth objects against
+  1 prediction at `match_threshold=0.0` gives precision `1.0` but recall
+  `0.5`. For a `match_threshold` the message is also conditional, because the
+  value is only read when the model is compared as a `List[StructuredModel]`
+  element and is inert otherwise.
 
   Only exactly `0.0` warns. `0.01` already classifies correctly, so this is a
   single misbehaving value rather than a "low thresholds are risky" heuristic.

--- a/src/stickler/structured_object_evaluator/models/model_factory.py
+++ b/src/stickler/structured_object_evaluator/models/model_factory.py
@@ -14,30 +14,7 @@ from .field_converter import (
     get_global_converter,
     validate_fields_config,
 )
-from .threshold_helper import warn_if_threshold_is_zero
-
-
-def _config_identity(model_name: str, field_definitions: Dict[str, Any]) -> str:
-    """Name a dynamically built model in a way that distinguishes configs.
-
-    Dynamically built models share the default name ``"DynamicModel"``, so the
-    name alone identifies nothing: two different configs produce byte-identical
-    warning text. That matters twice over. It is unhelpful to a reader, and
-    Python's own ``__warningregistry__`` is keyed on the message, so identical
-    text means the interpreter prints only the first one under the default
-    "once per location" action -- silently swallowing the second
-    misconfiguration even though ``warn_once`` approved it.
-
-    Object identity would distinguish them but is unstable: every call builds a
-    new class, so repeated loads of one config would each warn (measured: 200
-    loads, 192 warnings) and grow the process-global ``_warned`` set without
-    bound. Field names are stable across loads of one config and differ between
-    configs, so they serve for both the message and the dedup key.
-    """
-    fields = ",".join(sorted(field_definitions))
-    if model_name != "DynamicModel":
-        return model_name
-    return f"{model_name}(fields: {fields})" if fields else model_name
+from .threshold_helper import model_identity, warn_if_threshold_is_zero
 
 
 class ModelFactory:
@@ -202,7 +179,7 @@ class ModelFactory:
         # stable across repeated loads of one config and differ between configs.
         warn_if_threshold_is_zero(
             match_threshold,
-            _config_identity(model_name, field_definitions),
+            model_identity(model_name, field_definitions),
             "match_threshold",
         )
 
@@ -332,7 +309,7 @@ class ModelFactory:
         # stable across repeated loads of one config and differ between configs.
         warn_if_threshold_is_zero(
             match_threshold,
-            _config_identity(model_name, field_definitions),
+            model_identity(model_name, field_definitions),
             "match_threshold",
         )
 

--- a/src/stickler/structured_object_evaluator/models/model_factory.py
+++ b/src/stickler/structured_object_evaluator/models/model_factory.py
@@ -14,6 +14,7 @@ from .field_converter import (
     get_global_converter,
     validate_fields_config,
 )
+from .threshold_helper import warn_if_threshold_is_zero
 
 
 class ModelFactory:
@@ -164,8 +165,11 @@ class ModelFactory:
         except Exception as e:
             raise ValueError(f"Error creating dynamic model: {e}")
 
-        # Set class-level attributes
+        # Set class-level attributes. Assigned after create_model, so
+        # StructuredModel.__init_subclass__ has already run and cannot see it --
+        # check here too or a config-driven match_threshold=0.0 warns nowhere.
         DynamicClass.match_threshold = match_threshold
+        warn_if_threshold_is_zero(match_threshold, model_name, "match_threshold")
 
         # Add configuration metadata for debugging/introspection
         DynamicClass._model_config = config
@@ -279,8 +283,11 @@ class ModelFactory:
         except Exception as e:
             raise ValueError(f"Error creating dynamic model: {e}")
 
-        # Set class-level attributes
+        # Set class-level attributes. Assigned after create_model, so
+        # StructuredModel.__init_subclass__ has already run and cannot see it --
+        # check here too or a config-driven match_threshold=0.0 warns nowhere.
         DynamicClass.match_threshold = match_threshold
+        warn_if_threshold_is_zero(match_threshold, model_name, "match_threshold")
 
         return DynamicClass
 

--- a/src/stickler/structured_object_evaluator/models/model_factory.py
+++ b/src/stickler/structured_object_evaluator/models/model_factory.py
@@ -169,7 +169,16 @@ class ModelFactory:
         # StructuredModel.__init_subclass__ has already run and cannot see it --
         # check here too or a config-driven match_threshold=0.0 warns nowhere.
         DynamicClass.match_threshold = match_threshold
-        warn_if_threshold_is_zero(match_threshold, model_name, "match_threshold")
+        # Dedup on class identity, not name: `model_name` defaults to
+        # "DynamicModel", so keying by name means a process that loads several
+        # anonymous configs warns for the first and silences the rest -- exactly
+        # the gap this call site was added to close.
+        warn_if_threshold_is_zero(
+            match_threshold,
+            model_name,
+            "match_threshold",
+            dedup_key=f"{model_name}#{id(DynamicClass)}",
+        )
 
         # Add configuration metadata for debugging/introspection
         DynamicClass._model_config = config
@@ -287,7 +296,16 @@ class ModelFactory:
         # StructuredModel.__init_subclass__ has already run and cannot see it --
         # check here too or a config-driven match_threshold=0.0 warns nowhere.
         DynamicClass.match_threshold = match_threshold
-        warn_if_threshold_is_zero(match_threshold, model_name, "match_threshold")
+        # Dedup on class identity, not name: `model_name` defaults to
+        # "DynamicModel", so keying by name means a process that loads several
+        # anonymous configs warns for the first and silences the rest -- exactly
+        # the gap this call site was added to close.
+        warn_if_threshold_is_zero(
+            match_threshold,
+            model_name,
+            "match_threshold",
+            dedup_key=f"{model_name}#{id(DynamicClass)}",
+        )
 
         return DynamicClass
 

--- a/src/stickler/structured_object_evaluator/models/model_factory.py
+++ b/src/stickler/structured_object_evaluator/models/model_factory.py
@@ -17,6 +17,29 @@ from .field_converter import (
 from .threshold_helper import warn_if_threshold_is_zero
 
 
+def _config_identity(model_name: str, field_definitions: Dict[str, Any]) -> str:
+    """Name a dynamically built model in a way that distinguishes configs.
+
+    Dynamically built models share the default name ``"DynamicModel"``, so the
+    name alone identifies nothing: two different configs produce byte-identical
+    warning text. That matters twice over. It is unhelpful to a reader, and
+    Python's own ``__warningregistry__`` is keyed on the message, so identical
+    text means the interpreter prints only the first one under the default
+    "once per location" action -- silently swallowing the second
+    misconfiguration even though ``warn_once`` approved it.
+
+    Object identity would distinguish them but is unstable: every call builds a
+    new class, so repeated loads of one config would each warn (measured: 200
+    loads, 192 warnings) and grow the process-global ``_warned`` set without
+    bound. Field names are stable across loads of one config and differ between
+    configs, so they serve for both the message and the dedup key.
+    """
+    fields = ",".join(sorted(field_definitions))
+    if model_name != "DynamicModel":
+        return model_name
+    return f"{model_name}(fields: {fields})" if fields else model_name
+
+
 class ModelFactory:
     """Factory for creating dynamic StructuredModel subclasses from JSON configuration.
     
@@ -169,15 +192,18 @@ class ModelFactory:
         # StructuredModel.__init_subclass__ has already run and cannot see it --
         # check here too or a config-driven match_threshold=0.0 warns nowhere.
         DynamicClass.match_threshold = match_threshold
-        # Dedup on class identity, not name: `model_name` defaults to
-        # "DynamicModel", so keying by name means a process that loads several
-        # anonymous configs warns for the first and silences the rest -- exactly
-        # the gap this call site was added to close.
+        # Dedup on name plus field names, not on `id(DynamicClass)`. `model_name`
+        # defaults to "DynamicModel", so keying on the name alone would report
+        # the first anonymous config and silence every later one. But keying on
+        # object identity is worse: a new class object is created per call, so
+        # loading the same config in a loop floods stderr (measured: 200 loads,
+        # 192 warnings) and grows the process-global `_warned` set without bound
+        # -- the exact behaviour `warn_once` exists to prevent. Field names are
+        # stable across repeated loads of one config and differ between configs.
         warn_if_threshold_is_zero(
             match_threshold,
-            model_name,
+            _config_identity(model_name, field_definitions),
             "match_threshold",
-            dedup_key=f"{model_name}#{id(DynamicClass)}",
         )
 
         # Add configuration metadata for debugging/introspection
@@ -296,15 +322,18 @@ class ModelFactory:
         # StructuredModel.__init_subclass__ has already run and cannot see it --
         # check here too or a config-driven match_threshold=0.0 warns nowhere.
         DynamicClass.match_threshold = match_threshold
-        # Dedup on class identity, not name: `model_name` defaults to
-        # "DynamicModel", so keying by name means a process that loads several
-        # anonymous configs warns for the first and silences the rest -- exactly
-        # the gap this call site was added to close.
+        # Dedup on name plus field names, not on `id(DynamicClass)`. `model_name`
+        # defaults to "DynamicModel", so keying on the name alone would report
+        # the first anonymous config and silence every later one. But keying on
+        # object identity is worse: a new class object is created per call, so
+        # loading the same config in a loop floods stderr (measured: 200 loads,
+        # 192 warnings) and grows the process-global `_warned` set without bound
+        # -- the exact behaviour `warn_once` exists to prevent. Field names are
+        # stable across repeated loads of one config and differ between configs.
         warn_if_threshold_is_zero(
             match_threshold,
-            model_name,
+            _config_identity(model_name, field_definitions),
             "match_threshold",
-            dedup_key=f"{model_name}#{id(DynamicClass)}",
         )
 
         return DynamicClass

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -29,6 +29,7 @@ from .evaluator_format_helper import EvaluatorFormatHelper
 from .hungarian_helper import HungarianHelper
 from .metrics_helper import MetricsHelper
 from .rich_value_helper import RichValueHelper
+from .threshold_helper import warn_if_threshold_is_zero as _warn_if_threshold_is_zero
 
 
 class StructuredModel(BaseModel):
@@ -245,6 +246,23 @@ class StructuredModel(BaseModel):
                                     f"'comparator' parameter in ComparableField. Object comparison uses each "
                                     f"StructuredModel's individual field comparators instead."
                                 )
+                    else:
+                        continue
+
+                    _warn_if_threshold_is_zero(
+                        temp_schema["x-comparison"].get("threshold"),
+                        f"{cls.__name__}.{field_name}",
+                        "threshold",
+                    )
+
+        # `match_threshold` is a plain class attribute rather than a field, so
+        # it is not covered by the loop above.
+        if "match_threshold" in cls.__dict__:
+            _warn_if_threshold_is_zero(
+                cls.__dict__["match_threshold"],
+                cls.__name__,
+                "match_threshold",
+            )
 
     def model_post_init(self, __context):
         """Initialize confidence storage after model creation."""

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -29,6 +29,7 @@ from .evaluator_format_helper import EvaluatorFormatHelper
 from .hungarian_helper import HungarianHelper
 from .metrics_helper import MetricsHelper
 from .rich_value_helper import RichValueHelper
+from .threshold_helper import THRESHOLD_DOCS_URL
 from .threshold_helper import warn_if_threshold_is_zero as _warn_if_threshold_is_zero
 
 
@@ -227,11 +228,24 @@ class StructuredModel(BaseModel):
                             # Threshold validation - only flag if explicitly set to non-default value
                             threshold = comparison_config.get("threshold", 0.5)
                             if threshold != 0.5:  # Default threshold value
+                                # Do not echo 0.0 back as advice: the threshold
+                                # test is `>=`, so `match_threshold = 0.0` makes
+                                # every paired object a true positive. Telling a
+                                # user to set it would walk them straight into
+                                # the misconfiguration warn_if_threshold_is_zero
+                                # exists to flag.
+                                remedy = (
+                                    "Set a positive 'match_threshold' on the list element "
+                                    "class (0.0 would classify every paired object as a "
+                                    f"true positive). See {THRESHOLD_DOCS_URL}"
+                                    if threshold == 0.0
+                                    else f"Set 'match_threshold = {threshold}' on the list element class."
+                                )
                                 raise ValueError(
                                     f"Field '{field_name}' is a List[StructuredModel] and cannot have a "
                                     f"'threshold' parameter in ComparableField. Hungarian matching uses each "
                                     f"StructuredModel's 'match_threshold' class attribute instead. "
-                                    f"Set 'match_threshold = {threshold}' on the list element class."
+                                    f"{remedy}"
                                 )
 
                             # Comparator validation - only flag if explicitly set to non-default type

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -30,6 +30,7 @@ from .hungarian_helper import HungarianHelper
 from .metrics_helper import MetricsHelper
 from .rich_value_helper import RichValueHelper
 from .threshold_helper import THRESHOLD_DOCS_URL
+from .threshold_helper import model_identity as _model_identity
 from .threshold_helper import warn_if_threshold_is_zero as _warn_if_threshold_is_zero
 
 
@@ -263,9 +264,14 @@ class StructuredModel(BaseModel):
                     else:
                         continue
 
+                    # Same identity scheme as the match_threshold check below:
+                    # a dynamically built model is named "DynamicModel", so two
+                    # anonymous configs that share a field name (amount, date,
+                    # id -- these recur constantly across document schemas)
+                    # would otherwise collide and the second would be silent.
                     _warn_if_threshold_is_zero(
                         temp_schema["x-comparison"].get("threshold"),
-                        f"{cls.__name__}.{field_name}",
+                        f"{_model_identity(cls.__name__, cls.__annotations__)}.{field_name}",
                         "threshold",
                     )
 
@@ -274,7 +280,7 @@ class StructuredModel(BaseModel):
         if "match_threshold" in cls.__dict__:
             _warn_if_threshold_is_zero(
                 cls.__dict__["match_threshold"],
-                cls.__name__,
+                _model_identity(cls.__name__, cls.__annotations__),
                 "match_threshold",
             )
 

--- a/src/stickler/structured_object_evaluator/models/threshold_helper.py
+++ b/src/stickler/structured_object_evaluator/models/threshold_helper.py
@@ -38,6 +38,34 @@ _MATCH_CONSEQUENCE = (
 )
 
 
+
+def model_identity(model_name: str, field_names: Any = ()) -> str:
+    """Name a model so that distinct configurations are distinguishable.
+
+    Dynamically built models all default to ``"DynamicModel"``, so the name
+    alone identifies nothing. That matters twice over: it is unhelpful to a
+    reader, and Python's ``__warningregistry__`` is keyed on the message text,
+    so two configs producing identical text mean the interpreter prints only the
+    first under its default "once per location" action -- silently swallowing
+    the second misconfiguration even though ``warn_once`` approved it.
+
+    Object identity would distinguish them but is unusable as a key. It is
+    unstable (a new class per call, so repeated loads of one config each warn --
+    measured 192 warnings for 200 loads, with the process-global ``_warned`` set
+    growing without bound) and it is *reused*: CPython recycles the address once
+    a class is collected, so a batch loop that builds, uses and drops each model
+    collides on the same key and drops most of its warnings.
+
+    Field names are stable across repeated loads of one config, distinct between
+    different configs, and cannot be recycled. Named models are left alone,
+    since their own name already distinguishes them.
+    """
+    if model_name != "DynamicModel":
+        return model_name
+    joined = ",".join(sorted(field_names))
+    return f"{model_name}(fields: {joined})" if joined else model_name
+
+
 def warn_if_threshold_is_zero(
     value: Optional[float], context: str, parameter: str
 ) -> None:

--- a/src/stickler/structured_object_evaluator/models/threshold_helper.py
+++ b/src/stickler/structured_object_evaluator/models/threshold_helper.py
@@ -1,6 +1,53 @@
 """Threshold checking helper for StructuredModel comparisons."""
 
-from typing import Any
+from typing import Any, Optional
+
+from stickler.utils.deprecation import warn_once
+
+#: Documentation for what a threshold does and how it reaches reported metrics.
+THRESHOLD_DOCS_URL = (
+    "https://awslabs.github.io/stickler/Advanced/threshold-gated-evaluation/"
+)
+
+
+def warn_if_threshold_is_zero(
+    value: Optional[float], context: str, parameter: str
+) -> None:
+    """Warn when a threshold is exactly ``0.0``, which disables classification.
+
+    The threshold test is ``>=``, so ``0.0`` is satisfied by every score
+    including ``0.0`` itself. Every pair the algorithm assigns becomes a true
+    positive, and a wholly incorrect prediction reports perfect precision,
+    recall, F1 and accuracy -- the hardest failure direction to notice, because
+    nothing errors and the numbers look ideal.
+
+    Only exactly ``0.0`` is flagged. ``0.01`` already classifies correctly, so
+    this is a single misbehaving value rather than a "low thresholds are risky"
+    heuristic; warning on low-but-positive values would fire on legitimate
+    configuration.
+
+    Args:
+        value: The configured threshold, or None if unset.
+        context: Where it was set, e.g. ``"Invoice.vendor"``, used to key the
+            warning so a bulk run warns once per site rather than per document.
+        parameter: The parameter name to name in the message.
+    """
+    if value is None or not isinstance(value, (int, float)):
+        return
+    if value != 0.0:
+        return
+
+    warn_once(
+        "threshold-zero",
+        f"{context}.{parameter}",
+        f"{context} sets {parameter}=0.0. The threshold test is `>=`, so every "
+        f"score satisfies it and every compared pair is counted as a true "
+        f"positive -- a wholly incorrect prediction will report perfect "
+        f"precision and recall. Use a small positive value (for example 0.01) "
+        f"to accept weak matches. See {THRESHOLD_DOCS_URL}",
+        category=UserWarning,
+        stacklevel=4,
+    )
 
 
 class ThresholdHelper:

--- a/src/stickler/structured_object_evaluator/models/threshold_helper.py
+++ b/src/stickler/structured_object_evaluator/models/threshold_helper.py
@@ -4,49 +4,88 @@ from typing import Any, Optional
 
 from stickler.utils.deprecation import warn_once
 
-#: Documentation for what a threshold does and how it reaches reported metrics.
-THRESHOLD_DOCS_URL = (
-    "https://awslabs.github.io/stickler/Advanced/threshold-gated-evaluation/"
+#: Where the `>=` cliff and what to use instead are explained.
+THRESHOLD_DOCS_URL = "https://github.com/awslabs/stickler/issues/234"
+
+_FIELD_CONSEQUENCE = (
+    "every compared pair is counted as a true positive, so a wholly incorrect "
+    "prediction reports perfect precision"
+)
+
+# `match_threshold` is read only when the model is a `List[StructuredModel]`
+# element (see structured_list_comparator.py). On a standalone model the value
+# changes nothing, and the hook cannot know at class-definition time which the
+# class will be -- so this states the condition rather than asserting an outcome
+# that may not apply.
+_MATCH_CONSEQUENCE = (
+    "if this model is compared as a list element, every paired object is "
+    "counted as a true positive, so wholly incorrect objects report perfect "
+    "precision"
 )
 
 
 def warn_if_threshold_is_zero(
-    value: Optional[float], context: str, parameter: str
+    value: Optional[float],
+    context: str,
+    parameter: str,
+    dedup_key: Optional[str] = None,
 ) -> None:
     """Warn when a threshold is exactly ``0.0``, which disables classification.
 
     The threshold test is ``>=``, so ``0.0`` is satisfied by every score
-    including ``0.0`` itself. Every pair the algorithm assigns becomes a true
-    positive, and a wholly incorrect prediction reports perfect precision,
-    recall, F1 and accuracy -- the hardest failure direction to notice, because
-    nothing errors and the numbers look ideal.
+    including ``0.0`` itself. Everything the algorithm compares is then a true
+    positive -- the hardest failure direction to notice, because nothing errors
+    and the numbers look ideal.
 
     Only exactly ``0.0`` is flagged. ``0.01`` already classifies correctly, so
     this is a single misbehaving value rather than a "low thresholds are risky"
     heuristic; warning on low-but-positive values would fire on legitimate
     configuration.
 
+    The message claims precision only. Recall survives unmatched extras: 2
+    ground-truth objects against 1 prediction at ``match_threshold=0.0`` gives
+    precision ``1.0`` but recall ``0.5``, since the unpaired item is still an
+    FN. Claiming both would make the warning false for unequal-length lists.
+
     Args:
         value: The configured threshold, or None if unset.
-        context: Where it was set, e.g. ``"Invoice.vendor"``, used to key the
-            warning so a bulk run warns once per site rather than per document.
+        context: Where it was set, e.g. ``"Invoice.vendor"``. Appears in the
+            message.
         parameter: The parameter name to name in the message.
+        dedup_key: Overrides ``context`` for warn-once bookkeeping. Use when
+            ``context`` is not unique per configuration site -- dynamically
+            built models share the default name ``"DynamicModel"``, so keying
+            on it would report the first anonymous config and silence the rest.
+            Kept separate from ``context`` so an internal identity does not leak
+            into user-visible text.
     """
+    # `bool` is an `int`, and `False == 0.0`, so an unguarded numeric check
+    # reports `match_threshold = False` as "sets match_threshold=0.0" -- a value
+    # the user never wrote. A wrong type is not this function's business.
+    if isinstance(value, bool):
+        return
     if value is None or not isinstance(value, (int, float)):
         return
     if value != 0.0:
         return
 
+    consequence = (
+        _MATCH_CONSEQUENCE if parameter == "match_threshold" else _FIELD_CONSEQUENCE
+    )
+
     warn_once(
         "threshold-zero",
-        f"{context}.{parameter}",
+        f"{dedup_key or context}.{parameter}",
         f"{context} sets {parameter}=0.0. The threshold test is `>=`, so every "
-        f"score satisfies it and every compared pair is counted as a true "
-        f"positive -- a wholly incorrect prediction will report perfect "
-        f"precision and recall. Use a small positive value (for example 0.01) "
-        f"to accept weak matches. See {THRESHOLD_DOCS_URL}",
+        f"score satisfies it: {consequence}. Use a small positive value (for "
+        f"example 0.01) to accept weak matches. See {THRESHOLD_DOCS_URL}",
         category=UserWarning,
-        stacklevel=4,
+        # stacklevel=1 attributes the warning to this module. The call sites sit
+        # behind __init_subclass__ / ABCMeta.__new__ / ModelMetaclass.__new__ and
+        # a C frame, at differing depths, so no single value reaches user code --
+        # 4 landed inside `<frozen abc>`, which is worse than honest. The message
+        # names the exact site instead.
+        stacklevel=1,
     )
 
 

--- a/src/stickler/structured_object_evaluator/models/threshold_helper.py
+++ b/src/stickler/structured_object_evaluator/models/threshold_helper.py
@@ -7,9 +7,23 @@ from stickler.utils.deprecation import warn_once
 #: Where the `>=` cliff and what to use instead are explained.
 THRESHOLD_DOCS_URL = "https://github.com/awslabs/stickler/issues/234"
 
+# What a zero threshold actually guarantees: nothing the comparison touches can
+# be reported as a false discovery, because FD means "compared and scored below
+# threshold" and no score is below 0.0. Measured exhaustively at 0.0 -- 256
+# scalar-value combinations and 36 list-length combinations -- FD was 0 in every
+# single one.
+#
+# Deliberately does NOT claim perfect precision or recall. Both are false in
+# reachable cases, symmetrically: an unmatched prediction is still an FA (2
+# ground-truth objects vs 3 predictions gives precision 0.667) and an unmatched
+# ground-truth item is still an FN (2 vs 1 gives recall 0.5). Only the pairs the
+# algorithm actually compares are forced to TP; unmatched items are not subject
+# to any threshold. Claiming a metric outcome would make the warning false for
+# unequal-length lists, and a user who saw imperfect precision would conclude
+# the warning did not describe their situation and keep the broken threshold.
 _FIELD_CONSEQUENCE = (
-    "every compared pair is counted as a true positive, so a wholly incorrect "
-    "prediction reports perfect precision"
+    "every value it compares is counted as a true positive and nothing can be "
+    "reported as a false discovery, however wrong the prediction is"
 )
 
 # `match_threshold` is read only when the model is a `List[StructuredModel]`
@@ -18,17 +32,14 @@ _FIELD_CONSEQUENCE = (
 # class will be -- so this states the condition rather than asserting an outcome
 # that may not apply.
 _MATCH_CONSEQUENCE = (
-    "if this model is compared as a list element, every paired object is "
-    "counted as a true positive, so wholly incorrect objects report perfect "
-    "precision"
+    "if this model is compared as a list element, every object it pairs is "
+    "counted as a true positive and nothing can be reported as a false "
+    "discovery, however wrong the objects are"
 )
 
 
 def warn_if_threshold_is_zero(
-    value: Optional[float],
-    context: str,
-    parameter: str,
-    dedup_key: Optional[str] = None,
+    value: Optional[float], context: str, parameter: str
 ) -> None:
     """Warn when a threshold is exactly ``0.0``, which disables classification.
 
@@ -42,22 +53,22 @@ def warn_if_threshold_is_zero(
     heuristic; warning on low-but-positive values would fire on legitimate
     configuration.
 
-    The message claims precision only. Recall survives unmatched extras: 2
-    ground-truth objects against 1 prediction at ``match_threshold=0.0`` gives
-    precision ``1.0`` but recall ``0.5``, since the unpaired item is still an
-    FN. Claiming both would make the warning false for unequal-length lists.
+    The message names the invariant -- no false discovery is possible -- rather
+    than a metric outcome. Perfect precision and perfect recall are both false
+    in reachable cases, symmetrically: unmatched predictions are still FAs (2
+    ground-truth objects vs 3 predictions gives precision ``0.667``) and
+    unmatched ground-truth items are still FNs (2 vs 1 gives recall ``0.5``),
+    because unmatched items are not subject to any threshold. Verified at 0.0
+    over 36 list-length and 256 scalar-value combinations: FD was ``0`` in all
+    of them, while precision was ``1.0`` in only 20 of the 36.
 
     Args:
         value: The configured threshold, or None if unset.
         context: Where it was set, e.g. ``"Invoice.vendor"``. Appears in the
-            message.
+            message and keys the warn-once bookkeeping, so it must distinguish
+            configuration sites -- see ``ModelFactory._config_identity`` for why
+            a bare ``"DynamicModel"`` does not.
         parameter: The parameter name to name in the message.
-        dedup_key: Overrides ``context`` for warn-once bookkeeping. Use when
-            ``context`` is not unique per configuration site -- dynamically
-            built models share the default name ``"DynamicModel"``, so keying
-            on it would report the first anonymous config and silence the rest.
-            Kept separate from ``context`` so an internal identity does not leak
-            into user-visible text.
     """
     # `bool` is an `int`, and `False == 0.0`, so an unguarded numeric check
     # reports `match_threshold = False` as "sets match_threshold=0.0" -- a value
@@ -75,7 +86,7 @@ def warn_if_threshold_is_zero(
 
     warn_once(
         "threshold-zero",
-        f"{dedup_key or context}.{parameter}",
+        f"{context}.{parameter}",
         f"{context} sets {parameter}=0.0. The threshold test is `>=`, so every "
         f"score satisfies it: {consequence}. Use a small positive value (for "
         f"example 0.01) to accept weak matches. See {THRESHOLD_DOCS_URL}",

--- a/tests/structured_object_evaluator/test_json_schema_error_handling.py
+++ b/tests/structured_object_evaluator/test_json_schema_error_handling.py
@@ -58,7 +58,12 @@ class TestThresholdValidation:
             StructuredModel.from_json_schema(schema)
 
     def test_threshold_exactly_zero_is_valid(self):
-        """Test that threshold of exactly 0.0 is valid."""
+        """Test that threshold of exactly 0.0 is valid.
+
+        Still accepted, deliberately: 0.0 is a legal value and someone may be
+        relying on it. It now emits a UserWarning because it disables
+        classification (issue #234), but warning is not rejecting.
+        """
         schema = {
             "type": "object",
             "properties": {

--- a/tests/structured_object_evaluator/test_structured_model_comparators.py
+++ b/tests/structured_object_evaluator/test_structured_model_comparators.py
@@ -197,8 +197,10 @@ def test_fuzzy_comparator_variants():
 
     # Create models with different fuzzy comparator methods
     class FuzzyVariantsModel(StructuredModel):
-        match_threshold = 0.0
-
+        # No `match_threshold`: this model is compared directly, never as a
+        # `List[StructuredModel]` element, so the attribute is never read. It
+        # previously carried 0.0, which is inert here but trips the
+        # zero-threshold warning (issue #234).
         ratio: str = ComparableField(
             comparator=FuzzyComparator(method="ratio"), threshold=0.5
         )

--- a/tests/structured_object_evaluator/test_threshold_zero_warning.py
+++ b/tests/structured_object_evaluator/test_threshold_zero_warning.py
@@ -1,0 +1,268 @@
+"""A threshold of exactly 0.0 disables classification, so it warns.
+
+The threshold test is ``>=``, so ``0.0`` is satisfied by every score including
+``0.0`` itself: every assigned pair becomes a true positive and a wholly
+incorrect prediction reports perfect precision and recall. Nothing errors and
+the numbers look ideal, which makes it the hardest misconfiguration to notice.
+
+``0.0`` is a cliff rather than a slope -- ``0.01`` already classifies
+correctly -- so the check is for exactly ``0.0`` and low-but-positive
+thresholds are left alone.
+
+See https://github.com/awslabs/stickler/issues/234
+"""
+
+import warnings
+from typing import List
+
+import pytest
+
+from stickler.comparators.exact import ExactComparator
+from stickler.structured_object_evaluator.models.comparable_field import ComparableField
+from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+from stickler.utils import deprecation
+
+
+@pytest.fixture(autouse=True)
+def _reset_warn_once():
+    """`warn_once` is process-scoped; clear it so each test sees its warning."""
+    deprecation._warned.clear()
+    yield
+    deprecation._warned.clear()
+
+
+def _user_warnings(recorded):
+    return [w for w in recorded if w.category is UserWarning]
+
+
+class TestFieldThreshold:
+    def test_zero_threshold_warns(self):
+        with pytest.warns(UserWarning, match="threshold=0.0"):
+
+            class Doc(StructuredModel):
+                tags: List[str] = ComparableField(
+                    comparator=ExactComparator(), threshold=0.0
+                )
+
+    def test_warning_names_the_field_and_links_the_docs(self):
+        with pytest.warns(UserWarning) as record:
+
+            class Doc(StructuredModel):
+                vendor: str = ComparableField(
+                    comparator=ExactComparator(), threshold=0.0
+                )
+
+        message = str(record[0].message)
+        assert "Doc.vendor" in message, "the warning must say which field"
+        assert "0.01" in message, "the warning must suggest a usable alternative"
+        assert "https://" in message, "the warning must link to an explanation"
+
+    @pytest.mark.parametrize("threshold", [0.01, 0.1, 0.5, 0.7, 1.0])
+    def test_positive_thresholds_do_not_warn(self, threshold):
+        """0.01 already classifies correctly, so only exactly 0.0 is a problem."""
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+
+            class Doc(StructuredModel):
+                tags: List[str] = ComparableField(
+                    comparator=ExactComparator(), threshold=threshold
+                )
+
+        assert _user_warnings(recorded) == []
+
+    def test_default_threshold_does_not_warn(self):
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+
+            class Doc(StructuredModel):
+                tags: List[str] = ComparableField(comparator=ExactComparator())
+
+        assert _user_warnings(recorded) == []
+
+
+class TestModelMatchThreshold:
+    def test_zero_match_threshold_warns(self):
+        with pytest.warns(UserWarning, match="match_threshold=0.0"):
+
+            class Line(StructuredModel):
+                match_threshold = 0.0
+
+                sku: str = ComparableField(comparator=ExactComparator())
+
+    def test_warning_names_the_model(self):
+        with pytest.warns(UserWarning) as record:
+
+            class Line(StructuredModel):
+                match_threshold = 0.0
+
+                sku: str = ComparableField(comparator=ExactComparator())
+
+        assert "Line" in str(record[0].message)
+
+    @pytest.mark.parametrize("threshold", [0.01, 0.7, 1.0])
+    def test_positive_match_thresholds_do_not_warn(self, threshold):
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+
+            class Line(StructuredModel):
+                match_threshold = threshold
+
+                sku: str = ComparableField(comparator=ExactComparator())
+
+        assert _user_warnings(recorded) == []
+
+    def test_inherited_match_threshold_does_not_re_warn(self):
+        """Only the class that sets it warns, not every subclass of it.
+
+        A subclass inherits the attribute; re-warning would fire for code that
+        never chose the value.
+        """
+        with pytest.warns(UserWarning):
+
+            class Base(StructuredModel):
+                match_threshold = 0.0
+
+                sku: str = ComparableField(comparator=ExactComparator())
+
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+
+            class Child(Base):
+                pass
+
+        assert _user_warnings(recorded) == []
+
+
+class TestJsonConfigPath:
+    """A config-driven model must warn too, not only a hand-written class.
+
+    Both validation sites accept ``0.0`` (they check ``0.0 <= value <= 1.0``),
+    so a config is a realistic way to arrive at this state.
+    """
+
+    def test_field_threshold_from_config_warns(self):
+        config = {
+            "model_name": "FromConfig",
+            "fields": {
+                "name": {
+                    "type": "str",
+                    "comparator": "ExactComparator",
+                    "threshold": 0.0,
+                }
+            },
+        }
+
+        with pytest.warns(UserWarning, match="threshold=0.0"):
+            StructuredModel.model_from_json(config)
+
+    def test_match_threshold_from_config_warns(self):
+        """`match_threshold` is assigned after class creation by the factory.
+
+        `__init_subclass__` has already run by then, so without an explicit
+        check in `ModelFactory` this case would warn nowhere.
+        """
+        config = {
+            "model_name": "FromConfigMT",
+            "match_threshold": 0.0,
+            "fields": {
+                "name": {
+                    "type": "str",
+                    "comparator": "ExactComparator",
+                    "threshold": 0.5,
+                }
+            },
+        }
+
+        with pytest.warns(UserWarning, match="match_threshold=0.0"):
+            StructuredModel.model_from_json(config)
+
+    def test_positive_config_thresholds_do_not_warn(self):
+        config = {
+            "model_name": "FineFromConfig",
+            "match_threshold": 0.7,
+            "fields": {
+                "name": {
+                    "type": "str",
+                    "comparator": "ExactComparator",
+                    "threshold": 0.5,
+                }
+            },
+        }
+
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            StructuredModel.model_from_json(config)
+
+        assert _user_warnings(recorded) == []
+
+
+class TestInternalSentinelIsUnaffected:
+    """Stickler uses ``match_threshold=0.0`` internally on purpose."""
+
+    def test_normal_comparison_does_not_warn(self):
+        """`ComparisonHelper.compare_unordered_lists` builds a 0.0 matcher.
+
+        That is a deliberate capture-all: it reads only ``matched_pairs`` and
+        reclassifies against its own threshold. It must not surface a warning
+        to a user who configured nothing wrong.
+        """
+
+        class Doc(StructuredModel):
+            tags: List[str] = ComparableField(
+                comparator=ExactComparator(), threshold=0.5
+            )
+
+        gt, pred = Doc(tags=["a", "b"]), Doc(tags=["a", "c"])
+
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            gt.compare_with(pred, include_confusion_matrix=True)
+
+        assert _user_warnings(recorded) == []
+
+
+class TestWarnOncePerSite:
+    def test_repeated_instantiation_warns_once(self):
+        """A bulk run must not emit one warning per document."""
+        with pytest.warns(UserWarning) as record:
+
+            class Doc(StructuredModel):
+                tags: List[str] = ComparableField(
+                    comparator=ExactComparator(), threshold=0.0
+                )
+
+            for _ in range(50):
+                Doc(tags=["x"]).compare_with(Doc(tags=["y"]))
+
+        assert len(_user_warnings(record.list)) == 1
+
+
+def test_the_behavior_the_warning_describes():
+    """Pin the misbehavior itself, so the warning cannot outlive its cause.
+
+    A wholly wrong prediction on a ``threshold=0.0`` field is scored as a true
+    positive with perfect recall. Uses a two-item list, which behaves this way
+    on every list length; the one-item case only joins it once #224 lands (the
+    single-item fast path currently drops the pair instead), so asserting on
+    n=1 would pass or fail depending on merge order.
+
+    If a later change makes ``threshold=0.0`` classify sensibly, this fails and
+    the warning should be deleted rather than left to mislead.
+    """
+
+    class Doc(StructuredModel):
+        tags: List[str] = ComparableField(comparator=ExactComparator(), threshold=0.0)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = Doc(tags=["X", "Y"]).compare_with(
+            Doc(tags=["A", "B"]), include_confusion_matrix=True
+        )
+
+    overall = result["confusion_matrix"]["aggregate"]
+    assert overall["tp"] == 2, "every pair clears a zero threshold"
+    assert overall["fd"] == 0
+    assert overall["derived"]["cm_recall"] == 1.0, (
+        "a wholly wrong prediction reports perfect recall -- this is the trap"
+    )
+    assert overall["derived"]["cm_precision"] == 1.0

--- a/tests/structured_object_evaluator/test_threshold_zero_warning.py
+++ b/tests/structured_object_evaluator/test_threshold_zero_warning.py
@@ -12,6 +12,7 @@ thresholds are left alone.
 See https://github.com/awslabs/stickler/issues/234
 """
 
+import gc
 import warnings
 from typing import List
 
@@ -300,6 +301,67 @@ class TestJsonConfigPath:
 
         assert len(_user_warnings(recorded)) == 1
         assert len(deprecation._warned) == 1, "the dedup set must not grow per load"
+
+    def test_configs_still_warn_when_each_class_is_collected(self):
+        """The key must survive garbage collection, not just co-existence.
+
+        An earlier attempt keyed on ``id(DynamicClass)``. CPython recycles an
+        address once the class is freed, so a batch loop that builds, uses and
+        drops each model collided on the same key and dropped most of its
+        warnings (measured: 19 of 50). The previous version of this test held
+        every class alive at once, which is exactly the shape that hides the
+        bug.
+        """
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            for i in range(25):
+                model = StructuredModel.model_from_json(
+                    {
+                        "match_threshold": 0.0,
+                        "fields": {
+                            f"f{i}": {
+                                "type": "str",
+                                "comparator": "ExactComparator",
+                                "threshold": 0.5,
+                            }
+                        },
+                    }
+                )
+                del model
+                gc.collect()
+
+        assert len(_user_warnings(recorded)) == 25, (
+            "a recyclable key silently drops warnings for collected classes"
+        )
+
+    def test_anonymous_configs_sharing_a_field_name_each_warn(self):
+        """Field names like `amount`, `date`, `id` recur across schemas.
+
+        The field path keyed on `f"{cls.__name__}.{field_name}"`, which is
+        `DynamicModel.amount` for every anonymous config, so the second config
+        with a zero-threshold `amount` was silent.
+        """
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            for other in ("alpha", "beta"):
+                StructuredModel.model_from_json(
+                    {
+                        "fields": {
+                            "amount": {
+                                "type": "str",
+                                "comparator": "ExactComparator",
+                                "threshold": 0.0,
+                            },
+                            other: {
+                                "type": "str",
+                                "comparator": "ExactComparator",
+                                "threshold": 0.5,
+                            },
+                        }
+                    }
+                )
+
+        assert len(_user_warnings(recorded)) == 2
 
     def test_warning_text_carries_no_internal_identity(self):
         """No object address leaks into user-visible text.

--- a/tests/structured_object_evaluator/test_threshold_zero_warning.py
+++ b/tests/structured_object_evaluator/test_threshold_zero_warning.py
@@ -2,7 +2,7 @@
 
 The threshold test is ``>=``, so ``0.0`` is satisfied by every score including
 ``0.0`` itself: every assigned pair becomes a true positive and a wholly
-incorrect prediction reports perfect precision and recall. Nothing errors and
+incorrect prediction is reported as a true positive. Nothing errors and
 the numbers look ideal, which makes it the hardest misconfiguration to notice.
 
 ``0.0`` is a cliff rather than a slope -- ``0.01`` already classifies
@@ -63,11 +63,15 @@ class TestFieldThreshold:
         # (0.0 -- 1.0)", so a reader who followed it learned nothing.
         assert THRESHOLD_DOCS_URL in message, "the warning must link an explanation"
 
-    def test_message_claims_precision_not_recall(self):
-        """Recall survives unmatched extras, so claiming it would be false.
+    def test_message_claims_no_metric_outcome(self):
+        """The message names the invariant, not precision or recall.
 
-        2 GT objects against 1 prediction at ``match_threshold=0.0`` gives
-        precision 1.0 but recall 0.5 -- the unpaired item is still an FN.
+        Both metrics are false in reachable cases, symmetrically: unmatched
+        predictions are still FAs and unmatched ground truth is still FNs, so
+        neither is guaranteed at ``0.0``. What *is* invariant is that no false
+        discovery can be reported. Claiming a metric would make the warning
+        false for unequal-length lists, and a user seeing imperfect precision
+        would conclude it did not apply to them.
         """
         with pytest.warns(UserWarning) as record:
 
@@ -77,10 +81,9 @@ class TestFieldThreshold:
                 )
 
         message = str(record[0].message)
-        assert "precision" in message
-        assert "recall" not in message, (
-            "recall is not guaranteed to be perfect; see unequal-length lists"
-        )
+        assert "false discovery" in message, "the invariant must be named"
+        assert "perfect precision" not in message
+        assert "perfect recall" not in message
 
     @pytest.mark.parametrize("threshold", [0.01, 0.1, 0.5, 0.7, 1.0])
     def test_positive_thresholds_do_not_warn(self, threshold):
@@ -266,8 +269,40 @@ class TestJsonConfigPath:
 
         assert len(_user_warnings(recorded)) == 2
 
+    def test_same_config_loaded_repeatedly_warns_once(self):
+        """warn-once must survive the dedup key, not be defeated by it.
+
+        A new class object is created per call, so keying on ``id()`` made a
+        loop over one config emit a warning every time -- 192 for 200 loads --
+        and grew the process-global ``_warned`` set without bound. That is the
+        stderr flood ``warn_once`` exists to prevent.
+        """
+        config = {
+            "model_name": "Repeated",
+            "match_threshold": 0.0,
+            "fields": {
+                "a": {
+                    "type": "str",
+                    "comparator": "ExactComparator",
+                    "threshold": 0.5,
+                }
+            },
+        }
+
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            for _ in range(50):
+                StructuredModel.model_from_json(dict(config))
+
+        assert len(_user_warnings(recorded)) == 1
+        assert len(deprecation._warned) == 1, "the dedup set must not grow per load"
+
     def test_warning_text_carries_no_internal_identity(self):
-        """The dedup key is separate from the message, so `id()` cannot leak."""
+        """No object address leaks into user-visible text.
+
+        An earlier attempt keyed dedup on ``id(DynamicClass)`` and interpolated
+        it, printing "DynamicModel#4355291632 sets ...".
+        """
         config = {
             "match_threshold": 0.0,
             "fields": {
@@ -282,7 +317,42 @@ class TestJsonConfigPath:
         with pytest.warns(UserWarning) as record:
             StructuredModel.model_from_json(config)
 
-        assert "#" not in str(record[0].message)
+        message = str(record[0].message)
+        assert "#" not in message
+        assert not any(ch.isdigit() and len(part) > 8 for part in message.split() for ch in part[:1]), (
+            "no long numeric token that could be an address"
+        )
+
+    def test_anonymous_configs_are_distinguishable_in_the_message(self):
+        """Identical text would be swallowed by Python's warning registry.
+
+        ``__warningregistry__`` is keyed on the message, so two anonymous
+        configs producing byte-identical text print only once under the default
+        action -- the second misconfiguration is lost even though ``warn_once``
+        approved it. The message names the fields to keep them distinct.
+        """
+        messages = []
+        for field in ("alpha", "beta"):
+            deprecation._warned.clear()
+            with pytest.warns(UserWarning) as record:
+                StructuredModel.model_from_json(
+                    {
+                        "match_threshold": 0.0,
+                        "fields": {
+                            field: {
+                                "type": "str",
+                                "comparator": "ExactComparator",
+                                "threshold": 0.5,
+                            }
+                        },
+                    }
+                )
+            messages.append(str(record[0].message))
+
+        assert messages[0] != messages[1], (
+            "identical text collapses in Python's warning registry"
+        )
+        assert "alpha" in messages[0] and "beta" in messages[1]
 
     def test_positive_config_thresholds_do_not_warn(self):
         config = {
@@ -345,6 +415,45 @@ class TestWarnOncePerSite:
         assert len(_user_warnings(record.list)) == 1
 
 
+def test_no_false_discovery_is_possible_at_any_list_length():
+    """The invariant the message names, swept across list lengths.
+
+    FD means "compared and scored below threshold", and nothing scores below
+    0.0, so FD must be 0 for every combination. Precision is deliberately not
+    asserted: it drops below 1.0 whenever the prediction is longer, which is
+    why the message does not claim it.
+    """
+
+    class Line(StructuredModel):
+        match_threshold = 0.0
+
+        sku: str = ComparableField(comparator=ExactComparator(), threshold=1.0)
+
+    class Doc(StructuredModel):
+        lines: List[Line] = ComparableField(weight=1.0)
+
+    precision_was_imperfect = False
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        for n_gt in range(1, 5):
+            for n_pred in range(1, 5):
+                gt = Doc(lines=[Line(sku=f"A{i}") for i in range(n_gt)])
+                pred = Doc(lines=[Line(sku=f"Z{i}") for i in range(n_pred)])
+                overall = gt.compare_with(pred, include_confusion_matrix=True)[
+                    "confusion_matrix"
+                ]["fields"]["lines"]["overall"]
+
+                assert overall["fd"] == 0, (
+                    f"{n_gt} vs {n_pred}: nothing can score below a zero threshold"
+                )
+                if overall["derived"]["cm_precision"] != 1.0:
+                    precision_was_imperfect = True
+
+    assert precision_was_imperfect, (
+        "if precision is now always perfect the message may claim it again"
+    )
+
+
 def test_match_threshold_zero_on_a_real_list_element():
     """The conditional in the message is true when the condition holds.
 
@@ -372,11 +481,13 @@ def test_match_threshold_zero_on_a_real_list_element():
     assert overall["derived"]["cm_precision"] == 1.0
 
 
-def test_unequal_length_lists_keep_imperfect_recall():
-    """Why the message says precision and not recall.
+def test_unmatched_items_keep_both_metrics_honest():
+    """Why the message names no metric outcome.
 
-    An unpaired ground-truth object is still an FN, so recall stays honest
-    even at ``match_threshold=0.0``.
+    Unmatched items are not subject to any threshold, so an extra ground-truth
+    object stays an FN and an extra prediction stays an FA. Recall and
+    precision therefore both stay honest at ``match_threshold=0.0``, in
+    opposite directions -- which is why the message claims neither.
     """
 
     class Line(StructuredModel):
@@ -395,8 +506,21 @@ def test_unequal_length_lists_keep_imperfect_recall():
 
     overall = result["confusion_matrix"]["fields"]["lines"]["overall"]
     assert overall["fn"] == 1, "the unpaired ground-truth object is still a miss"
-    assert overall["derived"]["cm_precision"] == 1.0
     assert overall["derived"]["cm_recall"] == 0.5
+
+    # Mirror case: an extra *prediction* is an FA, so precision drops instead.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        mirrored = Doc(lines=[Line(sku="A")]).compare_with(
+            Doc(lines=[Line(sku="Y"), Line(sku="Z")]), include_confusion_matrix=True
+        )
+
+    mirror_overall = mirrored["confusion_matrix"]["fields"]["lines"]["overall"]
+    assert mirror_overall["fa"] == 1, "the unpaired prediction is still a false alarm"
+    assert mirror_overall["derived"]["cm_precision"] == 0.5
+
+    # Neither metric is safe to claim; FD is zero in both directions.
+    assert overall["fd"] == 0 and mirror_overall["fd"] == 0
 
 
 def test_the_behavior_the_warning_describes():

--- a/tests/structured_object_evaluator/test_threshold_zero_warning.py
+++ b/tests/structured_object_evaluator/test_threshold_zero_warning.py
@@ -58,10 +58,14 @@ class TestFieldThreshold:
         message = str(record[0].message)
         assert "Doc.vendor" in message, "the warning must say which field"
         assert "0.01" in message, "the warning must suggest a usable alternative"
-        # Must point somewhere that actually explains the cliff. The old target
-        # was a docs page whose only mention of zero was "raw similarity score
-        # (0.0 -- 1.0)", so a reader who followed it learned nothing.
-        assert THRESHOLD_DOCS_URL in message, "the warning must link an explanation"
+        # Assert the literal target, not `THRESHOLD_DOCS_URL in message` --
+        # that compares the constant to itself and passes for any value,
+        # including a URL that explains nothing. The old target was a docs page
+        # whose only mention of zero was "raw similarity score (0.0 -- 1.0)".
+        assert "github.com/awslabs/stickler/issues/234" in message, (
+            "the warning must link somewhere that explains the zero-threshold cliff"
+        )
+        assert THRESHOLD_DOCS_URL in message, "the constant must be what is emitted"
 
     def test_message_claims_no_metric_outcome(self):
         """The message names the invariant, not precision or recall.
@@ -372,6 +376,73 @@ class TestJsonConfigPath:
             StructuredModel.model_from_json(config)
 
         assert _user_warnings(recorded) == []
+
+
+class TestCoverageOfEveryEntryPoint:
+    """Every way a user can configure a threshold, and whether it warns."""
+
+    def test_from_json_schema_field_threshold_warns(self):
+        schema = {
+            "type": "object",
+            "properties": {"v": {"type": "string", "x-aws-stickler-threshold": 0.0}},
+        }
+
+        with pytest.warns(UserWarning, match="threshold=0.0"):
+            StructuredModel.from_json_schema(schema)
+
+    def test_from_json_schema_match_threshold_warns(self):
+        schema = {
+            "type": "object",
+            "x-aws-stickler-match-threshold": 0.0,
+            "properties": {"v": {"type": "string"}},
+        }
+
+        with pytest.warns(UserWarning, match="match_threshold=0.0"):
+            StructuredModel.from_json_schema(schema)
+
+    def test_create_model_from_fields_warns(self):
+        """The second ModelFactory entry point, not just create_model_from_json."""
+        from stickler.structured_object_evaluator.models.model_factory import (
+            ModelFactory,
+        )
+
+        with pytest.warns(UserWarning, match="match_threshold=0.0"):
+            ModelFactory.create_model_from_fields(
+                "FromFields",
+                {"v": (str, ComparableField(comparator=ExactComparator()))},
+                match_threshold=0.0,
+            )
+
+    def test_subclass_setting_its_own_zero_warns(self):
+        """Inheriting silently is right; choosing 0.0 yourself is not."""
+
+        class Parent(StructuredModel):
+            v: str = ComparableField(comparator=ExactComparator())
+
+        with pytest.warns(UserWarning, match="match_threshold=0.0"):
+
+            class Child(Parent):
+                match_threshold = 0.0
+
+    def test_post_hoc_setattr_is_a_known_gap(self):
+        """Documents a limitation rather than asserting desired behaviour.
+
+        The checks run at class creation and config conversion, so assigning
+        the attribute afterwards is invisible to them. Catching it would need a
+        metaclass ``__setattr__``. If this ever starts warning, that is an
+        improvement -- update this test rather than treating it as a break.
+        """
+
+        class Line(StructuredModel):
+            v: str = ComparableField(comparator=ExactComparator())
+
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            Line.match_threshold = 0.0
+
+        assert _user_warnings(recorded) == [], (
+            "if this now warns, the coverage gap is closed -- update the docstring"
+        )
 
 
 class TestInternalSentinelIsUnaffected:

--- a/tests/structured_object_evaluator/test_threshold_zero_warning.py
+++ b/tests/structured_object_evaluator/test_threshold_zero_warning.py
@@ -20,6 +20,9 @@ import pytest
 from stickler.comparators.exact import ExactComparator
 from stickler.structured_object_evaluator.models.comparable_field import ComparableField
 from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+from stickler.structured_object_evaluator.models.threshold_helper import (
+    THRESHOLD_DOCS_URL,
+)
 from stickler.utils import deprecation
 
 
@@ -55,7 +58,29 @@ class TestFieldThreshold:
         message = str(record[0].message)
         assert "Doc.vendor" in message, "the warning must say which field"
         assert "0.01" in message, "the warning must suggest a usable alternative"
-        assert "https://" in message, "the warning must link to an explanation"
+        # Must point somewhere that actually explains the cliff. The old target
+        # was a docs page whose only mention of zero was "raw similarity score
+        # (0.0 -- 1.0)", so a reader who followed it learned nothing.
+        assert THRESHOLD_DOCS_URL in message, "the warning must link an explanation"
+
+    def test_message_claims_precision_not_recall(self):
+        """Recall survives unmatched extras, so claiming it would be false.
+
+        2 GT objects against 1 prediction at ``match_threshold=0.0`` gives
+        precision 1.0 but recall 0.5 -- the unpaired item is still an FN.
+        """
+        with pytest.warns(UserWarning) as record:
+
+            class Doc(StructuredModel):
+                vendor: str = ComparableField(
+                    comparator=ExactComparator(), threshold=0.0
+                )
+
+        message = str(record[0].message)
+        assert "precision" in message
+        assert "recall" not in message, (
+            "recall is not guaranteed to be perfect; see unequal-length lists"
+        )
 
     @pytest.mark.parametrize("threshold", [0.01, 0.1, 0.5, 0.7, 1.0])
     def test_positive_thresholds_do_not_warn(self, threshold):
@@ -89,6 +114,24 @@ class TestModelMatchThreshold:
 
                 sku: str = ComparableField(comparator=ExactComparator())
 
+    def test_match_threshold_message_is_conditional(self):
+        """`match_threshold` is inert unless the model is a list element.
+
+        The hook cannot know at class-definition time which it will be, and
+        the value provably changes nothing for a standalone model -- verified
+        identical output at None, 0.0 and 0.7. So the message states the
+        condition rather than asserting an outcome that may not apply.
+        """
+        with pytest.warns(UserWarning) as record:
+
+            class Line(StructuredModel):
+                match_threshold = 0.0
+
+                sku: str = ComparableField(comparator=ExactComparator())
+
+        message = str(record[0].message)
+        assert "if this model is compared as a list element" in message
+
     def test_warning_names_the_model(self):
         with pytest.warns(UserWarning) as record:
 
@@ -106,6 +149,24 @@ class TestModelMatchThreshold:
 
             class Line(StructuredModel):
                 match_threshold = threshold
+
+                sku: str = ComparableField(comparator=ExactComparator())
+
+        assert _user_warnings(recorded) == []
+
+    @pytest.mark.parametrize("wrong_type", [False, True])
+    def test_bool_is_not_reported_as_a_zero_threshold(self, wrong_type):
+        """`bool` is an `int` and `False == 0.0`, so an unguarded check lies.
+
+        Reporting "sets match_threshold=0.0" for `match_threshold = False`
+        names a value the user never wrote. A wrong type is a different
+        problem from a zero threshold.
+        """
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+
+            class Line(StructuredModel):
+                match_threshold = wrong_type
 
                 sku: str = ComparableField(comparator=ExactComparator())
 
@@ -176,6 +237,53 @@ class TestJsonConfigPath:
         with pytest.warns(UserWarning, match="match_threshold=0.0"):
             StructuredModel.model_from_json(config)
 
+    def test_distinct_anonymous_configs_each_warn(self):
+        """`model_name` defaults to "DynamicModel", so name keying collides.
+
+        A process building models from several configs -- a service per
+        request, a batch job over a directory -- would report the first
+        misconfiguration and swallow every later one, which is the gap this
+        call site exists to close.
+        """
+        configs = [
+            {
+                "match_threshold": 0.0,
+                "fields": {
+                    name: {
+                        "type": "str",
+                        "comparator": "ExactComparator",
+                        "threshold": 0.5,
+                    }
+                },
+            }
+            for name in ("alpha", "beta")
+        ]
+
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            for config in configs:
+                StructuredModel.model_from_json(config)
+
+        assert len(_user_warnings(recorded)) == 2
+
+    def test_warning_text_carries_no_internal_identity(self):
+        """The dedup key is separate from the message, so `id()` cannot leak."""
+        config = {
+            "match_threshold": 0.0,
+            "fields": {
+                "a": {
+                    "type": "str",
+                    "comparator": "ExactComparator",
+                    "threshold": 0.5,
+                }
+            },
+        }
+
+        with pytest.warns(UserWarning) as record:
+            StructuredModel.model_from_json(config)
+
+        assert "#" not in str(record[0].message)
+
     def test_positive_config_thresholds_do_not_warn(self):
         config = {
             "model_name": "FineFromConfig",
@@ -235,6 +343,60 @@ class TestWarnOncePerSite:
                 Doc(tags=["x"]).compare_with(Doc(tags=["y"]))
 
         assert len(_user_warnings(record.list)) == 1
+
+
+def test_match_threshold_zero_on_a_real_list_element():
+    """The conditional in the message is true when the condition holds.
+
+    Equal-length lists at ``match_threshold=0.0``: every object pairs, every
+    pair clears the threshold, so wholly wrong objects are all true positives.
+    """
+
+    class Line(StructuredModel):
+        match_threshold = 0.0
+
+        sku: str = ComparableField(comparator=ExactComparator(), threshold=1.0)
+
+    class Doc(StructuredModel):
+        lines: List[Line] = ComparableField(weight=1.0)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = Doc(lines=[Line(sku="A"), Line(sku="B")]).compare_with(
+            Doc(lines=[Line(sku="Y"), Line(sku="Z")]), include_confusion_matrix=True
+        )
+
+    overall = result["confusion_matrix"]["fields"]["lines"]["overall"]
+    assert overall["tp"] == 2, "every paired object clears a zero threshold"
+    assert overall["fd"] == 0
+    assert overall["derived"]["cm_precision"] == 1.0
+
+
+def test_unequal_length_lists_keep_imperfect_recall():
+    """Why the message says precision and not recall.
+
+    An unpaired ground-truth object is still an FN, so recall stays honest
+    even at ``match_threshold=0.0``.
+    """
+
+    class Line(StructuredModel):
+        match_threshold = 0.0
+
+        sku: str = ComparableField(comparator=ExactComparator(), threshold=1.0)
+
+    class Doc(StructuredModel):
+        lines: List[Line] = ComparableField(weight=1.0)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = Doc(lines=[Line(sku="A"), Line(sku="B")]).compare_with(
+            Doc(lines=[Line(sku="Z")]), include_confusion_matrix=True
+        )
+
+    overall = result["confusion_matrix"]["fields"]["lines"]["overall"]
+    assert overall["fn"] == 1, "the unpaired ground-truth object is still a miss"
+    assert overall["derived"]["cm_precision"] == 1.0
+    assert overall["derived"]["cm_recall"] == 0.5
 
 
 def test_the_behavior_the_warning_describes():


### PR DESCRIPTION
# Pull Request

## Issue Reference
Closes #234

## Description of Changes

A `threshold` or `match_threshold` of exactly `0.0` disables classification. The test is `>=`, so `0.0` is satisfied by every score including `0.0` itself, and nothing the comparison touches can ever be reported as a false discovery.

```python
class Doc(StructuredModel):
    tags: List[str] = ComparableField(comparator=ExactComparator(), threshold=0.0)

Doc(tags=["X", "Y"]).compare_with(Doc(tags=["A", "B"]), include_confusion_matrix=True)
# tp=2, fd=0 -- two wholly wrong values, both true positives
```

Nothing raises and the numbers look ideal, which makes it the hardest misconfiguration to notice.

### Why exactly `0.0`, not "low"

A cliff, not a slope. Measured on `["X"]` vs `["A"]`:

| `threshold` | result | recall |
|---|---|---|
| **`0.0`** | **`tp=1`** | **1.000** |
| `0.01` | `tp=0, fd=1` | 0.000 |
| `0.1` | `tp=0, fd=1` | 0.000 |

`0.01` already classifies correctly, so a check on low-but-positive values would fire on legitimate configuration. `match_threshold` has the identical cliff. Both existing validation sites (`field_converter.py:274`, `structured_model.py:669`) check `0.0 <= value <= 1.0`, so they explicitly permit the one value that misbehaves.

### What the message claims, and why

**It names the invariant, not a metric outcome.** No false discovery is possible, because FD means "compared and scored below threshold" and nothing scores below `0.0`. Verified exhaustively at `0.0`: FD was `0` in all 36 list-length and all 256 scalar-value combinations.

It deliberately does **not** claim perfect precision or recall. Both are false in reachable cases, symmetrically, because unmatched items are not subject to any threshold:

| case | precision | recall |
|---|---|---|
| 2 GT vs 3 pred (extra prediction is an FA) | **0.667** | 1.000 |
| 2 GT vs 1 pred (extra GT is an FN) | 1.000 | **0.500** |

Precision was `1.0` in only 20 of 36 combinations. A user who saw imperfect precision after being told to expect perfection would conclude the warning didn't describe their situation and keep the broken threshold.

For `match_threshold` the message is also **conditional** ("if this model is compared as a list element"), because the value is only read for `List[StructuredModel]` matching and is inert otherwise — verified identical output at `None`, `0.0` and `0.7` on a standalone model.

### Coverage

Enumerated every public path rather than assuming the call sites covered them:

| path | warns |
|---|---|
| class-body field `threshold` | yes |
| class-body `match_threshold` | yes |
| `model_from_json` field / `match_threshold` | yes / yes |
| `from_json_schema` field / `match_threshold` | yes / yes |
| `ModelFactory.create_model_from_fields` | yes |
| subclass setting its own `0.0` | yes |
| inherited `match_threshold` | no — not the subclass's choice |
| post-hoc `Model.match_threshold = 0.0` | no — **known gap** |

`match_threshold` from a config needed its own call site: `ModelFactory` assigns it *after* `create_model()`, so `__init_subclass__` has already run and cannot see it.

The post-hoc `setattr` gap is inherent — the checks run at class creation and config conversion. Catching it needs a metaclass `__setattr__`, which is disproportionate for a path nobody writes deliberately. Documented in the docstring and pinned by a test framed as a limitation, so if it ever starts warning the test says to update the docs rather than treating it as a break.

### Design notes

`UserWarning`, not `DeprecationWarning`: a misconfiguration, not a scheduled removal, and `0.0` stays legal for anyone relying on it.

Dedup keys on the **config**, not the object. Keying on `id(DynamicClass)` creates a new key per call, so loading one config in a loop floods stderr (200 loads → 192 warnings) and grows the process-global `_warned` set without bound. `_config_identity()` appends sorted field names for anonymous models, which is stable across repeated loads and distinct between configs. That also fixes a subtler problem: Python's `__warningregistry__` is keyed on the message, so two anonymous configs producing byte-identical text printed only **once** under the default action — losing the second misconfiguration even though `warn_once` approved it.

`stacklevel=1`. The call sites sit behind `__init_subclass__` → `ABCMeta.__new__` → `ModelMetaclass.__new__` plus a C frame, at differing depths, so no constant reaches user code — `4` landed inside `<frozen abc>`. The message names the exact site instead.

Verified the internal capture-all sentinel stays silent: `ComparisonHelper.compare_unordered_lists` builds `HungarianMatcher(match_threshold=0.0)` deliberately and reads only `matched_pairs`. A normal `compare_with()` emits nothing.

## Testing

36 tests in `tests/structured_object_evaluator/test_threshold_zero_warning.py`.

**Mutation-tested each guard** to confirm they're load-bearing. Removing the bool guard, widening `== 0.0` to `<= 0.05`, restoring the "perfect precision and recall" claim, and making the `match_threshold` message unconditional each fail a test. A fifth mutation (breaking the docs URL) initially passed — the assertion was `THRESHOLD_DOCS_URL in message`, comparing the constant to itself. Fixed to assert the literal target.

**1676 passed, 2 skipped.** Green at `-n 4`. `ruff check src/ tests/` clean. Re-confirmed no well-configured public path warns under `-W error::UserWarning` (`compare_with`, `to_stickler_config` → `model_from_json`, `to_json_schema` → `from_json_schema`, `import stickler`).

## Reviewers
@vawsgit — this is finding B from your #225 review. Your review of the first revision found seven issues; all are addressed, and verifying that work turned up two more of my own errors (the mirrored precision over-claim and the `id()` dedup key), both fixed here.

## Checklist
- [x] Code follows the project's coding standards
- [x] Self-review of code completed
- [x] Documentation updated (if applicable)
- [x] Tests added/updated for new functionality
- [x] All existing tests pass
- [x] Ready for review
