### PR TITLE
docs: backfill missing CHANGELOG entries and settle the refactor convention (#213)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -34,6 +34,8 @@ Fixes #[issue_number]
 - [ ] Code follows the project's coding standards
 - [ ] Self-review of code completed
 - [ ] Documentation updated (if applicable)
+- [ ] `CHANGELOG.md` entry added under `[Unreleased]`, or not needed because
+      nothing user-visible changed (see [RELEASING.md](../../RELEASING.md))
 - [ ] Tests added/updated for new functionality
 - [ ] All CI checks are passing
 - [ ] Ready for review

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,20 @@ Each release links to full notes on the
 
 ### Fixed
 
+- Accept an explicit `null` for an optional field built from a JSON Schema.
+  `from_json({"note": None})` raised `ValidationError` for a `{"type":
+  "string"}` property absent from `required`; it now constructs and scores.
+  Required fields are unaffected and still reject `None`. Only reproduced for
+  fields nested at least one level down, and only on the
+  `process_rich_values=True` path, which is why plain `ModelClass(**data)`
+  appeared to work ([#159](https://github.com/awslabs/stickler/pull/159))
+
+- `ConfigurationHelper.is_structured_field_type()` now recognises
+  `Optional[SomeStructuredModel]`, where it previously returned `False`. This
+  affects hand-written `StructuredModel` classes as well as schema-built ones,
+  so a nullable nested model is now dispatched as a structured field rather
+  than a primitive ([#159](https://github.com/awslabs/stickler/pull/159))
+
 - The Hungarian single-item shortcut now classifies pairs the same way the
   general multi-item path does, so a confusion-matrix result no longer depends
   on how many items happen to be in a list. Previously a 1-vs-1 comparison at
@@ -171,6 +185,21 @@ Each release links to full notes on the
   `registry.get("LLMComparator")` reports it missing
 
 ### Changed
+
+- Optional fields built from a JSON Schema are now annotated `Optional[T]`
+  rather than `T`, so `to_json_schema()` exports them with a nullable type:
+
+  | | before | after |
+  |---|---|---|
+  | `to_json_schema()` | `{"type": "string"}` | `{"type": ["string", "null"]}` |
+  | `model_json_schema()` | `{"type": "string"}` | `{"anyOf": [{"type": "string"}, {"type": "null"}]}` |
+
+  The two spellings differ because `model_json_schema()` is Pydantic's own
+  rendering of `Optional[T]`, while `to_json_schema()` uses the list form.
+  Meaning is preserved and re-import is idempotent, but the exported bytes
+  differ from the input schema, which matters when feeding our output into a
+  validator or a codegen tool. `required` membership is unchanged
+  ([#159](https://github.com/awslabs/stickler/pull/159))
 
 - **Breaking:** the peripheral modules now require their extra. `pandas`,
   `scipy`, `scikit-learn`, and `jinja2` are no longer core dependencies, so

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,6 +51,21 @@ git push origin dev
 Also add a `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md` (move entries
 out of `[Unreleased]`) in the same commit.
 
+### What belongs in the changelog
+
+Entries are for changes a user can observe. A PR needs one when it changes
+behaviour, an exported format, a public signature, a default, or a dependency,
+and when it fixes a bug someone could have hit.
+
+Internal refactors with no runtime change do **not** get an entry: dead-code
+removal, moving a private helper, renaming something not exported. `git log` is
+the record for those. This is the existing convention, made explicit here
+because it had been applied by default rather than by decision
+([#213](https://github.com/awslabs/stickler/issues/213)).
+
+When in doubt, ask whether a user reading the release notes could act on it. If
+not, leave it out.
+
 ## 3. Open the release PR
 
 ```bash


### PR DESCRIPTION
# Pull Request

## Issue Reference
Closes #213

## Description of Changes

Backfills the missing `[Unreleased]` entries, settles the convention question, and adds the process guard.

### Scope

Only #159 and #183 have merged. **#146 and #198 are still open**, so their entries belong with those PRs rather than being written here for behaviour that has not landed.

### #159 — three entries

Verified every claim against the merge parent (`b78c1f0`) rather than trusting the issue text, which describes the export shape incorrectly:

| | before | after |
|---|---|---|
| `to_json_schema()` | `{"type": "string"}` | `{"type": ["string", "null"]}` |
| `model_json_schema()` | `{"type": "string"}` | `{"anyOf": [{"type": "string"}, {"type": "null"}]}` |

The issue says both emit `anyOf`. Only `model_json_schema()` does, because that is Pydantic's own rendering of `Optional[T]`; `to_json_schema()` uses the list form. The `Changed` entry documents both, since a reader feeding our output into a validator or codegen tool needs whichever they actually call.

The other claims held and are written up as `Fixed`:

- explicit `null` now accepted for an optional schema-built field (`ValidationError` before), required fields still reject `None`, re-import still idempotent
- `is_structured_field_type()` now returns `True` for `Optional[SomeStructuredModel]`, where it returned `False`

That last one needed a `FieldInfo` to reproduce, not a bare annotation — passing the annotation returns `False` on both sides, which would have read as the claim being wrong.

### #183 — deliberately no entry

44 lines of a duplicate private helper removed, no runtime change. The issue asked for a decision rather than a default, so the convention is now written down in `RELEASING.md`: entries are for changes a user can observe, internal refactors are `git log`'s job. 0.6.0's notes already followed this, it just had not been stated anywhere.

### Process guard

Added a `CHANGELOG.md` checkbox to the PR template, phrased so that "not needed because nothing user-visible changed" is an explicit choice rather than an omission, and linking the new `RELEASING.md` section. Every gap in #213 is a PR that passed review without an entry, which points at the process rather than the authors.

## Testing

**1746 passed, 2 skipped.** `mkdocs build` clean. Confirmed the template's relative link to `RELEASING.md` resolves from `.github/PULL_REQUEST_TEMPLATE/`.

No source changes.

## Reviewers
@vawsgit

## Checklist
- [x] Code follows the project's coding standards
- [x] Self-review of code completed
- [x] Documentation updated (if applicable)
- [x] `CHANGELOG.md` entry added under `[Unreleased]`, or not needed because nothing user-visible changed
- [ ] Tests added/updated for new functionality (docs-only)
- [x] All existing tests pass
- [x] Ready for review

## Additional Notes

#213 also lists #146 and #198. Both are still open; their entries should land with them, and the new template checkbox is what should catch that at review time.
