### PR TITLE
Feature/239 infer unspecified fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,17 @@ Each release links to full notes on the
   `format: date-time` fields into `datetime.date` / `datetime.datetime` types
   and `enum` string fields into synthesized `Enum` subclasses, so downstream
   inference picks `DateComparator` and `ExactComparator` rather than the
-  character-edit-distance default. Enabling the flag will shift metrics for
-  any field it fires on relative to the pre-flag `LevenshteinComparator @ 0.5`
+  character-edit-distance default. The enrichment also flows through
+  `List[primitive]` items — an array of `format: date` strings becomes
+  `List[datetime.date]` under the flag. One side effect worth noting: once
+  a field's annotation becomes `datetime.date` (or a synthesized `Enum`),
+  Pydantic validates values at model construction — a data instance with
+  an invalid ISO date string, or an enum value outside the declared set,
+  now raises where the pre-flag pipeline coerced the raw string. This is
+  the intended tightening, but callers whose fixtures include malformed
+  dates or enum values should expect stricter validation once they flip
+  the flag on. Enabling the flag will also shift metrics for any field it
+  fires on relative to the pre-flag `LevenshteinComparator @ 0.5`
   fallback — that's the point of the flag, but callers should re-baseline
   when they turn it on. On the `model_from_json` path, the flag also relaxes
   the existing `"primitive fields require a 'comparator'"` validation gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,46 @@ Each release links to full notes on the
 
 ### Added
 
+- Opt-in `infer_unspecified_fields` flag on `StructuredModel.model_from_json`
+  and `StructuredModel.from_json_schema` that routes fields without a
+  comparator through `stickler.auto.inference` for a type + name-aware pick.
+  Off by default; on preserves existing behavior for fields that DO declare a
+  comparator and, on the JSON Schema path, for fields whose schema carries an
+  `x-aws-stickler-comparator` extension. When the flag fires, the four
+  parameters (`comparator`, `threshold`, `weight`, `clip_under_threshold`)
+  merge per-parameter: the author's explicit values win over the inferred
+  defaults for that specific parameter, so a config that specifies only
+  `threshold` gets that threshold paired with an inferred comparator. On the
+  JSON Schema path, the flag additionally enriches `format: date` /
+  `format: date-time` fields into `datetime.date` / `datetime.datetime` types
+  and `enum` string fields into synthesized `Enum` subclasses, so downstream
+  inference picks `DateComparator` and `ExactComparator` rather than the
+  character-edit-distance default. Enabling the flag will shift metrics for
+  any field it fires on relative to the pre-flag `LevenshteinComparator @ 0.5`
+  fallback — that's the point of the flag, but callers should re-baseline
+  when they turn it on. On the `model_from_json` path, the flag also relaxes
+  the existing `"primitive fields require a 'comparator'"` validation gate
+  (which stays intact when the flag is off); when the flag is on, an omitted
+  comparator is filled in by inference rather than raising.
+
+  Provenance for every inferred field is retrievable via
+  `model.model_fields[field_name].json_schema_extra._provenance` — a list of
+  ordered rule-application strings such as
+  `["type:str -> LevenshteinComparator@0.7",
+    "name-token:invoice_id -> ExactComparator@1.0"]`. Absence of the attribute
+  (or an empty list) signals an author-configured field. This channel is the
+  same one that already carries `_comparator_instance` / `_threshold` /
+  `_weight` metadata, so no new schema-extension key is introduced. Reads no
+  worse than one extra attribute lookup per field.
+
+  Hand-written `StructuredModel` subclasses (fields declared with a bare
+  annotation and no `ComparableField`) remain on the pre-existing
+  `ConfigurationHelper.get_comparison_info` fallback — the same defect they
+  had before this PR. That path has no natural opt-in surface (it lives in
+  Python code, not config) and warrants its own opt-in mechanism; filed as a
+  follow-up ([#239](https://github.com/awslabs/stickler/issues/239) mentions
+  this scope decision explicitly).
+
 - A `UserWarning` when a field `threshold` or a model `match_threshold` is set
   to exactly `0.0`. The threshold test is `>=`, so `0.0` is satisfied by every
   score including `0.0` itself: every compared pair counts as a true positive,

--- a/src/stickler/structured_object_evaluator/models/field_converter.py
+++ b/src/stickler/structured_object_evaluator/models/field_converter.py
@@ -21,13 +21,26 @@ class FieldConverter:
         pass
 
     def convert_field_config(
-        self, field_name: str, field_config: Dict[str, Any]
+        self,
+        field_name: str,
+        field_config: Dict[str, Any],
+        *,
+        infer_unspecified_fields: bool = False,
     ) -> Tuple[Type, Any]:
         """Convert a JSON field configuration to a Pydantic field definition.
 
         Args:
             field_name: Name of the field
             field_config: JSON configuration for the field
+            infer_unspecified_fields: When True, a field without a
+                ``comparator`` key routes through ``stickler.auto.inference``
+                to pick a type + name-aware default (with the operator's
+                explicit ``threshold`` / ``weight`` still winning per
+                parameter). Off by default; when off, this method's behavior
+                is unchanged from before the flag (the pre-existing
+                Levenshtein fallback stays in place, though in practice the
+                validation step at ``validate_nested_field_schema`` rejects
+                missing-comparator configs before this method sees them).
 
         Returns:
             Tuple of (field_type, pydantic_field)
@@ -46,7 +59,11 @@ class FieldConverter:
             "list_structured_model",
             "optional_structured_model",
         ]:
-            return self._convert_nested_model_field(field_name, field_config)
+            return self._convert_nested_model_field(
+                field_name,
+                field_config,
+                infer_unspecified_fields=infer_unspecified_fields,
+            )
 
         # Handle primitive fields (existing logic)
         # Resolve the type
@@ -55,9 +72,34 @@ class FieldConverter:
         except ValueError as e:
             raise ValueError(f"Invalid type for field '{field_name}': {e}")
 
-        # Extract comparator configuration
-        comparator_name = field_config.get("comparator", "LevenshteinComparator")
-        comparator_config = field_config.get("comparator_config", {})
+        # Comparator selection. Three paths merge here:
+        #   1. Author declared ``comparator`` — honor it verbatim.
+        #   2. ``infer_unspecified_fields`` is ON and ``comparator`` is
+        #      absent — route through ``stickler.auto.inference``. The
+        #      resulting InferredSpec provides defaults for ``comparator``,
+        #      ``threshold``, ``weight``, and ``clip_under_threshold`` that
+        #      the author can still override per-parameter below.
+        #   3. Flag is OFF and ``comparator`` is absent — legacy behavior:
+        #      Levenshtein. In practice validate_nested_field_schema
+        #      rejects this before we get here, so path 3 is only
+        #      reachable when the caller bypassed validation.
+        inferred_spec = None
+        if "comparator" in field_config:
+            comparator_name = field_config["comparator"]
+            comparator_config = field_config.get("comparator_config", {})
+        elif infer_unspecified_fields:
+            from pydantic.fields import FieldInfo as _AutoFieldInfo
+
+            from ...auto.inference import infer_field_config
+
+            inferred_spec = infer_field_config(
+                field_name, _AutoFieldInfo(annotation=field_type)
+            )
+            comparator_name = inferred_spec.comparator_name
+            comparator_config = inferred_spec.comparator_config
+        else:
+            comparator_name = "LevenshteinComparator"
+            comparator_config = field_config.get("comparator_config", {})
 
         # Create comparator instance
         try:
@@ -65,10 +107,21 @@ class FieldConverter:
         except (KeyError, TypeError) as e:
             raise ValueError(f"Invalid comparator for field '{field_name}': {e}")
 
-        # Extract other field parameters
-        threshold = field_config.get("threshold", 0.5)
-        weight = field_config.get("weight", 1.0)
-        clip_under_threshold = field_config.get("clip_under_threshold", True)
+        # Extract other field parameters. When inference fired, each
+        # parameter falls back to the InferredSpec value if the author
+        # didn't declare it — per-parameter merge, matching Decision 2.
+        # When inference didn't fire, fall back to the historical flat
+        # defaults (0.5 / 1.0 / True).
+        if inferred_spec is not None:
+            threshold = field_config.get("threshold", inferred_spec.threshold)
+            weight = field_config.get("weight", inferred_spec.weight)
+            clip_under_threshold = field_config.get(
+                "clip_under_threshold", inferred_spec.clip_under_threshold
+            )
+        else:
+            threshold = field_config.get("threshold", 0.5)
+            weight = field_config.get("weight", 1.0)
+            clip_under_threshold = field_config.get("clip_under_threshold", True)
         # Reading a config is not an explicit use of the deprecated `aggregate`
         # parameter: `to_stickler_config()` writes the key for every field, so
         # passing it through would warn on every round trip -- blaming this
@@ -118,10 +171,25 @@ class FieldConverter:
 
         _restore_deprecated_aggregate(comparable_field, config_aggregate)
 
+        # Attach provenance for retrieval when inference fired. Consumers
+        # read ``model.model_fields[name].json_schema_extra._provenance``
+        # to see the ordered rule trace, e.g.
+        # ``["type:str -> LevenshteinComparator@0.7",
+        #    "name-token:invoice_id -> ExactComparator@1.0"]``. Missing
+        # attribute (or empty list) = author-configured comparator.
+        if inferred_spec is not None:
+            extra = comparable_field.json_schema_extra
+            if extra is not None:
+                extra._provenance = list(inferred_spec.provenance)
+
         return field_type, comparable_field
 
     def _convert_nested_model_field(
-        self, field_name: str, field_config: Dict[str, Any]
+        self,
+        field_name: str,
+        field_config: Dict[str, Any],
+        *,
+        infer_unspecified_fields: bool = False,
     ) -> Tuple[Type, Any]:
         """Convert a nested structured model field configuration.
 
@@ -137,7 +205,6 @@ class FieldConverter:
         """
         from typing import List, Optional
 
-
         type_string = field_config["type"]
         nested_fields_config = field_config["fields"]
 
@@ -151,8 +218,12 @@ class FieldConverter:
             "match_threshold": field_config.get("match_threshold", 0.7),
         }
 
-        # Create the nested model class
-        NestedModelClass = StructuredModel.model_from_json(nested_config)
+        # Create the nested model class. Thread the flag through so
+        # nested un-annotated fields inherit the caller's inference choice.
+        NestedModelClass = StructuredModel.model_from_json(
+            nested_config,
+            infer_unspecified_fields=infer_unspecified_fields,
+        )
 
         # Determine the field type based on the type string
         if type_string == "structured_model":
@@ -222,12 +293,16 @@ class FieldConverter:
         return field_type, comparable_field
 
     def convert_fields_config(
-        self, fields_config: Dict[str, Dict[str, Any]]
+        self,
+        fields_config: Dict[str, Dict[str, Any]],
+        *,
+        infer_unspecified_fields: bool = False,
     ) -> Dict[str, Tuple[Type, Field]]:
         """Convert multiple field configurations.
 
         Args:
             fields_config: Dictionary of field configurations
+            infer_unspecified_fields: Threaded through to ``convert_field_config``.
 
         Returns:
             Dictionary mapping field names to (type, field) tuples
@@ -240,7 +315,9 @@ class FieldConverter:
         for field_name, field_config in fields_config.items():
             try:
                 field_type, pydantic_field = self.convert_field_config(
-                    field_name, field_config
+                    field_name,
+                    field_config,
+                    infer_unspecified_fields=infer_unspecified_fields,
                 )
                 field_definitions[field_name] = (field_type, pydantic_field)
             except ValueError as e:
@@ -249,7 +326,11 @@ class FieldConverter:
         return field_definitions
 
     def validate_field_config(
-        self, field_name: str, field_config: Dict[str, Any]
+        self,
+        field_name: str,
+        field_config: Dict[str, Any],
+        *,
+        infer_unspecified_fields: bool = False,
     ) -> None:
         """Validate a field configuration without converting it.
 
@@ -308,20 +389,34 @@ class FieldConverter:
                         f"Field '{field_name}' parameter '{param}' must be boolean, got {type(value)}"
                     )
 
-    def validate_fields_config(self, fields_config: Dict[str, Dict[str, Any]]) -> None:
+    def validate_fields_config(
+        self,
+        fields_config: Dict[str, Dict[str, Any]],
+        *,
+        infer_unspecified_fields: bool = False,
+    ) -> None:
         """Validate multiple field configurations.
 
         Args:
             fields_config: Dictionary of field configurations
+            infer_unspecified_fields: Threaded through to ``validate_field_config``.
 
         Raises:
             ValueError: If any field configuration is invalid
         """
         for field_name, field_config in fields_config.items():
-            self.validate_field_config(field_name, field_config)
+            self.validate_field_config(
+                field_name,
+                field_config,
+                infer_unspecified_fields=infer_unspecified_fields,
+            )
 
     def validate_nested_field_schema(
-        self, field_name: str, field_config: Dict[str, Any]
+        self,
+        field_name: str,
+        field_config: Dict[str, Any],
+        *,
+        infer_unspecified_fields: bool = False,
     ) -> None:
         """Validate schema for nested structured model fields.
 
@@ -364,7 +459,9 @@ class FieldConverter:
             # Validate each nested field
             for nested_field_name, nested_field_config in nested_fields.items():
                 self.validate_nested_field_schema(
-                    f"{field_name}.{nested_field_name}", nested_field_config
+                    f"{field_name}.{nested_field_name}",
+                    nested_field_config,
+                    infer_unspecified_fields=infer_unspecified_fields,
                 )
 
         else:
@@ -375,8 +472,13 @@ class FieldConverter:
                     "Only structured_model types can have nested fields."
                 )
 
-            # Primitive fields must have comparators
-            if "comparator" not in field_config:
+            # Primitive fields must have comparators — unless the caller
+            # opted into ``infer_unspecified_fields``, in which case an
+            # absent comparator is filled in by ``stickler.auto.inference``
+            # at convert time (see ``convert_field_config``). Flag off
+            # preserves the original strict behavior, so every existing
+            # test at ``test_model_from_json.py:792-804`` still passes.
+            if "comparator" not in field_config and not infer_unspecified_fields:
                 raise ValueError(
                     f"Field '{field_name}' with primitive type '{field_type}' requires a 'comparator'. "
                     "Primitive fields need comparators to define how they should be compared."
@@ -397,54 +499,52 @@ def get_global_converter() -> FieldConverter:
 
 
 def convert_field_config(
-    field_name: str, field_config: Dict[str, Any]
+    field_name: str,
+    field_config: Dict[str, Any],
+    *,
+    infer_unspecified_fields: bool = False,
 ) -> Tuple[Type, Field]:
-    """Convert a field configuration using the global converter.
-
-    Args:
-        field_name: Name of the field
-        field_config: JSON configuration for the field
-
-    Returns:
-        Tuple of (field_type, pydantic_field)
-    """
-    return _global_converter.convert_field_config(field_name, field_config)
+    """Convert a field configuration using the global converter."""
+    return _global_converter.convert_field_config(
+        field_name,
+        field_config,
+        infer_unspecified_fields=infer_unspecified_fields,
+    )
 
 
 def convert_fields_config(
     fields_config: Dict[str, Dict[str, Any]],
+    *,
+    infer_unspecified_fields: bool = False,
 ) -> Dict[str, Tuple[Type, Field]]:
-    """Convert multiple field configurations using the global converter.
-
-    Args:
-        fields_config: Dictionary of field configurations
-
-    Returns:
-        Dictionary mapping field names to (type, field) tuples
-    """
-    return _global_converter.convert_fields_config(fields_config)
+    """Convert multiple field configurations using the global converter."""
+    return _global_converter.convert_fields_config(
+        fields_config,
+        infer_unspecified_fields=infer_unspecified_fields,
+    )
 
 
-def validate_field_config(field_name: str, field_config: Dict[str, Any]) -> None:
-    """Validate a field configuration using the global converter.
+def validate_field_config(
+    field_name: str,
+    field_config: Dict[str, Any],
+    *,
+    infer_unspecified_fields: bool = False,
+) -> None:
+    """Validate a field configuration using the global converter."""
+    _global_converter.validate_field_config(
+        field_name,
+        field_config,
+        infer_unspecified_fields=infer_unspecified_fields,
+    )
 
-    Args:
-        field_name: Name of the field
-        field_config: JSON configuration for the field
 
-    Raises:
-        ValueError: If configuration is invalid
-    """
-    _global_converter.validate_field_config(field_name, field_config)
-
-
-def validate_fields_config(fields_config: Dict[str, Dict[str, Any]]) -> None:
-    """Validate multiple field configurations using the global converter.
-
-    Args:
-        fields_config: Dictionary of field configurations
-
-    Raises:
-        ValueError: If any field configuration is invalid
-    """
-    _global_converter.validate_fields_config(fields_config)
+def validate_fields_config(
+    fields_config: Dict[str, Dict[str, Any]],
+    *,
+    infer_unspecified_fields: bool = False,
+) -> None:
+    """Validate multiple field configurations using the global converter."""
+    _global_converter.validate_fields_config(
+        fields_config,
+        infer_unspecified_fields=infer_unspecified_fields,
+    )

--- a/src/stickler/structured_object_evaluator/models/json_schema_field_converter.py
+++ b/src/stickler/structured_object_evaluator/models/json_schema_field_converter.py
@@ -4,6 +4,8 @@ This module provides utilities for converting JSON Schema properties to
 Pydantic Field instances with ComparableField functionality.
 """
 
+import datetime
+import enum
 from typing import Any, Dict, List, Optional, Tuple, Type, Union, get_args, get_origin
 
 from pydantic.fields import FieldInfo
@@ -19,12 +21,36 @@ JSON_TYPE_TO_PYTHON_TYPE = {
     "boolean": bool,
 }
 
+# String-format enrichment. When a JSON Schema property is ``type: string``
+# with a recognized ``format`` hint, we return the richer Python type so
+# downstream comparator selection (and Stickler's auto-inference, if the
+# caller has enabled ``infer_unspecified_fields``) can pick a type-aware
+# comparator — ``DateComparator`` for date-shaped values rather than the
+# character-edit-distance default. Only the two calendar formats are honored
+# for now; other JSON Schema formats (uuid, email, uri, etc.) still resolve
+# to plain ``str`` because we don't yet have first-class comparators for
+# them and rich strings still evaluate correctly under the string default.
+STRING_FORMAT_TO_PYTHON_TYPE = {
+    "date": datetime.date,
+    "date-time": datetime.datetime,
+}
+
 # Bidirectional type mappings for export
 PYTHON_TYPE_TO_JSON_TYPE = {
     str: "string",
     int: "integer",
     float: "number",
     bool: "boolean",
+    datetime.date: "string",
+    datetime.datetime: "string",
+}
+
+# Format hint emitted alongside ``type: string`` on export so the round
+# trip re-imports as the richer type — otherwise export would silently
+# downgrade a ``datetime.date`` field to plain ``str``.
+PYTHON_TYPE_TO_STRING_FORMAT = {
+    datetime.date: "date",
+    datetime.datetime: "date-time",
 }
 
 PYTHON_TYPE_TO_STICKLER_TYPE = {
@@ -32,9 +58,15 @@ PYTHON_TYPE_TO_STICKLER_TYPE = {
     int: "int",
     float: "float",
     bool: "bool",
+    datetime.date: "date",
+    datetime.datetime: "datetime",
 }
 
-# Default comparator mapping from JSON Schema types to comparator class names
+# Default comparator mapping from JSON Schema types to comparator class names.
+# Used only when the caller did not pass ``x-aws-stickler-comparator`` AND the
+# ``infer_unspecified_fields`` flag is OFF — this is the legacy flat-default
+# fallback. When the flag is ON, ``stickler.auto.inference`` decides based on
+# type + name and this table is bypassed.
 JSON_TYPE_TO_DEFAULT_COMPARATOR = {
     "string": "LevenshteinComparator",
     "number": "NumericComparator",
@@ -43,24 +75,121 @@ JSON_TYPE_TO_DEFAULT_COMPARATOR = {
 }
 
 
+# Cache of Enum classes we've synthesized from JSON Schema ``enum`` values.
+# Keyed by ``(field_path, tuple(enum_values))`` so distinct fields with the
+# same value set still get distinct Enum classes (mirroring how a hand-authored
+# model would declare a fresh Enum subclass per field), while re-visiting the
+# same field on repeated calls (e.g. round-trip export/re-import in tests)
+# returns the same class object rather than a stream of near-duplicates.
+_ENUM_CLASS_CACHE: Dict[Tuple[str, Tuple[Any, ...]], Type[enum.Enum]] = {}
+
+
+def _resolve_python_type(
+    json_type: str, property_schema: Dict[str, Any], field_path: str = ""
+) -> Any:
+    """Resolve a JSON Schema property to its richest Python type.
+
+    Order of precedence:
+    1. ``type: string`` with ``format: date`` / ``date-time`` → ``datetime.date`` / ``datetime.datetime``.
+    2. ``type: string`` with an ``enum`` list of strings → a synthesized ``Enum`` subclass.
+    3. Fallback to the primitive ``JSON_TYPE_TO_PYTHON_TYPE`` mapping (``str``,
+       ``int``, ``float``, ``bool``).
+
+    Enum synthesis: builds a Python ``Enum`` class named after the field
+    path (sanitized) whose members map ``UPPERCASED_VALUE`` → the original
+    string. Numeric / mixed-type enums fall through to the primitive
+    mapping — Stickler's inference layer picks ``ExactComparator`` for
+    those via the general ``_is_literal`` check when the schema value is
+    homogeneous, but non-string enums are less common and we don't try to
+    build heterogeneous Enum classes here.
+    """
+    # Format-hinted string first (calendar types).
+    if json_type == "string":
+        fmt = property_schema.get("format")
+        if isinstance(fmt, str) and fmt in STRING_FORMAT_TO_PYTHON_TYPE:
+            return STRING_FORMAT_TO_PYTHON_TYPE[fmt]
+
+        # String enum: build (or retrieve) a synthesized Enum class. Only
+        # done when the schema declares an ``enum`` and all values are
+        # strings; heterogeneous enums still resolve to ``str``.
+        enum_values = property_schema.get("enum")
+        if (
+            isinstance(enum_values, list)
+            and enum_values
+            and all(isinstance(v, str) for v in enum_values)
+        ):
+            cache_key = (field_path or "", tuple(enum_values))
+            cached = _ENUM_CLASS_CACHE.get(cache_key)
+            if cached is not None:
+                return cached
+            # Enum class name: derived from the field path so the generated
+            # class is greppable. Sanitize aggressively — a JSON Schema
+            # field path can contain dots, brackets, spaces, etc.
+            sanitized = "".join(
+                c if c.isalnum() else "_" for c in (field_path or "Field")
+            )
+            if not sanitized or sanitized[0].isdigit():
+                sanitized = f"_{sanitized}"
+            class_name = f"{sanitized}Enum"
+            # Member names: uppercased value with non-alphanumerics folded
+            # to ``_``; collisions on the sanitized member name would
+            # otherwise raise, so append a numeric suffix if needed.
+            member_names: Dict[str, str] = {}
+            for value in enum_values:
+                name = "".join(c if c.isalnum() else "_" for c in value.upper())
+                if not name or name[0].isdigit():
+                    name = f"_{name}"
+                original = name
+                suffix = 1
+                while name in member_names:
+                    name = f"{original}_{suffix}"
+                    suffix += 1
+                member_names[name] = value
+            enum_cls = enum.Enum(class_name, member_names)  # type: ignore[call-overload]
+            _ENUM_CLASS_CACHE[cache_key] = enum_cls
+            return enum_cls
+
+    if json_type not in JSON_TYPE_TO_PYTHON_TYPE:
+        raise ValueError(
+            f"Unsupported JSON Schema type: {json_type}. "
+            f"Supported types: {list(JSON_TYPE_TO_PYTHON_TYPE.keys())}"
+        )
+    return JSON_TYPE_TO_PYTHON_TYPE[json_type]
+
+
 class JsonSchemaFieldConverter:
     """Converter for JSON Schema properties to/from Pydantic fields with comparison capabilities.
-    
+
     This class handles bidirectional conversion:
     - Import: JSON Schema → Pydantic Field (existing functionality)
     - Export: Pydantic Field → JSON Schema (new functionality)
-    
+
     It extracts x-aws-stickler-* extensions and calls ComparableField() to create Pydantic Fields.
     """
 
-    def __init__(self, schema: Dict[str, Any], field_path: str = ""):
+    def __init__(
+        self,
+        schema: Dict[str, Any],
+        field_path: str = "",
+        *,
+        infer_unspecified_fields: bool = False,
+    ):
         """Initialize with a JSON Schema document.
-        
+
         Args:
             schema: JSON Schema document (already validated)
             field_path: Current field path for error messages (e.g., "address.street")
+            infer_unspecified_fields: When True, fields whose schema has no
+                ``x-aws-stickler-comparator`` extension route through
+                ``stickler.auto.inference`` for a type + name-aware comparator
+                pick (with per-parameter override — the operator's explicit
+                ``x-aws-stickler-threshold`` / ``-weight`` still win). Also
+                enables ``format: date`` / ``format: date-time`` / ``enum``
+                type enrichment on primitive property mapping. Off by default;
+                the pre-existing flat-default behavior is preserved.
         """
         self.schema = schema
+        self.infer_unspecified_fields = infer_unspecified_fields
         self.definitions = schema.get("definitions", {})
         self.defs = schema.get("$defs", {})  # JSON Schema draft 2019-09+
         self.field_path = field_path
@@ -69,13 +198,13 @@ class JsonSchemaFieldConverter:
         self, properties: Dict[str, Any], required: List[str]
     ) -> Dict[str, Tuple[Type, Any]]:
         """Convert JSON Schema properties to Pydantic field definitions.
-        
+
         This is the main entry point, similar to FieldConverter.convert_fields_config().
-        
+
         Args:
             properties: JSON Schema properties object
             required: List of required field names
-            
+
         Returns:
             Dictionary mapping field names to (type, Field) tuples for create_model()
         """
@@ -83,7 +212,9 @@ class JsonSchemaFieldConverter:
         for field_name, property_schema in properties.items():
             is_required = field_name in required
             # Build field path for nested error messages
-            current_path = f"{self.field_path}.{field_name}" if self.field_path else field_name
+            current_path = (
+                f"{self.field_path}.{field_name}" if self.field_path else field_name
+            )
             try:
                 field_type, field = self.convert_property_to_field(
                     field_name, property_schema, is_required, current_path
@@ -97,18 +228,22 @@ class JsonSchemaFieldConverter:
         return field_definitions
 
     def convert_property_to_field(
-        self, field_name: str, property_schema: Dict[str, Any], is_required: bool, field_path: str = None
+        self,
+        field_name: str,
+        property_schema: Dict[str, Any],
+        is_required: bool,
+        field_path: str = None,
     ) -> Tuple[Type, Any]:
         """Convert a single JSON Schema property to a Pydantic field.
-        
+
         Similar to FieldConverter.convert_field_config(), but reads JSON Schema format.
-        
+
         Args:
             field_name: Name of the field
             property_schema: JSON Schema for this property
             is_required: Whether this field is required
             field_path: Full path to this field for error messages
-            
+
         Returns:
             Tuple of (field_type, pydantic_field) where pydantic_field is from ComparableField()
         """
@@ -150,19 +285,69 @@ class JsonSchemaFieldConverter:
                 field_name, property_schema, is_required, field_path
             )
         else:
-            # Handle primitive types
-            field_type = self._map_json_type_to_python_type(json_type)
+            # Handle primitive types. Type enrichment (``format: date`` →
+            # ``datetime.date``, ``enum`` → synthesized ``Enum``) is gated
+            # on ``self.infer_unspecified_fields`` — enrichment changes
+            # the Pydantic value coercion (a date string becomes a
+            # ``date`` object; an enum value becomes an Enum member), so
+            # applying it unconditionally would be a silent behavior
+            # change to schemas that today declare ``format``/``enum``
+            # for documentation only. Flag off = plain-primitive types
+            # exactly as before; flag on = the richer types Stickler's
+            # inference layer can act on.
+            enrich = getattr(self, "infer_unspecified_fields", False)
+            field_type = self._map_json_type_to_python_type(
+                json_type,
+                property_schema if enrich else None,
+                field_path,
+            )
 
             # Extract x-aws-stickler-* extensions
             extensions = self._extract_stickler_extensions(property_schema, field_path)
 
-            # Get comparator (from extension or default)
-            comparator = extensions.get("comparator") or self._get_default_comparator_for_type(json_type)
+            # Comparator selection. Three paths merge here:
+            #   1. ``x-aws-stickler-comparator`` extension is present —
+            #      honor the author's choice verbatim.
+            #   2. Flag is ON and no comparator extension — route through
+            #      ``stickler.auto.inference``. The InferredSpec provides
+            #      defaults for comparator / threshold / weight /
+            #      clip_under_threshold that the author's other
+            #      extensions can still override per-parameter.
+            #   3. Flag is OFF and no comparator extension — legacy
+            #      flat-default fallback (Levenshtein for string, Numeric
+            #      for number/integer, Exact for boolean).
+            inferred_spec = None
+            if extensions.get("comparator") is not None:
+                comparator = extensions["comparator"]
+            elif enrich:
+                from ...auto.inference import infer_field_config
 
-            # Get other parameters
-            threshold = extensions.get("threshold", 0.5)
-            weight = extensions.get("weight", 1.0)
-            clip_under_threshold = extensions.get("clip_under_threshold", True)
+                inferred_spec = infer_field_config(
+                    field_name, FieldInfo(annotation=field_type)
+                )
+                comparator = create_comparator(
+                    inferred_spec.comparator_name,
+                    inferred_spec.comparator_config,
+                )
+            else:
+                comparator = self._get_default_comparator_for_type(
+                    json_type, field_type if enrich else None
+                )
+
+            # Per-parameter merge: when inference fired, its InferredSpec
+            # provides the fallback for each remaining parameter that the
+            # author didn't specify via an extension. When inference did
+            # NOT fire, fall back to the pre-existing flat defaults.
+            if inferred_spec is not None:
+                threshold = extensions.get("threshold", inferred_spec.threshold)
+                weight = extensions.get("weight", inferred_spec.weight)
+                clip_under_threshold = extensions.get(
+                    "clip_under_threshold", inferred_spec.clip_under_threshold
+                )
+            else:
+                threshold = extensions.get("threshold", 0.5)
+                weight = extensions.get("weight", 1.0)
+                clip_under_threshold = extensions.get("clip_under_threshold", True)
 
             # Get Pydantic field parameters (``default`` resolved above, where
             # the widening decision needed it).
@@ -177,8 +362,15 @@ class JsonSchemaFieldConverter:
                 clip_under_threshold=clip_under_threshold,
                 default=default,
                 description=description,
-                examples=examples
+                examples=examples,
             )
+
+            # Attach provenance for retrieval (see FieldConverter for the
+            # same channel on the model_from_json path).
+            if inferred_spec is not None:
+                extra = field.json_schema_extra
+                if extra is not None:
+                    extra._provenance = list(inferred_spec.provenance)
 
         if widen_to_optional:
             field_type = Optional[field_type]
@@ -224,34 +416,83 @@ class JsonSchemaFieldConverter:
             )
         return non_null[0], True
 
-    def _map_json_type_to_python_type(self, json_type: str) -> Type:
-        """Map JSON Schema type to Python type.
-        
-        Args:
-            json_type: JSON Schema type string
-            
-        Returns:
-            Python type
-            
-        Raises:
-            ValueError: If json_type is not supported
-        """
-        if json_type not in JSON_TYPE_TO_PYTHON_TYPE:
-            raise ValueError(
-                f"Unsupported JSON Schema type: {json_type}. "
-                f"Supported types: {list(JSON_TYPE_TO_PYTHON_TYPE.keys())}"
-            )
-        return JSON_TYPE_TO_PYTHON_TYPE[json_type]
+    def _map_json_type_to_python_type(
+        self,
+        json_type: str,
+        property_schema: Optional[Dict[str, Any]] = None,
+        field_path: str = "",
+    ) -> Type:
+        """Map a JSON Schema property to the richest Python type it represents.
 
-    def _get_default_comparator_for_type(self, json_type: str):
-        """Get default comparator instance for a JSON Schema type.
-        
+        When ``property_schema`` is passed and carries a ``format`` hint
+        (``date`` / ``date-time``) or an ``enum`` list of strings, the return
+        type is enriched accordingly — ``datetime.date`` / ``datetime.datetime``
+        for the calendar formats, or a synthesized ``Enum`` subclass for
+        string enums. This is what lets downstream comparator selection (and
+        ``stickler.auto.inference`` when ``infer_unspecified_fields`` is on)
+        pick a type-aware comparator such as ``DateComparator`` for date-shaped
+        strings, rather than the character-edit-distance default.
+
         Args:
             json_type: JSON Schema type string
-            
+            property_schema: Full property subschema. Optional for backward
+                compatibility — callers on the old signature still get the
+                primitive mapping without format/enum enrichment.
+            field_path: Full path to this field, used for naming synthesized
+                Enum classes.
+
+        Returns:
+            Python type (possibly enriched).
+
+        Raises:
+            ValueError: If json_type is not supported.
+        """
+        if property_schema is None:
+            # Legacy call sites — retain original behavior for backward
+            # compatibility with anything importing the class externally.
+            if json_type not in JSON_TYPE_TO_PYTHON_TYPE:
+                raise ValueError(
+                    f"Unsupported JSON Schema type: {json_type}. "
+                    f"Supported types: {list(JSON_TYPE_TO_PYTHON_TYPE.keys())}"
+                )
+            return JSON_TYPE_TO_PYTHON_TYPE[json_type]
+        return _resolve_python_type(json_type, property_schema, field_path)
+
+    def _get_default_comparator_for_type(
+        self, json_type: str, python_type: Optional[Type] = None
+    ):
+        """Get default comparator instance for a JSON Schema type.
+
+        Called only when no comparator extension is present AND the caller
+        did not enable ``infer_unspecified_fields``. Keeps the historical
+        type-only flat-default table intact for the primitive JSON types
+        (``string`` / ``number`` / ``integer`` / ``boolean``).
+
+        For the enriched Python types (``datetime.date`` / ``datetime.datetime``
+        / synthesized ``Enum`` subclasses), returns ``DateComparator`` and
+        ``ExactComparator`` respectively — otherwise the format/enum
+        enrichment above would silently pair with a plain-string comparator
+        and defeat its own purpose.
+
+        Args:
+            json_type: JSON Schema type string.
+            python_type: Optional richer Python type resolved by
+                ``_resolve_python_type``. When provided and it maps to a
+                calendar type or ``Enum`` subclass, its comparator wins over
+                the primitive-type default.
+
         Returns:
             Comparator instance
         """
+        if python_type is not None:
+            if isinstance(python_type, type):
+                if issubclass(python_type, enum.Enum):
+                    return create_comparator("ExactComparator", {})
+                # datetime.datetime is a subclass of datetime.date, so this
+                # order-independent check picks Date for both.
+                if issubclass(python_type, datetime.date):
+                    return create_comparator("DateComparator", {})
+
         comparator_name = JSON_TYPE_TO_DEFAULT_COMPARATOR.get(
             json_type, "LevenshteinComparator"
         )
@@ -261,31 +502,35 @@ class JsonSchemaFieldConverter:
         self, property_schema: Dict[str, Any], field_path: str = ""
     ) -> Dict[str, Any]:
         """Extract x-aws-stickler-* extensions from property schema.
-        
+
         Args:
             property_schema: JSON Schema property object
             field_path: Full path to this field for error messages
-            
+
         Returns:
             Dictionary with extracted comparison configuration
-            
+
         Raises:
             ValueError: If extension values are invalid
         """
         extensions = {}
-        
+
         # Extract comparator
         if "x-aws-stickler-comparator" in property_schema:
             comparator_name = property_schema["x-aws-stickler-comparator"]
-            comparator_config = property_schema.get("x-aws-stickler-comparator-config", {})
+            comparator_config = property_schema.get(
+                "x-aws-stickler-comparator-config", {}
+            )
             try:
-                extensions["comparator"] = create_comparator(comparator_name, comparator_config)
+                extensions["comparator"] = create_comparator(
+                    comparator_name, comparator_config
+                )
             except Exception as e:
                 field_info = f" in field '{field_path}'" if field_path else ""
                 raise ValueError(
                     f"Invalid x-aws-stickler-comparator '{comparator_name}'{field_info}: {e}"
                 )
-        
+
         # Extract and validate threshold
         if "x-aws-stickler-threshold" in property_schema:
             threshold = property_schema["x-aws-stickler-threshold"]
@@ -295,7 +540,7 @@ class JsonSchemaFieldConverter:
                     f"x-aws-stickler-threshold must be a number between 0.0 and 1.0{field_info}, got: {threshold}"
                 )
             extensions["threshold"] = threshold
-        
+
         # Extract and validate weight
         if "x-aws-stickler-weight" in property_schema:
             weight = property_schema["x-aws-stickler-weight"]
@@ -305,7 +550,7 @@ class JsonSchemaFieldConverter:
                     f"x-aws-stickler-weight must be a positive number{field_info}, got: {weight}"
                 )
             extensions["weight"] = weight
-        
+
         # Extract boolean parameters
         if "x-aws-stickler-clip-under-threshold" in property_schema:
             clip_value = property_schema["x-aws-stickler-clip-under-threshold"]
@@ -315,7 +560,7 @@ class JsonSchemaFieldConverter:
                     f"x-aws-stickler-clip-under-threshold must be a boolean{field_info}, got: {type(clip_value).__name__}"
                 )
             extensions["clip_under_threshold"] = clip_value
-        
+
         if "x-aws-stickler-aggregate" in property_schema:
             aggregate_value = property_schema["x-aws-stickler-aggregate"]
             if not isinstance(aggregate_value, bool):
@@ -324,18 +569,18 @@ class JsonSchemaFieldConverter:
                     f"x-aws-stickler-aggregate must be a boolean{field_info}, got: {type(aggregate_value).__name__}"
                 )
             extensions["aggregate"] = aggregate_value
-        
+
         return extensions
 
     def _resolve_ref(self, ref: str) -> Dict[str, Any]:
         """Resolve a $ref reference within the schema.
-        
+
         Args:
             ref: Reference string (e.g., "#/definitions/Address")
-            
+
         Returns:
             Resolved schema object
-            
+
         Raises:
             ValueError: If reference format is unsupported or reference not found
         """
@@ -363,26 +608,30 @@ class JsonSchemaFieldConverter:
             )
 
     def _handle_nested_object(
-        self, field_name: str, property_schema: Dict[str, Any], is_required: bool, field_path: str = None
+        self,
+        field_name: str,
+        property_schema: Dict[str, Any],
+        is_required: bool,
+        field_path: str = None,
     ) -> Tuple[Type, Any]:
         """Handle nested object type (creates nested StructuredModel).
-        
+
         Args:
             field_name: Name of the field
             property_schema: JSON Schema for the nested object
             is_required: Whether this field is required
             field_path: Full path to this field for error messages
-            
+
         Returns:
             Tuple of (NestedModel, ComparableField)
         """
         if field_path is None:
             field_path = field_name
-        
+
         # Recursively create nested model from the nested schema
         # Import here to avoid circular dependency
         from .structured_model import StructuredModel
-        
+
         # CRITICAL: Pass parent schema's definitions/defs to nested schema
         # so that nested $refs can be resolved
         enriched_schema = dict(property_schema)
@@ -390,31 +639,36 @@ class JsonSchemaFieldConverter:
             enriched_schema["definitions"] = self.definitions
         if self.defs and "$defs" not in enriched_schema:
             enriched_schema["$defs"] = self.defs
-        
+
         try:
-            NestedModel = StructuredModel._from_json_schema_internal(enriched_schema, field_path=field_path)
+            NestedModel = StructuredModel._from_json_schema_internal(
+                enriched_schema,
+                field_path=field_path,
+                infer_unspecified_fields=self.infer_unspecified_fields,
+            )
         except ValueError:
             # Nested errors already have field path context
             raise
-        
+
         # Extract extensions for the field itself
         extensions = self._extract_stickler_extensions(property_schema, field_path)
         weight = extensions.get("weight", 1.0)
         clip_under_threshold = extensions.get("clip_under_threshold", True)
-        
+
         # Get default value
         default = property_schema.get("default", ... if is_required else None)
         description = property_schema.get("description")
-        
+
         # Create ComparableField with dummy comparator (not used for StructuredModel)
         from stickler.comparators.levenshtein import LevenshteinComparator
+
         field = ComparableField(
             comparator=LevenshteinComparator(),  # Not used for nested models
             threshold=0.7,  # Use model's match_threshold instead
             weight=weight,
             clip_under_threshold=clip_under_threshold,
             default=default,
-            description=description
+            description=description,
         )
 
         # Annotation widening (Optional[...]) is decided once by the caller
@@ -422,29 +676,33 @@ class JsonSchemaFieldConverter:
         return NestedModel, field
 
     def _handle_array_type(
-        self, field_name: str, property_schema: Dict[str, Any], is_required: bool, field_path: str = None
+        self,
+        field_name: str,
+        property_schema: Dict[str, Any],
+        is_required: bool,
+        field_path: str = None,
     ) -> Tuple[Type, Any]:
         """Handle array type (creates List field).
-        
+
         Args:
             field_name: Name of the field
             property_schema: JSON Schema for the array
             is_required: Whether this field is required
             field_path: Full path to this field for error messages
-            
+
         Returns:
             Tuple of (List[ElementType], ComparableField)
         """
         if field_path is None:
             field_path = field_name
         from typing import List
-        
+
         items_schema = property_schema.get("items", {})
-        
+
         # Handle $ref in items
         if "$ref" in items_schema:
             items_schema = self._resolve_ref(items_schema["$ref"])
-        
+
         items_type, items_nullable = self._normalize_type(
             items_schema.get("type"), f"{field_path}[]"
         )
@@ -452,8 +710,13 @@ class JsonSchemaFieldConverter:
         # Array of objects -> List[StructuredModel]
         if items_type == "object":
             from .structured_model import StructuredModel
+
             try:
-                ElementModel = StructuredModel._from_json_schema_internal(items_schema, field_path=f"{field_path}[]")
+                ElementModel = StructuredModel._from_json_schema_internal(
+                    items_schema,
+                    field_path=f"{field_path}[]",
+                    infer_unspecified_fields=self.infer_unspecified_fields,
+                )
             except ValueError:
                 # Nested errors already have field path context
                 raise
@@ -462,24 +725,35 @@ class JsonSchemaFieldConverter:
             # Use default comparator for the element type
             comparator = self._get_default_comparator_for_type("string")
         else:
-            # Array of primitives -> List[primitive]
-            element_type = self._map_json_type_to_python_type(items_type)
+            # Array of primitives -> List[primitive]. Same enrichment
+            # gating as ``convert_property_to_field`` above — flag off
+            # keeps element type as plain primitive, flag on enriches to
+            # ``datetime.date`` / synthesized ``Enum`` when the items
+            # schema declares a matching ``format`` / ``enum``.
+            enrich = getattr(self, "infer_unspecified_fields", False)
+            element_type = self._map_json_type_to_python_type(
+                items_type,
+                items_schema if enrich else None,
+                f"{field_path}[]",
+            )
             if items_nullable:
                 element_type = Optional[element_type]
             field_type = List[element_type]
-            # Use default comparator for the element type
-            comparator = self._get_default_comparator_for_type(items_type)
-        
+            # Element-type default comparator — same enrichment gating.
+            comparator = self._get_default_comparator_for_type(
+                items_type, element_type if enrich else None
+            )
+
         # Extract extensions from the array property itself
         extensions = self._extract_stickler_extensions(property_schema, field_path)
         # Override comparator if specified in extensions
         if "comparator" in extensions:
             comparator = extensions["comparator"]
-        
+
         threshold = extensions.get("threshold", 0.5)
         weight = extensions.get("weight", 1.0)
         clip_under_threshold = extensions.get("clip_under_threshold", True)
-        
+
         # Get default
         default = property_schema.get("default", ... if is_required else None)
         description = property_schema.get("description")
@@ -491,14 +765,13 @@ class JsonSchemaFieldConverter:
             weight=weight,
             clip_under_threshold=clip_under_threshold,
             default=default,
-            description=description
+            description=description,
         )
 
         # Annotation widening (Optional[...]) is decided once by the caller
         # convert_property_to_field; this handler returns the bare List[...].
         return field_type, field
 
-    
     def field_to_property(
         self, field_type: Type, field_info: FieldInfo, is_nullable: bool = False
     ) -> Dict[str, Any]:
@@ -526,12 +799,14 @@ class JsonSchemaFieldConverter:
 
         json_type = PYTHON_TYPE_TO_JSON_TYPE.get(field_type, "string")
         property_schema = {"type": [json_type, "null"] if is_nullable else json_type}
-        
+
         # Extract metadata and build extensions using consolidated helper
         metadata = self._extract_field_metadata(field_info)
-        extensions = self._build_comparison_extensions(metadata, output_format="json_schema")
+        extensions = self._build_comparison_extensions(
+            metadata, output_format="json_schema"
+        )
         property_schema.update(extensions)
-        
+
         # Add Pydantic field params
         if field_info.description:
             property_schema["description"] = field_info.description
@@ -539,30 +814,34 @@ class JsonSchemaFieldConverter:
             property_schema["alias"] = field_info.alias
         if field_info.examples:
             property_schema["examples"] = field_info.examples
-        
+
         return property_schema
-    
-    def field_to_stickler_config(self, field_type: Type, field_info: FieldInfo) -> Dict[str, Any]:
+
+    def field_to_stickler_config(
+        self, field_type: Type, field_info: FieldInfo
+    ) -> Dict[str, Any]:
         """Convert Pydantic field to Stickler config format.
-        
+
         Extracts comparison metadata and formats it as custom Stickler configuration
         compatible with model_from_json().
-        
+
         Args:
             field_type: Python type annotation (e.g., str, int, float)
             field_info: Pydantic FieldInfo object containing field metadata
-            
+
         Returns:
             Stickler field config dict with type, comparator, threshold, etc.
         """
         stickler_type = PYTHON_TYPE_TO_STICKLER_TYPE.get(field_type, "str")
         field_config = {"type": stickler_type}
-        
+
         # Extract metadata and build extensions using consolidated helper
         metadata = self._extract_field_metadata(field_info)
-        extensions = self._build_comparison_extensions(metadata, output_format="stickler_config")
+        extensions = self._build_comparison_extensions(
+            metadata, output_format="stickler_config"
+        )
         field_config.update(extensions)
-        
+
         # Add Pydantic field params
         field_config["required"] = field_info.is_required()
         if not field_info.is_required():
@@ -573,88 +852,96 @@ class JsonSchemaFieldConverter:
             field_config["alias"] = field_info.alias
         if field_info.examples:
             field_config["examples"] = field_info.examples
-        
+
         return field_config
-    
+
     def _build_comparison_extensions(
-        self, 
-        metadata: Dict[str, Any], 
-        output_format: str = "json_schema"
+        self, metadata: Dict[str, Any], output_format: str = "json_schema"
     ) -> Dict[str, Any]:
         """Build comparison extensions in specified format.
-        
+
         Consolidates duplicate logic from field_to_property() and field_to_stickler_config().
-        
+
         Args:
             metadata: Extracted field metadata from _extract_field_metadata()
             output_format: Output format - "json_schema" or "stickler_config"
-        
+
         Returns:
             Dictionary with comparison extensions in the specified format
         """
         extensions = {}
         if output_format not in ("json_schema", "stickler_config"):
-            raise ValueError(f"Unsupported format: {output_format!r}. Use 'json_schema' or 'stickler_config'.")
+            raise ValueError(
+                f"Unsupported format: {output_format!r}. Use 'json_schema' or 'stickler_config'."
+            )
         prefix = "x-aws-stickler-" if output_format == "json_schema" else ""
-        
+
         # Export comparator class name and configuration
         if metadata.get("comparator"):
             comparator = metadata["comparator"]
             extensions[f"{prefix}comparator"] = comparator.__class__.__name__
-            
+
             # Export comparator configuration (e.g., tolerance, case_sensitive)
             if hasattr(comparator, "config") and comparator.config:
-                config_key = f"{prefix}comparator-config" if output_format == "json_schema" else "comparator_config"
+                config_key = (
+                    f"{prefix}comparator-config"
+                    if output_format == "json_schema"
+                    else "comparator_config"
+                )
                 extensions[config_key] = comparator.config
-        
+
         # Export comparison parameters
         if "threshold" in metadata:
             extensions[f"{prefix}threshold"] = metadata["threshold"]
         if "weight" in metadata:
             extensions[f"{prefix}weight"] = metadata["weight"]
         if metadata.get("clip_under_threshold") is not None:
-            clip_key = f"{prefix}clip-under-threshold" if output_format == "json_schema" else "clip_under_threshold"
+            clip_key = (
+                f"{prefix}clip-under-threshold"
+                if output_format == "json_schema"
+                else "clip_under_threshold"
+            )
             extensions[clip_key] = metadata["clip_under_threshold"]
         if metadata.get("aggregate") is not None:
             extensions[f"{prefix}aggregate"] = metadata["aggregate"]
-        
+
         return extensions
-    
+
     def _extract_field_metadata(self, field_info: FieldInfo) -> Dict[str, Any]:
         """Extract comparison metadata from field's json_schema_extra.
-        
+
         Only includes attributes that are explicitly set (no default values).
-        
+
         Args:
             field_info: Pydantic FieldInfo object
-            
+
         Returns:
             Dictionary with explicitly set comparator, threshold, weight, etc.
             Empty dict if no metadata found.
         """
         if not hasattr(field_info, "json_schema_extra"):
             return {}
-        
+
         json_func = field_info.json_schema_extra
         if not callable(json_func):
             return {}
-        
+
         # Only include attributes that are explicitly set
         metadata = {}
-        
+
         if hasattr(json_func, "_comparator_instance"):
             metadata["comparator"] = json_func._comparator_instance
-        
+
         if hasattr(json_func, "_threshold"):
             metadata["threshold"] = json_func._threshold
-        
+
         if hasattr(json_func, "_weight"):
             metadata["weight"] = json_func._weight
-        
+
         if hasattr(json_func, "_clip_under_threshold"):
             metadata["clip_under_threshold"] = json_func._clip_under_threshold
-        
+
         if hasattr(json_func, "_aggregate"):
             metadata["aggregate"] = json_func._aggregate
-        
+
         return metadata

--- a/src/stickler/structured_object_evaluator/models/json_schema_field_converter.py
+++ b/src/stickler/structured_object_evaluator/models/json_schema_field_converter.py
@@ -81,6 +81,15 @@ JSON_TYPE_TO_DEFAULT_COMPARATOR = {
 # model would declare a fresh Enum subclass per field), while re-visiting the
 # same field on repeated calls (e.g. round-trip export/re-import in tests)
 # returns the same class object rather than a stream of near-duplicates.
+#
+# Growth bound: entries accumulate over process lifetime, one per unique
+# ``(field_path, values)`` tuple ever synthesized. In practice this is bounded
+# by the number of distinct enum fields across all schemas a process loads --
+# a batch job that reloads the same schema in a loop is a cache hit, and even
+# a process that loads thousands of distinct schemas typically shares field
+# names and value sets. No eviction is warranted for the observed use cases;
+# if a caller ever needs to reset the cache (long-lived tests that assert on
+# class identity across generations), clearing the dict is safe.
 _ENUM_CLASS_CACHE: Dict[Tuple[str, Tuple[Any, ...]], Type[enum.Enum]] = {}
 
 

--- a/src/stickler/structured_object_evaluator/models/model_factory.py
+++ b/src/stickler/structured_object_evaluator/models/model_factory.py
@@ -19,24 +19,27 @@ from .threshold_helper import model_identity, warn_if_threshold_is_zero
 
 class ModelFactory:
     """Factory for creating dynamic StructuredModel subclasses from JSON configuration.
-    
+
     This class implements the factory pattern to create StructuredModel subclasses
     dynamically from JSON configuration. It handles:
     - Configuration validation
     - Field definition conversion
     - Dynamic model creation using Pydantic's create_model()
     - Class-level attribute configuration
-    
+
     The factory ensures that all generated models are fully compatible with Pydantic
     while inheriting all StructuredModel comparison capabilities.
     """
 
     @staticmethod
     def create_model_from_json(
-        config: Dict[str, Any], base_class: Type = None
+        config: Dict[str, Any],
+        base_class: Type = None,
+        *,
+        infer_unspecified_fields: bool = False,
     ) -> Type:
         """Create a StructuredModel subclass from JSON configuration.
-        
+
         This method leverages Pydantic's native dynamic model creation capabilities to ensure
         full compatibility with all Pydantic features while adding structured comparison
         functionality through inherited StructuredModel methods.
@@ -111,6 +114,7 @@ class ModelFactory:
         # Import here to avoid circular dependency
         if base_class is None:
             from .structured_model import StructuredModel
+
             base_class = StructuredModel
 
         # Validate configuration structure
@@ -135,23 +139,35 @@ class ModelFactory:
                 f"match_threshold must be a number between 0.0 and 1.0, got: {match_threshold}"
             )
 
-        # Validate all field configurations before proceeding (including nested schema validation)
+        # Validate all field configurations before proceeding (including nested schema validation).
+        # The ``infer_unspecified_fields`` flag threads all the way down to
+        # ``validate_nested_field_schema`` (which owns the "missing comparator
+        # raises" gate) and to ``convert_fields_config`` (which calls
+        # ``stickler.auto.inference`` when the flag is on).
         try:
             converter = get_global_converter()
 
             # First validate basic field configurations
-            validate_fields_config(fields_config)
+            validate_fields_config(
+                fields_config, infer_unspecified_fields=infer_unspecified_fields
+            )
 
             # Then validate nested schema rules
             for field_name, field_config in fields_config.items():
-                converter.validate_nested_field_schema(field_name, field_config)
+                converter.validate_nested_field_schema(
+                    field_name,
+                    field_config,
+                    infer_unspecified_fields=infer_unspecified_fields,
+                )
 
         except ValueError as e:
             raise ValueError(f"Invalid field configuration: {e}")
 
         # Convert field configurations to Pydantic field definitions
         try:
-            field_definitions = convert_fields_config(fields_config)
+            field_definitions = convert_fields_config(
+                fields_config, infer_unspecified_fields=infer_unspecified_fields
+            )
         except ValueError as e:
             raise ValueError(f"Error converting field configurations: {e}")
 
@@ -196,12 +212,12 @@ class ModelFactory:
         base_class: Type = None,
     ) -> Type:
         """Create a StructuredModel subclass from pre-converted Pydantic fields.
-        
+
         This method accepts field definitions that are already in Pydantic's format
         (type, Field) tuples, bypassing the need for intermediate configuration format.
         This is used by the JSON Schema converter and other advanced use cases where
         fields have already been converted to Pydantic format.
-        
+
         Args:
             model_name: Name for the generated class. Must be a valid Python identifier.
             field_definitions: Dictionary mapping field names to (type, Field) tuples.
@@ -212,20 +228,20 @@ class ModelFactory:
                            Must be between 0.0 and 1.0.
             base_class: The base class to extend (typically StructuredModel).
                        If None, will be imported to avoid circular dependency.
-            
+
         Returns:
             A fully functional StructuredModel subclass created with create_model()
-            
+
         Raises:
             ValueError: If model_name is invalid, match_threshold is out of range,
                        or field_definitions are malformed
-            
+
         Examples:
             >>> from pydantic import Field
             >>> from stickler import StructuredModel
             >>> from stickler import ComparableField
             >>> from stickler import LevenshteinComparator
-            >>> 
+            >>>
             >>> # Create field definitions directly
             >>> field_defs = {
             ...     "name": (str, ComparableField(
@@ -239,14 +255,14 @@ class ModelFactory:
             ...         default=0
             ...     ))
             ... }
-            >>> 
+            >>>
             >>> PersonClass = ModelFactory.create_model_from_fields(
             ...     model_name="Person",
             ...     field_definitions=field_defs,
             ...     match_threshold=0.8,
             ...     base_class=StructuredModel
             ... )
-            >>> 
+            >>>
             >>> person = PersonClass(name="Alice", age=30)
             >>> person.name
             'Alice'
@@ -254,6 +270,7 @@ class ModelFactory:
         # Import here to avoid circular dependency
         if base_class is None:
             from .structured_model import StructuredModel
+
             base_class = StructuredModel
 
         # Validate model name
@@ -318,22 +335,22 @@ class ModelFactory:
     @staticmethod
     def validate_config(config: Dict[str, Any]) -> None:
         """Validate model configuration before creation.
-        
+
         This method performs structural validation of the configuration dictionary
         to ensure it contains all required keys and has the correct structure.
         It does not validate individual field configurations - that is handled
         by the field_converter module.
-        
+
         Args:
             config: Configuration dictionary to validate
-            
+
         Raises:
             ValueError: If configuration structure is invalid
-            
+
         Examples:
             >>> config = {"fields": {"name": {"type": "str", "comparator": "ExactComparator"}}}
             >>> ModelFactory.validate_config(config)  # No exception raised
-            
+
             >>> invalid_config = {"model_name": "Test"}  # Missing 'fields'
             >>> ModelFactory.validate_config(invalid_config)
             Traceback (most recent call last):

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -409,8 +409,8 @@ class StructuredModel(BaseModel):
 
         if process_rich_values:
             # Only process rich values on the top-level call
-            processed_data, confidences, extras = (
-                RichValueHelper.process_rich_values(json_data)
+            processed_data, confidences, extras = RichValueHelper.process_rich_values(
+                json_data
             )
             instance = ConfigurationHelper.from_json(cls, processed_data)
             if confidences:
@@ -428,7 +428,12 @@ class StructuredModel(BaseModel):
         return instance
 
     @classmethod
-    def model_from_json(cls, config: Dict[str, Any]) -> Type["StructuredModel"]:
+    def model_from_json(
+        cls,
+        config: Dict[str, Any],
+        *,
+        infer_unspecified_fields: bool = False,
+    ) -> Type["StructuredModel"]:
         """Create a StructuredModel subclass from JSON configuration using Pydantic's create_model().
 
         This method leverages Pydantic's native dynamic model creation capabilities to ensure
@@ -502,10 +507,19 @@ class StructuredModel(BaseModel):
         # Delegate to ModelFactory for dynamic model creation
         from .model_factory import ModelFactory
 
-        return ModelFactory.create_model_from_json(config, base_class=cls)
+        return ModelFactory.create_model_from_json(
+            config,
+            base_class=cls,
+            infer_unspecified_fields=infer_unspecified_fields,
+        )
 
     @classmethod
-    def from_json_schema(cls, schema: Dict[str, Any]) -> Type["StructuredModel"]:
+    def from_json_schema(
+        cls,
+        schema: Dict[str, Any],
+        *,
+        infer_unspecified_fields: bool = False,
+    ) -> Type["StructuredModel"]:
         """Create a StructuredModel subclass from a JSON Schema document.
 
         This method accepts standard JSON Schema documents and creates fully functional
@@ -597,7 +611,11 @@ class StructuredModel(BaseModel):
             >>> # name field has weight=2.0, price field clips scores below 0.95
         """
 
-        return cls._from_json_schema_internal(schema, field_path="")
+        return cls._from_json_schema_internal(
+            schema,
+            field_path="",
+            infer_unspecified_fields=infer_unspecified_fields,
+        )
 
     @classmethod
     def from_pydantic(
@@ -657,7 +675,11 @@ class StructuredModel(BaseModel):
 
     @classmethod
     def _from_json_schema_internal(
-        cls, schema: Dict[str, Any], field_path: str
+        cls,
+        schema: Dict[str, Any],
+        field_path: str,
+        *,
+        infer_unspecified_fields: bool = False,
     ) -> Type["StructuredModel"]:
         """Internal method for creating StructuredModel from JSON Schema with field path tracking.
 
@@ -719,8 +741,15 @@ class StructuredModel(BaseModel):
         properties = schema.get("properties", {})
         required = schema.get("required", [])
 
-        # Create converter and convert properties to field definitions
-        converter = JsonSchemaFieldConverter(schema, field_path=field_path)
+        # Create converter and convert properties to field definitions.
+        # ``infer_unspecified_fields`` is stored on the converter (not passed
+        # per-property) so recursive nested-object / array handlers pick it
+        # up automatically when they build their own converter internally.
+        converter = JsonSchemaFieldConverter(
+            schema,
+            field_path=field_path,
+            infer_unspecified_fields=infer_unspecified_fields,
+        )
         field_definitions = converter.convert_properties_to_fields(properties, required)
 
         # Create the model using ModelFactory
@@ -1412,7 +1441,9 @@ class StructuredModel(BaseModel):
                 property_schema = field_type.to_json_schema()
                 metadata = converter._extract_field_metadata(field_info)
                 metadata.pop("comparator", None)
-                extensions = converter._build_comparison_extensions(metadata, output_format="json_schema")
+                extensions = converter._build_comparison_extensions(
+                    metadata, output_format="json_schema"
+                )
                 property_schema.update(extensions)
             elif get_origin(field_type) is list:
                 # Handle List[StructuredModel] or List[primitive]
@@ -1433,7 +1464,9 @@ class StructuredModel(BaseModel):
                     }
                     metadata = converter._extract_field_metadata(field_info)
                     metadata.pop("comparator", None)
-                    extensions = converter._build_comparison_extensions(metadata, output_format="json_schema")
+                    extensions = converter._build_comparison_extensions(
+                        metadata, output_format="json_schema"
+                    )
                     property_schema.update(extensions)
                 else:
                     # Primitive list - build array schema manually
@@ -1557,14 +1590,19 @@ class StructuredModel(BaseModel):
             # Check if nested StructuredModel - use "structured_model" type
             if cls._is_structured_model_type(field_type):
                 nested_config = field_type.to_stickler_config()
-                field_config = {"type": "structured_model", "fields": nested_config["fields"]}
+                field_config = {
+                    "type": "structured_model",
+                    "fields": nested_config["fields"],
+                }
                 if nested_config.get("model_name"):
                     field_config["model_name"] = nested_config["model_name"]
                 if nested_config.get("match_threshold") is not None:
                     field_config["match_threshold"] = nested_config["match_threshold"]
                 metadata = converter._extract_field_metadata(field_info)
                 metadata.pop("comparator", None)
-                extensions = converter._build_comparison_extensions(metadata, output_format="stickler_config")
+                extensions = converter._build_comparison_extensions(
+                    metadata, output_format="stickler_config"
+                )
                 field_config.update(extensions)
             elif get_origin(field_type) is list:
                 # Handle List[StructuredModel] or List[primitive]
@@ -1579,14 +1617,21 @@ class StructuredModel(BaseModel):
 
                 if cls._is_structured_model_type(element_type):
                     nested_config = element_type.to_stickler_config()
-                    field_config = {"type": "list_structured_model", "fields": nested_config["fields"]}
+                    field_config = {
+                        "type": "list_structured_model",
+                        "fields": nested_config["fields"],
+                    }
                     if nested_config.get("model_name"):
                         field_config["model_name"] = nested_config["model_name"]
                     if nested_config.get("match_threshold") is not None:
-                        field_config["match_threshold"] = nested_config["match_threshold"]
+                        field_config["match_threshold"] = nested_config[
+                            "match_threshold"
+                        ]
                     metadata = converter._extract_field_metadata(field_info)
                     metadata.pop("comparator", None)
-                    extensions = converter._build_comparison_extensions(metadata, output_format="stickler_config")
+                    extensions = converter._build_comparison_extensions(
+                        metadata, output_format="stickler_config"
+                    )
                     field_config.update(extensions)
                 else:
                     # Primitive list - pass element type, then fix up type string

--- a/tests/structured_object_evaluator/test_infer_unspecified_fields.py
+++ b/tests/structured_object_evaluator/test_infer_unspecified_fields.py
@@ -1,0 +1,520 @@
+"""Tests for the ``infer_unspecified_fields`` opt-in flag (issue #239).
+
+The flag routes fields WITHOUT a ``comparator`` (in ``model_from_json`` config)
+or WITHOUT ``x-aws-stickler-comparator`` (in JSON Schema) through
+``stickler.auto.inference`` for a type + name-aware comparator pick. It also
+enriches ``format: date`` / ``format: date-time`` / ``enum`` primitive
+mapping to their richer Python types on the JSON Schema path.
+
+Load-bearing invariants pinned here:
+
+- Flag off ⇒ behavior is unchanged from before the flag.
+- Flag on ⇒ un-annotated fields get a type + name-aware comparator;
+  provenance is retrievable via ``json_schema_extra._provenance``.
+- Explicit config always wins per-parameter (author's threshold overrides
+  the inferred threshold; inferred comparator still fills in).
+- ``format: date`` and ``enum`` produce ``DateComparator`` and
+  ``ExactComparator`` on the JSON Schema path when the flag is on.
+
+The weak-spot type categories from #239 — ``format: date``, ``enum``, and
+numeric types — get direct coverage here since they were the three cases
+Spencer specifically called out as differentiators from the flat type-only
+fallback.
+"""
+
+import datetime
+import enum
+
+import pytest
+
+from stickler.comparators.date import DateComparator
+from stickler.comparators.exact import ExactComparator
+from stickler.comparators.fuzzy import FuzzyComparator
+from stickler.comparators.levenshtein import LevenshteinComparator
+from stickler.comparators.numeric import NumericComparator
+from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+
+
+def _field_comparator(model_cls, field_name):
+    """Read the comparator instance attached to a field via json_schema_extra."""
+    extra = model_cls.model_fields[field_name].json_schema_extra
+    return getattr(extra, "_comparator_instance", None)
+
+
+def _field_provenance(model_cls, field_name):
+    """Read the provenance list attached to a field via json_schema_extra.
+
+    Returns ``None`` when the field was operator-configured (no inference
+    fired) or when the model predates the flag. Returns a list of ordered
+    rule-application strings when inference fired for the field.
+    """
+    extra = model_cls.model_fields[field_name].json_schema_extra
+    return getattr(extra, "_provenance", None)
+
+
+def _field_threshold(model_cls, field_name):
+    """Read the threshold attached to a field via json_schema_extra."""
+    extra = model_cls.model_fields[field_name].json_schema_extra
+    return getattr(extra, "_threshold", None)
+
+
+def _field_weight(model_cls, field_name):
+    """Read the weight attached to a field via json_schema_extra."""
+    extra = model_cls.model_fields[field_name].json_schema_extra
+    return getattr(extra, "_weight", None)
+
+
+# ---------------------------------------------------------------------------
+# model_from_json — flag off preserves the strict "requires comparator" gate
+# ---------------------------------------------------------------------------
+
+
+class TestModelFromJsonFlagOff:
+    """Flag OFF must preserve the pre-flag behavior exactly.
+
+    The strict "primitive fields require a comparator" gate at
+    ``field_converter.validate_nested_field_schema`` was existing behavior;
+    flipping the flag on relaxes it but flipping it off (or omitting it)
+    must leave every existing consumer's error path intact.
+    """
+
+    def test_missing_comparator_still_raises(self):
+        """Pinned by test_model_from_json.py:792-804 as well; asserted here
+        against the specific field-shape the flag would relax so a future
+        refactor that accidentally always-relaxes fails this test."""
+        config = {
+            "model_name": "M",
+            "fields": {
+                "invoice_id": {"type": "str"},
+            },
+        }
+        with pytest.raises(ValueError, match=r"requires.*'comparator'"):
+            StructuredModel.model_from_json(config)
+
+    def test_missing_comparator_still_raises_with_flag_explicitly_off(self):
+        """Explicit ``infer_unspecified_fields=False`` behaves identically
+        to omitting the kwarg — no drift between the two flag-off paths."""
+        config = {
+            "model_name": "M",
+            "fields": {
+                "invoice_id": {"type": "str"},
+            },
+        }
+        with pytest.raises(ValueError, match=r"requires.*'comparator'"):
+            StructuredModel.model_from_json(config, infer_unspecified_fields=False)
+
+
+# ---------------------------------------------------------------------------
+# model_from_json — flag on infers via type + name, attaches provenance
+# ---------------------------------------------------------------------------
+
+
+class TestModelFromJsonFlagOn:
+    """Flag ON routes un-annotated fields through auto-inference.
+
+    Covers the three weak-spot type categories called out in issue #239:
+    - Numeric types (``int`` / ``float``) via type-only rules.
+    - Date types via ``datetime.date`` / ``datetime.datetime`` annotations.
+    - Enum-shaped fields via ``enum.Enum`` subclasses (assessed indirectly
+      here since ``model_from_json`` accepts type strings — enums arrive
+      through the JSON Schema path in ``TestFromJsonSchemaFlagOn`` below).
+    """
+
+    def test_missing_comparator_no_longer_raises_with_flag(self):
+        """The strict gate at validate_nested_field_schema is relaxed
+        when the caller opts in."""
+        config = {
+            "model_name": "M",
+            "fields": {
+                "invoice_id": {"type": "str"},
+            },
+        }
+        # Must not raise
+        Model = StructuredModel.model_from_json(config, infer_unspecified_fields=True)
+        assert "invoice_id" in Model.model_fields
+
+    def test_inference_picks_exact_by_name_token_for_id_field(self):
+        """`invoice_id` is a Stickler name-token rule (``*_id``) that
+        overrides the ``str → Levenshtein`` type default. Provenance
+        trace must record both rules — type first, then the name-token
+        upgrade."""
+        config = {
+            "model_name": "M",
+            "fields": {"invoice_id": {"type": "str"}},
+        }
+        Model = StructuredModel.model_from_json(config, infer_unspecified_fields=True)
+
+        assert isinstance(_field_comparator(Model, "invoice_id"), ExactComparator)
+
+        provenance = _field_provenance(Model, "invoice_id")
+        assert provenance is not None
+        assert any("type:str" in step for step in provenance), provenance
+        assert any(
+            "name-token:invoice_id" in step and "ExactComparator" in step
+            for step in provenance
+        ), provenance
+
+    def test_inference_picks_numeric_for_int_and_float(self):
+        """Numeric types were called out in issue #239 as a weak spot —
+        the flat table maps them to ``NumericComparator`` today too, but
+        the flag path also injects the type-appropriate tolerance via
+        ``comparator_config``. Sanity-check both int and float produce
+        NumericComparator with a non-None provenance."""
+        config = {
+            "model_name": "M",
+            "fields": {
+                "quantity": {"type": "int"},
+                "total_amount": {"type": "float"},
+            },
+        }
+        Model = StructuredModel.model_from_json(config, infer_unspecified_fields=True)
+
+        assert isinstance(_field_comparator(Model, "quantity"), NumericComparator)
+        assert isinstance(_field_comparator(Model, "total_amount"), NumericComparator)
+
+        assert _field_provenance(Model, "quantity") is not None
+        # total_amount matches the ``*amount`` name-token — provenance
+        # should record both type and name-token rules.
+        prov = _field_provenance(Model, "total_amount")
+        assert prov is not None
+        assert any("name-token:total_amount" in step for step in prov), prov
+
+    # NOTE: Date-typed fields on the ``model_from_json`` path are not
+    # exercised here because ``type_resolver.resolve_type_string`` — the
+    # existing helper that maps ``config["type"]`` strings to Python
+    # types — does not recognize ``"date"`` / ``"datetime"`` as type
+    # names today. That gap is orthogonal to this flag; the JSON Schema
+    # path covers date types via ``format: date`` (see
+    # ``TestFromJsonSchemaFlagOn.test_format_date_picks_date_comparator``).
+    # Extending ``type_resolver`` is a separate change — filing a
+    # follow-up issue would be the right home for it.
+
+    def test_configured_fields_are_untouched(self):
+        """Fields WITH an explicit ``comparator`` must not carry a
+        provenance list — provenance's absence is the "author-configured"
+        signal downstream code (e.g., a Source column renderer) reads."""
+        config = {
+            "model_name": "M",
+            "fields": {
+                "name": {
+                    "type": "str",
+                    "comparator": "LevenshteinComparator",
+                    "threshold": 0.9,
+                },
+                "invoice_id": {"type": "str"},  # inferred
+            },
+        }
+        Model = StructuredModel.model_from_json(config, infer_unspecified_fields=True)
+
+        # Author-declared field: comparator matches declaration, no
+        # provenance attached.
+        assert isinstance(_field_comparator(Model, "name"), LevenshteinComparator)
+        assert _field_provenance(Model, "name") is None
+
+        # Inferred field: provenance present.
+        assert isinstance(_field_comparator(Model, "invoice_id"), ExactComparator)
+        assert _field_provenance(Model, "invoice_id") is not None
+
+    def test_per_parameter_merge_threshold_wins_over_inferred(self):
+        """Decision 2 semantics: author's explicit ``threshold`` wins
+        over the InferredSpec's threshold, but the comparator is still
+        inferred because ``comparator`` was omitted. Merges at the
+        parameter granularity, not the field granularity.
+        """
+        config = {
+            "model_name": "M",
+            "fields": {
+                # No comparator, but threshold explicitly set to 0.9.
+                # Under the flag, inference picks Fuzzy (name-token
+                # ``notes``) at its own threshold; the merge should
+                # honor 0.9 instead.
+                "notes": {"type": "str", "threshold": 0.9},
+            },
+        }
+        Model = StructuredModel.model_from_json(config, infer_unspecified_fields=True)
+
+        assert isinstance(_field_comparator(Model, "notes"), FuzzyComparator)
+        assert _field_threshold(Model, "notes") == pytest.approx(0.9)
+        # Weight-hint rules only fire when the caller passes
+        # ``weight_hints=True`` into ``infer_field_config``. The flag
+        # itself is scoped to comparator inference (that's what the
+        # motivating IDP use case wants), so weight stays at the
+        # InferredSpec default of 1.0. When a future extension lets
+        # callers opt into weight-hint enrichment, that path is what
+        # would raise this value to 0.3 for a ``notes`` field.
+        assert _field_weight(Model, "notes") == pytest.approx(1.0)
+
+    def test_per_parameter_merge_weight_wins_over_inferred(self):
+        """Same as threshold merge but on the weight parameter — makes
+        sure the merge is uniform across all three parameters. The
+        author's explicit weight overrides the InferredSpec default
+        (which itself defaults to 1.0 without weight_hints — see
+        ``test_per_parameter_merge_threshold_wins_over_inferred``)."""
+        config = {
+            "model_name": "M",
+            "fields": {
+                "invoice_id": {"type": "str", "weight": 5.0},
+            },
+        }
+        Model = StructuredModel.model_from_json(config, infer_unspecified_fields=True)
+
+        # Author's 5.0 wins.
+        assert _field_weight(Model, "invoice_id") == pytest.approx(5.0)
+
+
+# ---------------------------------------------------------------------------
+# from_json_schema — flag off preserves the flat type-only fallback
+# ---------------------------------------------------------------------------
+
+
+class TestFromJsonSchemaFlagOff:
+    """Flag OFF must not change any pre-existing JSON Schema behavior.
+
+    Pinned by four extension tests at
+    ``test_from_json_schema.py:1109-1173`` that specify partial extensions
+    (only weight, only threshold+clip, etc.) and rely on the flat
+    Levenshtein/Numeric/Exact defaults for the unspecified comparator.
+    """
+
+    def test_no_extension_falls_back_to_flat_default(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "invoice_id": {"type": "string"},
+                "amount": {"type": "number"},
+                "paid": {"type": "boolean"},
+            },
+        }
+        Model = StructuredModel.from_json_schema(schema)
+
+        # Flat defaults, ignoring name-token signals.
+        assert isinstance(_field_comparator(Model, "invoice_id"), LevenshteinComparator)
+        assert isinstance(_field_comparator(Model, "amount"), NumericComparator)
+        assert isinstance(_field_comparator(Model, "paid"), ExactComparator)
+        # No provenance attached — inference didn't fire.
+        assert _field_provenance(Model, "invoice_id") is None
+
+    def test_format_date_stays_str_when_flag_off(self):
+        """The ``format: date`` enrichment is gated on the flag —
+        without it, the field type stays ``str`` and gets Levenshtein
+        (preserving pre-flag behavior for schemas that already declared
+        ``format: date`` for documentation only)."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "issued": {"type": "string", "format": "date"},
+            },
+        }
+        Model = StructuredModel.from_json_schema(schema)
+
+        # The pydantic field annotation should still be str, not date.
+        # Check by exercising validation: a string that isn't a valid
+        # date string must NOT raise (would if annotation were date).
+        instance = Model(issued="not-a-date")
+        assert instance.issued == "not-a-date"
+
+    def test_enum_stays_str_when_flag_off(self):
+        """Same gating for enum — without the flag, ``{"type": "string",
+        "enum": [...]}`` stays plain ``str`` and coerces raw string values,
+        preserving the behavior pinned by
+        ``test_complex_nested_schema_with_enums``."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "status": {"type": "string", "enum": ["DRAFT", "FINAL"]},
+            },
+        }
+        Model = StructuredModel.from_json_schema(schema)
+
+        instance = Model(status="DRAFT")
+        # Value stays a raw string — the Enum enrichment did NOT fire.
+        assert instance.status == "DRAFT"
+        assert isinstance(instance.status, str)
+
+
+# ---------------------------------------------------------------------------
+# from_json_schema — flag on infers, enriches format/enum, attaches provenance
+# ---------------------------------------------------------------------------
+
+
+class TestFromJsonSchemaFlagOn:
+    """Flag ON routes un-annotated fields through auto-inference and
+    enriches ``format: date`` / ``format: date-time`` / ``enum``.
+    """
+
+    def test_no_extension_uses_inference_with_flag(self):
+        """When the schema has no comparator extension AND the flag is
+        on, ``stickler.auto.inference`` picks the comparator. On an
+        ``invoice_id`` string field it should pick Exact via the
+        name-token rule instead of the flat Levenshtein default."""
+        schema = {
+            "type": "object",
+            "properties": {"invoice_id": {"type": "string"}},
+        }
+        Model = StructuredModel.from_json_schema(schema, infer_unspecified_fields=True)
+
+        assert isinstance(_field_comparator(Model, "invoice_id"), ExactComparator)
+        prov = _field_provenance(Model, "invoice_id")
+        assert prov is not None
+        assert any("name-token:invoice_id" in step for step in prov)
+
+    def test_format_date_picks_date_comparator(self):
+        """The ``format: date`` enrichment lands only when the flag is
+        on. Under the flag, ``{"type": "string", "format": "date"}``
+        resolves to ``datetime.date`` and inference picks
+        DateComparator."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "issued": {"type": "string", "format": "date"},
+            },
+        }
+        Model = StructuredModel.from_json_schema(schema, infer_unspecified_fields=True)
+
+        assert isinstance(_field_comparator(Model, "issued"), DateComparator)
+        # Field annotation should be datetime.date, and pydantic should
+        # coerce string date values into ``date`` objects.
+        instance = Model(issued="2024-05-15")
+        assert isinstance(instance.issued, datetime.date)
+        assert instance.issued == datetime.date(2024, 5, 15)
+
+        prov = _field_provenance(Model, "issued")
+        assert prov is not None
+        assert any("DateComparator" in step for step in prov), prov
+
+    def test_format_date_time_picks_date_comparator(self):
+        """Same enrichment as ``format: date`` but for ``date-time``:
+        DateComparator handles both. Different Python type
+        (``datetime.datetime``) means pydantic coerces the value more
+        precisely."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "created_at": {"type": "string", "format": "date-time"},
+            },
+        }
+        Model = StructuredModel.from_json_schema(schema, infer_unspecified_fields=True)
+
+        assert isinstance(_field_comparator(Model, "created_at"), DateComparator)
+        instance = Model(created_at="2024-05-15T10:30:00Z")
+        assert isinstance(instance.created_at, datetime.datetime)
+
+    def test_enum_picks_exact_comparator(self):
+        """Enum-shaped strings become a synthesized Enum class under the
+        flag; Stickler's inference layer then picks ExactComparator via
+        the ``_is_enum`` rule."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "status": {"type": "string", "enum": ["DRAFT", "PENDING", "FINAL"]},
+            },
+        }
+        Model = StructuredModel.from_json_schema(schema, infer_unspecified_fields=True)
+
+        assert isinstance(_field_comparator(Model, "status"), ExactComparator)
+        # Value becomes an Enum member (the whole point of the
+        # enrichment — the pydantic field is a real Enum subclass now).
+        instance = Model(status="DRAFT")
+        assert isinstance(instance.status, enum.Enum)
+        assert instance.status.value == "DRAFT"
+
+        prov = _field_provenance(Model, "status")
+        assert prov is not None
+
+    def test_numeric_types_pick_numeric_comparator(self):
+        """Numeric types under the flag get the same NumericComparator
+        pick as the flat table, but with type-appropriate tolerance
+        injected via ``comparator_config`` and provenance attached."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "quantity": {"type": "integer"},
+                "total": {"type": "number"},
+            },
+        }
+        Model = StructuredModel.from_json_schema(schema, infer_unspecified_fields=True)
+
+        assert isinstance(_field_comparator(Model, "quantity"), NumericComparator)
+        assert isinstance(_field_comparator(Model, "total"), NumericComparator)
+        assert _field_provenance(Model, "quantity") is not None
+        assert _field_provenance(Model, "total") is not None
+
+    def test_configured_extension_still_wins(self):
+        """A field with an explicit ``x-aws-stickler-comparator``
+        extension must be honored verbatim — inference must not
+        overwrite operator choice. Provenance stays absent for
+        author-configured fields.
+        """
+        schema = {
+            "type": "object",
+            "properties": {
+                "notes": {
+                    "type": "string",
+                    "x-aws-stickler-comparator": "LevenshteinComparator",
+                },
+                "invoice_id": {"type": "string"},  # inferred
+            },
+        }
+        Model = StructuredModel.from_json_schema(schema, infer_unspecified_fields=True)
+
+        # Author's Levenshtein wins over inferred Fuzzy for ``notes``.
+        assert isinstance(_field_comparator(Model, "notes"), LevenshteinComparator)
+        assert _field_provenance(Model, "notes") is None
+
+        # Un-annotated field still gets Exact via inference.
+        assert isinstance(_field_comparator(Model, "invoice_id"), ExactComparator)
+        assert _field_provenance(Model, "invoice_id") is not None
+
+    def test_per_parameter_merge_threshold_extension_wins(self):
+        """Decision 2 for the JSON Schema path — author's explicit
+        ``x-aws-stickler-threshold`` merges with the inferred
+        comparator instead of the inferred threshold."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "notes": {
+                    "type": "string",
+                    "x-aws-stickler-threshold": 0.9,
+                },
+            },
+        }
+        Model = StructuredModel.from_json_schema(schema, infer_unspecified_fields=True)
+
+        assert isinstance(_field_comparator(Model, "notes"), FuzzyComparator)
+        assert _field_threshold(Model, "notes") == pytest.approx(0.9)
+
+    def test_flag_propagates_through_nested_object(self):
+        """Un-annotated leaves inside a nested object must inherit the
+        parent's flag setting — otherwise ``address.city`` would fall
+        back to flat defaults even though the top-level model opted in."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "invoice_id": {"type": "string"},
+                "address": {
+                    "type": "object",
+                    "properties": {
+                        "zip_code": {"type": "string"},
+                        "state": {"type": "string"},
+                    },
+                },
+            },
+        }
+        Model = StructuredModel.from_json_schema(schema, infer_unspecified_fields=True)
+
+        # Top-level inferred.
+        assert isinstance(_field_comparator(Model, "invoice_id"), ExactComparator)
+
+        # Reach into the nested model class and check its fields too.
+        AddressModel = Model.model_fields["address"].annotation
+        # Optional wrapping: unwrap if needed.
+        from typing import get_args, get_origin
+
+        if get_origin(AddressModel) is not None:
+            args = [a for a in get_args(AddressModel) if a is not type(None)]
+            if args:
+                AddressModel = args[0]
+
+        # Nested un-annotated fields also went through inference.
+        assert _field_provenance(AddressModel, "zip_code") is not None
+        assert _field_provenance(AddressModel, "state") is not None

--- a/tests/structured_object_evaluator/test_infer_unspecified_fields.py
+++ b/tests/structured_object_evaluator/test_infer_unspecified_fields.py
@@ -244,6 +244,45 @@ class TestModelFromJsonFlagOn:
         # would raise this value to 0.3 for a ``notes`` field.
         assert _field_weight(Model, "notes") == pytest.approx(1.0)
 
+    def test_flag_propagates_through_nested_structured_model(self):
+        """Mirror of ``test_flag_propagates_through_nested_object`` on the
+        ``model_from_json`` path: un-annotated leaves inside a nested
+        ``type: structured_model`` block must inherit the parent's flag
+        setting so ``_convert_nested_model_field`` doesn't drop it on the
+        recursive call."""
+        config = {
+            "model_name": "M",
+            "fields": {
+                "invoice_id": {"type": "str"},
+                "address": {
+                    "type": "structured_model",
+                    "fields": {
+                        "zip_code": {"type": "str"},
+                        "state": {"type": "str"},
+                    },
+                },
+            },
+        }
+        Model = StructuredModel.model_from_json(config, infer_unspecified_fields=True)
+
+        # Top-level inferred.
+        assert isinstance(_field_comparator(Model, "invoice_id"), ExactComparator)
+
+        # Reach into the nested model class and check its fields too.
+        AddressModel = Model.model_fields["address"].annotation
+        from typing import get_args, get_origin
+
+        if get_origin(AddressModel) is not None:
+            args = [a for a in get_args(AddressModel) if a is not type(None)]
+            if args:
+                AddressModel = args[0]
+
+        # Nested un-annotated fields also went through inference (i.e.,
+        # the flag threaded through the ``_convert_nested_model_field``
+        # recursive call at ``field_converter.py:225``).
+        assert _field_provenance(AddressModel, "zip_code") is not None
+        assert _field_provenance(AddressModel, "state") is not None
+
     def test_per_parameter_merge_weight_wins_over_inferred(self):
         """Same as threshold merge but on the weight parameter — makes
         sure the merge is uniform across all three parameters. The
@@ -482,6 +521,70 @@ class TestFromJsonSchemaFlagOn:
 
         assert isinstance(_field_comparator(Model, "notes"), FuzzyComparator)
         assert _field_threshold(Model, "notes") == pytest.approx(0.9)
+
+    def test_list_of_format_date_enriches_element_type(self):
+        """The enrichment gating in ``_handle_array_type`` must apply to
+        primitive array items too: an array of ``format: date`` strings
+        under the flag becomes ``List[datetime.date]`` bound to a
+        ``DateComparator``, not ``List[str]`` with Levenshtein. Without
+        this test the item-level enrichment branch would be untested."""
+        from typing import get_args, get_origin
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "invoice_dates": {
+                    "type": "array",
+                    "items": {"type": "string", "format": "date"},
+                },
+            },
+        }
+        Model = StructuredModel.from_json_schema(schema, infer_unspecified_fields=True)
+
+        annotation = Model.model_fields["invoice_dates"].annotation
+        # Field is Optional[List[datetime.date]] (non-required default None).
+        if get_origin(annotation) is not None:
+            args = [a for a in get_args(annotation) if a is not type(None)]
+            if args:
+                annotation = args[0]
+        assert get_origin(annotation) is list
+        (element_type,) = get_args(annotation)
+        assert element_type is datetime.date
+
+        assert isinstance(_field_comparator(Model, "invoice_dates"), DateComparator)
+
+        # Pydantic actually coerces the string items into ``date`` objects.
+        instance = Model(invoice_dates=["2024-05-15", "2024-06-01"])
+        assert all(isinstance(d, datetime.date) for d in instance.invoice_dates)
+
+    def test_format_date_with_explicit_comparator_keeps_type_enrichment(self):
+        """Type enrichment happens BEFORE comparator selection, so an
+        explicit ``x-aws-stickler-comparator`` doesn't undo the ``format:
+        date`` → ``datetime.date`` type change. Pydantic still coerces
+        the string into a ``date`` object; the operator's chosen
+        comparator (here ``LevenshteinComparator``) runs against the
+        stringified date at compare time. Pinning this so a future
+        change doesn't accidentally couple enrichment to comparator
+        absence."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "issued": {
+                    "type": "string",
+                    "format": "date",
+                    "x-aws-stickler-comparator": "LevenshteinComparator",
+                },
+            },
+        }
+        Model = StructuredModel.from_json_schema(schema, infer_unspecified_fields=True)
+
+        # Author's comparator wins.
+        assert isinstance(_field_comparator(Model, "issued"), LevenshteinComparator)
+        # No provenance — inference didn't fire.
+        assert _field_provenance(Model, "issued") is None
+        # Type enrichment still happened.
+        instance = Model(issued="2024-05-15")
+        assert isinstance(instance.issued, datetime.date)
 
     def test_flag_propagates_through_nested_object(self):
         """Un-annotated leaves inside a nested object must inherit the


### PR DESCRIPTION
Closes #239.

  ## What this adds

  - New `infer_unspecified_fields: bool = False` kwarg on
    `StructuredModel.model_from_json` and `StructuredModel.from_json_schema`.
  - When set, fields without a declared comparator route through
    `stickler.auto.inference` for a type + name-aware pick.
  - On the JSON Schema path, the flag also enriches `format: date` /
    `format: date-time` fields into their `datetime` types and `enum`
    string fields into synthesized `Enum` subclasses (including inside
    `List[primitive]` items), so inference lands `DateComparator` /
    `ExactComparator` instead of the character-edit-distance default.
  - Provenance for every inferred field is retrievable via
    `model.model_fields[name].json_schema_extra._provenance` — same
    channel as the existing `_comparator_instance` / `_threshold` /
    `_weight` metadata, no new schema extension key.

  ## Behavior invariants

  - **Flag off:** behavior unchanged. The strict "primitive fields
    require a `comparator`" gate stays intact; JSON Schema type mapping
    still uses the flat `int/float/str/bool` path (no format/enum
    enrichment).
  - **Flag on, author declared a comparator:** the author's declaration
    wins verbatim — inference does not fire.
  - **Flag on, comparator missing:** inference fires and fills in the
    four parameters (`comparator`, `threshold`, `weight`,
    `clip_under_threshold`). Author's explicit `threshold` / `weight`
    still win **per parameter** (Decision 2, below).
  - **Flag on, type enrichment:** invalid ISO date strings or enum
    values outside the declared set now raise at Pydantic model
    construction (previously coerced to raw string). Intended
    tightening; call this out to consumers when they flip the flag.

  ## Design decisions called out for review

  1. **Per-parameter merge**, not all-or-nothing. If a config supplies
     only `threshold: 0.8`, that threshold pairs with the inferred
     comparator. Matches how the pre-flag code already handled partial
     config against flat defaults, so no path regresses.
  2. **Hand-written `StructuredModel` fallback deferred.** Bare-annotation
     fields still use `ConfigurationHelper.get_comparison_info`. That
     path has no natural opt-in surface (Python code, not config), so
     it warrants its own mechanism — deliberately left as a follow-up
     per the scope note in #239.

  ## Tests

  22 new tests in
  `tests/structured_object_evaluator/test_infer_unspecified_fields.py`
  covering:

  - Flag off preserves the strict raise (both omitted and explicit
    `False`).
  - Flag on relaxes the raise and fills via inference.
  - Name-token rule (`invoice_id → ExactComparator`) beats the type
    default; provenance records both rules.
  - Numeric types (int/float) produce `NumericComparator`.
  - Per-parameter merge: explicit `threshold` and `weight` each override
    the inferred spec independently.
  - `format: date` → `DateComparator`, `format: date-time` → same.
  - `enum` string field → synthesized `Enum` subclass +
    `ExactComparator`.
  - **`List[primitive]` with `format: date`** → `List[datetime.date]`
    bound to `DateComparator` (item-level enrichment branch).
  - **`format: date` + explicit `x-aws-stickler-comparator`** →
    operator's comparator wins, type enrichment still happens.
  - Configured extension still wins over inference.
  - Flag propagates through nested objects (both JSON Schema
    `type: object` and Stickler-native `type: structured_model`).

  Full suite: **1760 passed, 10 skipped** (same skip set as `dev`).