### PR TITLE
fix(thresholds): the zero-threshold warning applies to standalone models too (#237)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,17 @@ Each release links to full notes on the
   prediction is still an FA (2 ground-truth objects vs 3 predictions gives
   precision `0.667`) and an unmatched ground-truth item is still an FN (2 vs 1
   gives recall `0.5`), because unmatched items are not subject to any
-  threshold. For a `match_threshold` the message is also conditional, since the
-  value is only read when the model is compared as a `List[StructuredModel]`
-  element and is inert otherwise.
+  threshold.
+
+  `match_threshold=0.0` warns unconditionally, because the value reaches the
+  comparison two ways: as the object-matching threshold for a
+  `List[StructuredModel]` element, *and* as the default field threshold for any
+  field with no explicit config of its own. A plainly annotated `name: str`
+  inherits it, so a standalone model at `0.0` reports precision and recall
+  `1.0` for a wholly incorrect prediction with no list involved. (Declaring the
+  field with `ComparableField()` takes an earlier branch and gets a hardcoded
+  `0.5`, which is why the value can look inert when probed that way -- see
+  [#237](https://github.com/awslabs/stickler/issues/237).)
 
   Only exactly `0.0` warns. `0.01` already classifies correctly, so this is a
   single misbehaving value rather than a "low thresholds are risky" heuristic.

--- a/src/stickler/structured_object_evaluator/models/threshold_helper.py
+++ b/src/stickler/structured_object_evaluator/models/threshold_helper.py
@@ -26,15 +26,28 @@ _FIELD_CONSEQUENCE = (
     "reported as a false discovery, however wrong the prediction is"
 )
 
-# `match_threshold` is read only when the model is a `List[StructuredModel]`
-# element (see structured_list_comparator.py). On a standalone model the value
-# changes nothing, and the hook cannot know at class-definition time which the
-# class will be -- so this states the condition rather than asserting an outcome
-# that may not apply.
+# `match_threshold` reaches the comparison two ways, which is why this states
+# the consequence unconditionally rather than hedging on list membership:
+#
+#   1. as the object-matching threshold for a `List[StructuredModel]` element
+#      (structured_list_comparator.py), and
+#   2. as the *default field threshold* for any field with no explicit
+#      comparison config -- `ConfigurationHelper.get_comparison_info` falls back
+#      to `getattr(cls, "match_threshold", 0.5)`, so a plainly annotated
+#      `name: str` inherits it.
+#
+# Route 2 is easy to miss because a field declared with `ComparableField()`
+# takes an earlier branch and gets a hardcoded 0.5 instead, so probing with
+# ComparableField makes the value look inert. It is not: a plain-annotated model
+# at 0.0 reports precision and recall 1.0 for a wholly wrong prediction, with no
+# list anywhere. An earlier version of this message said "if this model is
+# compared as a list element", which told exactly the users who were affected
+# that it did not apply to them (#237).
 _MATCH_CONSEQUENCE = (
-    "if this model is compared as a list element, every object it pairs is "
-    "counted as a true positive and nothing can be reported as a false "
-    "discovery, however wrong the objects are"
+    "every value it compares is counted as a true positive and nothing can be "
+    "reported as a false discovery, however wrong the prediction is. This "
+    "applies both to object matching when the model is a list element, and to "
+    "any field with no explicit threshold of its own, which inherits this value"
 )
 
 

--- a/tests/structured_object_evaluator/test_threshold_zero_warning.py
+++ b/tests/structured_object_evaluator/test_threshold_zero_warning.py
@@ -122,13 +122,14 @@ class TestModelMatchThreshold:
 
                 sku: str = ComparableField(comparator=ExactComparator())
 
-    def test_match_threshold_message_is_conditional(self):
-        """`match_threshold` is inert unless the model is a list element.
+    def test_match_threshold_message_is_unconditional(self):
+        """The consequence is not conditional on being a list element.
 
-        The hook cannot know at class-definition time which it will be, and
-        the value provably changes nothing for a standalone model -- verified
-        identical output at None, 0.0 and 0.7. So the message states the
-        condition rather than asserting an outcome that may not apply.
+        `match_threshold` also serves as the default field threshold for any
+        field with no explicit config, so a standalone model is affected too.
+        An earlier version of this message hedged with "if this model is
+        compared as a list element", which told exactly the affected users that
+        it did not apply to them (#237).
         """
         with pytest.warns(UserWarning) as record:
 
@@ -138,7 +139,73 @@ class TestModelMatchThreshold:
                 sku: str = ComparableField(comparator=ExactComparator())
 
         message = str(record[0].message)
-        assert "if this model is compared as a list element" in message
+        assert "if this model is compared as a list element" not in message
+        assert "inherits this value" in message, (
+            "the message must name the field-threshold route, not only lists"
+        )
+
+    def test_the_value_is_not_inert_on_a_standalone_model(self):
+        """The behaviour the message now describes, measured.
+
+        A plainly annotated field (no ComparableField) inherits
+        `match_threshold` as its own threshold, so a wholly wrong prediction
+        scores as a true positive with no list involved. Probing with
+        `ComparableField()` hides this -- that path takes an earlier branch and
+        gets a hardcoded 0.5.
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+
+            class Zero(StructuredModel):
+                match_threshold = 0.0
+
+                name: str
+
+            class Normal(StructuredModel):
+                match_threshold = 0.7
+
+                name: str
+
+            def overall(model_cls):
+                return model_cls(name="Acme Corporation").compare_with(
+                    model_cls(name="zzzzzzzz"), include_confusion_matrix=True
+                )["confusion_matrix"]["overall"]
+
+            zero, normal = overall(Zero), overall(Normal)
+
+        # At 0.0 a wholly wrong value is a true positive with perfect metrics.
+        assert zero["tp"] == 1 and zero["fd"] == 0
+        assert zero["derived"]["cm_precision"] == 1.0
+        assert zero["derived"]["cm_recall"] == 1.0
+
+        # At a normal threshold the same comparison is a false discovery.
+        assert normal["tp"] == 0 and normal["fd"] == 1
+
+    def test_a_comparable_field_does_not_inherit_match_threshold(self):
+        """Why the inertness claim looked true: this path ignores the value.
+
+        Documents the asymmetry that made the original message wrong, so a
+        future reader probing with ComparableField is not misled the same way.
+        """
+        from stickler.structured_object_evaluator.models.configuration_helper import (
+            ConfigurationHelper,
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+
+            class Explicit(StructuredModel):
+                match_threshold = 0.0
+
+                n: str = ComparableField(comparator=ExactComparator())
+
+            class Plain(StructuredModel):
+                match_threshold = 0.0
+
+                n: str
+
+        assert ConfigurationHelper.get_comparison_info(Explicit, "n").threshold == 0.5
+        assert ConfigurationHelper.get_comparison_info(Plain, "n").threshold == 0.0
 
     def test_warning_names_the_model(self):
         with pytest.warns(UserWarning) as record:


### PR DESCRIPTION
# Pull Request

## Issue Reference
Closes #237

## Description of Changes

The `match_threshold=0.0` warning added in #236 hedged with **"if this model is compared as a list element"**, which told exactly the affected users that it did not apply to them.

`match_threshold` reaches the comparison **two** ways, not one:

1. object matching for a `List[StructuredModel]` element (`structured_list_comparator.py`)
2. the **default field threshold** for any field with no explicit config — `ConfigurationHelper.get_comparison_info` falls back to `getattr(cls, "match_threshold", 0.5)`

Route 2 means a plainly annotated `name: str` inherits the value. Measured, with no list anywhere:

| | field threshold | tp | fd | precision | recall |
|---|---|---|---|---|---|
| `match_threshold=0.0` | **0.0** | 1 | 0 | **1.000** | **1.000** |
| `match_threshold=0.7` | 0.7 | 0 | 1 | 0.000 | 0.000 |

A wholly incorrect prediction scores perfectly — the exact failure the warning exists to flag.

### Why I got this wrong in #236

Not a code-reading error. My probes declared fields with `ComparableField()`, and **that path takes an earlier branch and gets a hardcoded `0.5`**, so the value genuinely looked inert:

```
ComparableField()   -> field threshold=0.5
plain annotation    -> field threshold=0.0
```

Both shapes are ordinary user code, and `from_pydantic()` plus the zero-config `evaluate()` path both produce plain-annotated models — so route 2 is the *common* one, not the exotic one.

### The fix

The message now states the consequence unconditionally and names both routes:

> `Z sets match_threshold=0.0`. The threshold test is `>=`, so every score satisfies it: every value it compares is counted as a true positive and nothing can be reported as a false discovery, however wrong the prediction is. This applies both to object matching when the model is a list element, and to any field with no explicit threshold of its own, which inherits this value. Use a small positive value (for example 0.01) …

Corrected the same claim in the **three other places it had propagated to**: the `_MATCH_CONSEQUENCE` comment, the test docstring that asserted the hedge, and the CHANGELOG entry for #236.

## Testing

Three tests, beyond flipping the wording assertion:

- `test_match_threshold_message_is_unconditional` — asserts the hedge is gone *and* that the field-threshold route is named, so a partial fix fails
- `test_the_value_is_not_inert_on_a_standalone_model` — pins the measured behaviour the message now describes
- `test_a_comparable_field_does_not_inherit_match_threshold` — records the asymmetry that misled me, so the next person probing that way isn't caught by it

Verified load-bearing: restoring the hedged wording fails the wording test.

**1756 passed, 2 skipped.** `ruff` clean.

## Out of scope

The underlying propagation is untouched. `match_threshold` doubling as the default field threshold conflates "how similar must two objects be to be the same object" with "how similar must two values be to count as a match" — two different questions with different natural defaults. That is a design change rather than a wording fix, and it is noted on #239.

## Reviewers
@vawsgit

## Checklist
- [x] Code follows the project's coding standards
- [x] Self-review of code completed
- [x] Documentation updated (if applicable)
- [x] `CHANGELOG.md` entry corrected under `[Unreleased]`
- [x] Tests added/updated for new functionality
- [x] All existing tests pass
- [x] Ready for review
