### PR TITLE
chore: bump version to 0.7.0 for release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,13 @@
 ## Testing
 - Test documentation and guidelines can be found in [tests/README.md](./tests/README.md).
 
+## Dependencies and `uv.lock`
+- `uv.lock` is committed deliberately. Do not gitignore or delete it: every CI workflow runs `uv sync --frozen`, which fails immediately if the lockfile is absent.
+- It does not constrain consumers of the published package. Installers resolve the `dependencies` ranges in `pyproject.toml`, which is what the wheel metadata carries; the lockfile is uv-specific and governs only this repo's dev and CI environments.
+- It also carries the dependency cooldown (`exclude-newer`, `exclude-newer-span`) that the semgrep supply-chain rules check for, so removing it regresses the security scan.
+- **Prefer hand-editing the lines you need over running `uv lock`.** In this repo `uv lock` rewrites `exclude-newer` to `0001-01-01` and strips platform markers from the CUDA and nvidia entries. If you do run it, diff the result and restore both. Verify any edit with `uv lock --check`, which is the authoritative consistency check.
+- The lockfile records this package's own `version`, so a release bump must update it alongside `pyproject.toml` and `src/stickler/__init__.py`. See [RELEASING.md](./RELEASING.md).
+
 ## README.md 
 - In addition to MKDocs, The project strives to maintain developer documentation distributed in README.md files throughout the codebase. This documentation exists to help human and AI coding assistants when working with the codebase.
 - When creating directories or working in a directory that does not have a README.md create a README.md file and document the final state of the code and logic that's in the directory. Do this in language that an AI coding assistant trying to understand the implementation and codebas would understand.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Each release links to full notes on the
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-14
+
 ### Added
 
 - `PhoneComparator`, which compares phone numbers by the number they dial rather
@@ -100,6 +102,210 @@ Each release links to full notes on the
   embeddings), `docsplit` (document packet splitting), `reporting` (HTML report
   tables). `all` aggregates every extra except `bert`, whose ML stack is large
   enough that installing it unasked is a surprise
+
+### Changed
+
+- **Breaking:** `ExactComparator` is now truly exact. The default is
+  `case_sensitive=True` (was `False`), and punctuation/whitespace stripping
+  has been removed entirely. This fixes
+  [#199](https://github.com/awslabs/stickler/issues/199), where
+  `"SHP-2024-001"` incorrectly matched `"shp 2024 001"`.
+
+  **This lowers scores** on existing evaluation sets, and it reaches you even if
+  you never named `ExactComparator`. The zero-config path (`stickler.evaluate()`,
+  `eval_for()`, `from_pydantic()`) infers `ExactComparator` for id-shaped,
+  code-shaped, email, zip and boolean fields, so on a typical extraction model
+  it covers roughly half the fields:
+
+  ```python
+  class Invoice(BaseModel):           # plain pydantic, no stickler config
+      invoice_id: str                 # inferred -> ExactComparator
+      sku: str                        # inferred -> ExactComparator
+      email: str                      # inferred -> ExactComparator
+      zip_code: str                   # inferred -> ExactComparator
+      vendor_name: str                # inferred -> LevenshteinComparator
+  ```
+
+  With predictions differing only in case and punctuation
+  (`"SHP-2024-001"` vs `"shp 2024 001"`, `"98101-1234"` vs `"98101 1234"`):
+
+  | | before | after |
+  |---|---|---|
+  | the four inferred-Exact fields | 1.0 each | **0.0 each** |
+  | `overall_score` | 1.0 | **0.20** |
+
+  That is the intended correction -- those pairs are not equal, and reporting
+  them as perfect matches is the bug -- but if you track a metric across
+  releases, expect a step change at this version rather than a drift.
+
+  | what changed | before | after |
+  |---|---|---|
+  | `ExactComparator().compare("Hello", "hello")` | 1.0 | **0.0** |
+  | `ExactComparator().compare("ID-123", "ID 123")` | 1.0 | **0.0** |
+  | `ExactComparator().compare("SHP-2024-001", "shp 2024 001")` | 1.0 | **0.0** |
+
+  **Migration:** For case-insensitive matching, pass `case_sensitive=False`.
+
+  For punctuation or whitespace differences, `ExactComparator` is the wrong
+  tool. Use a similarity comparator with a threshold tuned to your data:
+
+  ```python
+  vendor: str = ComparableField(comparator=LevenshteinComparator(), threshold=0.8)
+  ```
+
+  Note that a threshold of `1.0` will **not** work here: `"ID-123"` vs
+  `"ID 123"` scores `0.833`, so requiring a perfect score still rejects it. Pick
+  a threshold below the score your real data produces, or write a comparator
+  that normalizes the way your domain requires.
+
+  The `case_sensitive=False` path now uses `str.casefold()` (Unicode case
+  folding) instead of `str.lower()`, correctly handling cases like
+  `"STRASSE"` vs `"straße"` ([#199](https://github.com/awslabs/stickler/issues/199))
+
+- `model_json_schema()` now describes the model's shape the way an equivalent
+  plain `BaseModel` would, so a configured `StructuredModel` can drive a
+  Strands agent's structured output without degrading the schema the LLM sees:
+  `required` is derived from the annotation (`shipment_id: str` renders
+  required even though `ComparableField` assigns a `None` default for
+  construction tolerance), required fields no longer widen to
+  `["type", "null"]` or carry a contradictory `default: null`, and comparison
+  configuration (`x-comparison`) is no longer emitted. Verified through
+  Strands' `convert_pydantic_to_tool_spec`: a configured `StructuredModel` and
+  its plain-`BaseModel` twin now produce the same tool spec.
+
+  Field-level `description`, `examples`, and `alias` still reach the rendered
+  schema, and the deliberate export path `to_json_schema()` still carries the
+  comparison configuration as `x-aws-stickler-*` extensions. Runtime behavior
+  is unchanged: predictions that omit fields still construct and score.
+
+  Code that read `x-comparison` out of `model_json_schema()` output should
+  read the field's `json_schema_extra` (as the engine does) or use
+  `to_json_schema()`.
+
+  Note a side effect: dropping the internal `extra_fields` property means
+  `from_json_schema(M.model_json_schema())` now parses for a model whose fields
+  are all required, where it previously raised `ValueError`. It still does
+  **not** round-trip -- the rebuilt model carries default thresholds, weights
+  and comparators, because a shape-only schema does not describe them. A model
+  with any `Optional` field still raises, on the nullable `anyOf` gap that
+  [#198](https://github.com/awslabs/stickler/pull/198) addresses, so most real
+  models are unaffected either way. `model_json_schema()` remains documented as
+  not round-trip-capable; use `to_json_schema()` or `to_stickler_config()` to
+  preserve configuration. Tracked in
+  [#214](https://github.com/awslabs/stickler/issues/214)
+  ([#188](https://github.com/awslabs/stickler/issues/188))
+
+- Optional fields built from a JSON Schema are now annotated `Optional[T]`
+  rather than `T`, so `to_json_schema()` exports them with a nullable type:
+
+  | | before | after |
+  |---|---|---|
+  | `to_json_schema()` | `{"type": "string"}` | `{"type": ["string", "null"]}` |
+  | `model_json_schema()` | `{"type": "string"}` | `{"anyOf": [{"type": "string"}, {"type": "null"}]}` |
+
+  The two spellings differ because `model_json_schema()` is Pydantic's own
+  rendering of `Optional[T]`, while `to_json_schema()` uses the list form.
+  Meaning is preserved and re-import is idempotent, but the exported bytes
+  differ from the input schema, which matters when feeding our output into a
+  validator or a codegen tool. `required` membership is unchanged
+  ([#159](https://github.com/awslabs/stickler/pull/159))
+
+- **Breaking:** the peripheral modules now require their extra. `pandas`,
+  `scipy`, `scikit-learn`, and `jinja2` are no longer core dependencies, so
+  `pip install stickler-eval` installs the comparison engine and nothing else.
+  Code that used these without installing an extra now raises `ImportError`
+  naming the extra to install:
+
+  | what you were using | now needs |
+  |---|---|
+  | `stickler.doc_split` (raises at import) | `stickler-eval[docsplit]` |
+  | `MarkdownUtil.table_df()` | `stickler-eval[reporting]` |
+  | `LLMComparator(...)` | `stickler-eval[llm]` |
+  | `SemanticComparator` cosine similarity | `stickler-eval[semantic]` |
+
+  Confidence calibration metrics are **not** affected: `scikit-learn` stays in
+  the core dependency set because calibration is core functionality, not an
+  add-on. The `confidence` extra is now empty and kept only so existing pins
+  keep resolving.
+
+  `pip install "stickler-eval[all]"` restores everything except `bert`.
+
+  Only `stickler.doc_split` fails at import time; the rest fail at first use.
+  `SemanticComparator` still constructs on a core install and raises when the
+  similarity function runs
+  ([#201](https://github.com/awslabs/stickler/issues/201))
+
+- Optional comparators are now imported lazily. `import stickler` no longer
+  pulls a scientific-computing stack: 421 modules on a core install, down from
+  1664, with none of pandas, scipy, scikit-learn, jinja2, torch, transformers,
+  strands, or boto3 on the path. `scikit-learn` is a core dependency but its
+  import stays inside `AUROCMetric.compute()`, so it costs nothing at import
+  time. `BERTComparator` no longer loads its model at import time. Accessing an
+  optional comparator whose extra is missing raises `AttributeError`, so
+  `hasattr()` gating keeps working
+  ([#187](https://github.com/awslabs/stickler/issues/187))
+
+- Relaxed the `scikit-learn` floor from `>=1.8.0` to `>=1.7.2`. 1.8.0 requires
+  Python 3.11+, so the old floor made the 3.10 support above unresolvable. The
+  lock pins 1.7.2 below 3.11 and 1.8.0 above
+
+### Deprecated
+
+- **Custom comparators:** the extension point for comparators is now
+  `_compare()` instead of `compare()`. `BaseComparator.compare()` is a
+  template method that applies the shared `None` policy and then delegates
+  to `_compare()`, so the policy is defined once and cannot drift between
+  comparators. Callers are unaffected -- `compare()`, `__call__`, and
+  `binary_compare()` are unchanged.
+
+  Custom comparators must rename their `compare()` to `_compare()` and can
+  delete any `None` handling it contains, since `_compare()` only ever
+  receives present values.
+
+  This is not a hard break. A deprecation shim keeps pre-rename comparators
+  working: one that implements `compare()` still constructs and behaves
+  exactly as written, and emits a `DeprecationWarning` naming the rename.
+  That holds whether it extends `BaseComparator` directly, extends a
+  concrete comparator, or inherits `compare()` from a mixin.
+
+  An un-migrated comparator does **not** receive the `None` policy, because
+  its `compare()` shadows the template method, so the rename is still
+  required. The shim is removed in 0.8.0, after which such a comparator
+  raises `TypeError` at construction
+  ([#215](https://github.com/awslabs/stickler/issues/215)).
+
+  Note that the pre-fix `(None, "") -> 1.0` result cannot be inherited: the
+  coercion was removed from Levenshtein's algorithm rather than guarded, so
+  an un-migrated subclass that delegates upward gets the corrected score.
+  Only a subclass that reimplemented the coercion in its own `compare()`
+  still returns the old value
+  ([#200](https://github.com/awslabs/stickler/issues/200))
+
+- `ComparableField(aggregate=...)` now emits a `DeprecationWarning` for *any*
+  explicit use, where previously only `aggregate=True` warned and
+  `aggregate=False` was silent. The parameter has no effect: aggregation is
+  applied at the comparison layer, and every node in `compare_with()` output
+  already carries an `aggregate` block summing the primitive field metrics
+  below it.
+
+  Callers passing `aggregate=False` had no signal the parameter was going away
+  and would have met a bare `TypeError` on removal. Remove the argument; there
+  is no replacement to adopt. Scheduled for removal in 0.8.0.
+
+  Reading a config does **not** count as explicit use: `to_stickler_config()`
+  writes the `aggregate` key for every field, so `model_from_json()` restores
+  the value without warning. Otherwise every exported-config round trip would
+  warn once per field, blaming stickler's own frame for a key the caller never
+  wrote, and would fail outright under `-W error::DeprecationWarning`. The
+  export format is unchanged and stays idempotent: `export -> import -> export`
+  reproduces the original, including for `aggregate=True`.
+
+  Also removed a dead branch in `ConfusionMatrixCalculator` that zeroed and
+  re-summed a list field's confusion matrix when the flag was set. It was
+  unreachable by construction -- guarded on the argument *not* being a list, in
+  a method only ever called with one (instrumented the whole suite: 0 calls) --
+  and left a live-looking code path keyed on a parameter that is going away
+  ([#226](https://github.com/awslabs/stickler/issues/226))
 
 ### Fixed
 
@@ -264,210 +470,6 @@ Each release links to full notes on the
   helpers, so a mocked dependency counts as available in both places rather
   than having `stickler.LLMComparator` resolve while
   `registry.get("LLMComparator")` reports it missing
-
-### Changed
-
-- **Breaking:** `ExactComparator` is now truly exact. The default is
-  `case_sensitive=True` (was `False`), and punctuation/whitespace stripping
-  has been removed entirely. This fixes
-  [#199](https://github.com/awslabs/stickler/issues/199), where
-  `"SHP-2024-001"` incorrectly matched `"shp 2024 001"`.
-
-  **This lowers scores** on existing evaluation sets, and it reaches you even if
-  you never named `ExactComparator`. The zero-config path (`stickler.evaluate()`,
-  `eval_for()`, `from_pydantic()`) infers `ExactComparator` for id-shaped,
-  code-shaped, email, zip and boolean fields, so on a typical extraction model
-  it covers roughly half the fields:
-
-  ```python
-  class Invoice(BaseModel):           # plain pydantic, no stickler config
-      invoice_id: str                 # inferred -> ExactComparator
-      sku: str                        # inferred -> ExactComparator
-      email: str                      # inferred -> ExactComparator
-      zip_code: str                   # inferred -> ExactComparator
-      vendor_name: str                # inferred -> LevenshteinComparator
-  ```
-
-  With predictions differing only in case and punctuation
-  (`"SHP-2024-001"` vs `"shp 2024 001"`, `"98101-1234"` vs `"98101 1234"`):
-
-  | | before | after |
-  |---|---|---|
-  | the four inferred-Exact fields | 1.0 each | **0.0 each** |
-  | `overall_score` | 1.0 | **0.20** |
-
-  That is the intended correction -- those pairs are not equal, and reporting
-  them as perfect matches is the bug -- but if you track a metric across
-  releases, expect a step change at this version rather than a drift.
-
-  | what changed | before | after |
-  |---|---|---|
-  | `ExactComparator().compare("Hello", "hello")` | 1.0 | **0.0** |
-  | `ExactComparator().compare("ID-123", "ID 123")` | 1.0 | **0.0** |
-  | `ExactComparator().compare("SHP-2024-001", "shp 2024 001")` | 1.0 | **0.0** |
-
-  **Migration:** For case-insensitive matching, pass `case_sensitive=False`.
-
-  For punctuation or whitespace differences, `ExactComparator` is the wrong
-  tool. Use a similarity comparator with a threshold tuned to your data:
-
-  ```python
-  vendor: str = ComparableField(comparator=LevenshteinComparator(), threshold=0.8)
-  ```
-
-  Note that a threshold of `1.0` will **not** work here: `"ID-123"` vs
-  `"ID 123"` scores `0.833`, so requiring a perfect score still rejects it. Pick
-  a threshold below the score your real data produces, or write a comparator
-  that normalizes the way your domain requires.
-
-  The `case_sensitive=False` path now uses `str.casefold()` (Unicode case
-  folding) instead of `str.lower()`, correctly handling cases like
-  `"STRASSE"` vs `"straße"` ([#199](https://github.com/awslabs/stickler/issues/199))
-
-- `model_json_schema()` now describes the model's shape the way an equivalent
-  plain `BaseModel` would, so a configured `StructuredModel` can drive a
-  Strands agent's structured output without degrading the schema the LLM sees:
-  `required` is derived from the annotation (`shipment_id: str` renders
-  required even though `ComparableField` assigns a `None` default for
-  construction tolerance), required fields no longer widen to
-  `["type", "null"]` or carry a contradictory `default: null`, and comparison
-  configuration (`x-comparison`) is no longer emitted. Verified through
-  Strands' `convert_pydantic_to_tool_spec`: a configured `StructuredModel` and
-  its plain-`BaseModel` twin now produce the same tool spec.
-
-  Field-level `description`, `examples`, and `alias` still reach the rendered
-  schema, and the deliberate export path `to_json_schema()` still carries the
-  comparison configuration as `x-aws-stickler-*` extensions. Runtime behavior
-  is unchanged: predictions that omit fields still construct and score.
-
-  Code that read `x-comparison` out of `model_json_schema()` output should
-  read the field's `json_schema_extra` (as the engine does) or use
-  `to_json_schema()`.
-
-  Note a side effect: dropping the internal `extra_fields` property means
-  `from_json_schema(M.model_json_schema())` now parses for a model whose fields
-  are all required, where it previously raised `ValueError`. It still does
-  **not** round-trip -- the rebuilt model carries default thresholds, weights
-  and comparators, because a shape-only schema does not describe them. A model
-  with any `Optional` field still raises, on the nullable `anyOf` gap that
-  [#198](https://github.com/awslabs/stickler/pull/198) addresses, so most real
-  models are unaffected either way. `model_json_schema()` remains documented as
-  not round-trip-capable; use `to_json_schema()` or `to_stickler_config()` to
-  preserve configuration. Tracked in
-  [#214](https://github.com/awslabs/stickler/issues/214)
-  ([#188](https://github.com/awslabs/stickler/issues/188))
-
-- Optional fields built from a JSON Schema are now annotated `Optional[T]`
-  rather than `T`, so `to_json_schema()` exports them with a nullable type:
-
-  | | before | after |
-  |---|---|---|
-  | `to_json_schema()` | `{"type": "string"}` | `{"type": ["string", "null"]}` |
-  | `model_json_schema()` | `{"type": "string"}` | `{"anyOf": [{"type": "string"}, {"type": "null"}]}` |
-
-  The two spellings differ because `model_json_schema()` is Pydantic's own
-  rendering of `Optional[T]`, while `to_json_schema()` uses the list form.
-  Meaning is preserved and re-import is idempotent, but the exported bytes
-  differ from the input schema, which matters when feeding our output into a
-  validator or a codegen tool. `required` membership is unchanged
-  ([#159](https://github.com/awslabs/stickler/pull/159))
-
-- **Breaking:** the peripheral modules now require their extra. `pandas`,
-  `scipy`, `scikit-learn`, and `jinja2` are no longer core dependencies, so
-  `pip install stickler-eval` installs the comparison engine and nothing else.
-  Code that used these without installing an extra now raises `ImportError`
-  naming the extra to install:
-
-  | what you were using | now needs |
-  |---|---|
-  | `stickler.doc_split` (raises at import) | `stickler-eval[docsplit]` |
-  | `MarkdownUtil.table_df()` | `stickler-eval[reporting]` |
-  | `LLMComparator(...)` | `stickler-eval[llm]` |
-  | `SemanticComparator` cosine similarity | `stickler-eval[semantic]` |
-
-  Confidence calibration metrics are **not** affected: `scikit-learn` stays in
-  the core dependency set because calibration is core functionality, not an
-  add-on. The `confidence` extra is now empty and kept only so existing pins
-  keep resolving.
-
-  `pip install "stickler-eval[all]"` restores everything except `bert`.
-
-  Only `stickler.doc_split` fails at import time; the rest fail at first use.
-  `SemanticComparator` still constructs on a core install and raises when the
-  similarity function runs
-  ([#201](https://github.com/awslabs/stickler/issues/201))
-
-- Optional comparators are now imported lazily. `import stickler` no longer
-  pulls a scientific-computing stack: 421 modules on a core install, down from
-  1664, with none of pandas, scipy, scikit-learn, jinja2, torch, transformers,
-  strands, or boto3 on the path. `scikit-learn` is a core dependency but its
-  import stays inside `AUROCMetric.compute()`, so it costs nothing at import
-  time. `BERTComparator` no longer loads its model at import time. Accessing an
-  optional comparator whose extra is missing raises `AttributeError`, so
-  `hasattr()` gating keeps working
-  ([#187](https://github.com/awslabs/stickler/issues/187))
-
-- Relaxed the `scikit-learn` floor from `>=1.8.0` to `>=1.7.2`. 1.8.0 requires
-  Python 3.11+, so the old floor made the 3.10 support above unresolvable. The
-  lock pins 1.7.2 below 3.11 and 1.8.0 above
-
-- **Deprecated (custom comparators):** the extension point for comparators is
-  now `_compare()` instead of `compare()`. `BaseComparator.compare()` is a
-  template method that applies the shared `None` policy and then delegates
-  to `_compare()`, so the policy is defined once and cannot drift between
-  comparators. Callers are unaffected -- `compare()`, `__call__`, and
-  `binary_compare()` are unchanged.
-
-  Custom comparators must rename their `compare()` to `_compare()` and can
-  delete any `None` handling it contains, since `_compare()` only ever
-  receives present values.
-
-  This is not a hard break. A deprecation shim keeps pre-rename comparators
-  working: one that implements `compare()` still constructs and behaves
-  exactly as written, and emits a `DeprecationWarning` naming the rename.
-  That holds whether it extends `BaseComparator` directly, extends a
-  concrete comparator, or inherits `compare()` from a mixin.
-
-  An un-migrated comparator does **not** receive the `None` policy, because
-  its `compare()` shadows the template method, so the rename is still
-  required. The shim is removed in 0.8.0, after which such a comparator
-  raises `TypeError` at construction
-  ([#215](https://github.com/awslabs/stickler/issues/215)).
-
-  Note that the pre-fix `(None, "") -> 1.0` result cannot be inherited: the
-  coercion was removed from Levenshtein's algorithm rather than guarded, so
-  an un-migrated subclass that delegates upward gets the corrected score.
-  Only a subclass that reimplemented the coercion in its own `compare()`
-  still returns the old value
-  ([#200](https://github.com/awslabs/stickler/issues/200))
-
-- `ComparableField(aggregate=...)` now emits a `DeprecationWarning` for *any*
-  explicit use, where previously only `aggregate=True` warned and
-  `aggregate=False` was silent. The parameter has no effect: aggregation is
-  applied at the comparison layer, and every node in `compare_with()` output
-  already carries an `aggregate` block summing the primitive field metrics
-  below it.
-
-  Callers passing `aggregate=False` had no signal the parameter was going away
-  and would have met a bare `TypeError` on removal. Remove the argument; there
-  is no replacement to adopt. Scheduled for removal in 0.8.0.
-
-  Reading a config does **not** count as explicit use: `to_stickler_config()`
-  writes the `aggregate` key for every field, so `model_from_json()` restores
-  the value without warning. Otherwise every exported-config round trip would
-  warn once per field, blaming stickler's own frame for a key the caller never
-  wrote, and would fail outright under `-W error::DeprecationWarning`. The
-  export format is unchanged and stays idempotent: `export -> import -> export`
-  reproduces the original, including for `aggregate=True`.
-
-  Also removed a dead branch in `ConfusionMatrixCalculator` that zeroed and
-  re-summed a list field's confusion matrix when the flag was set. It was
-  unreachable by construction -- guarded on the argument *not* being a list, in
-  a method only ever called with one (instrumented the whole suite: 0 calls) --
-  and left a live-looking code path keyed on a parameter that is going away
-  ([#226](https://github.com/awslabs/stickler/issues/226))
-
-### Fixed
 
 - Import Pydantic v2 JSON Schemas whose `Optional` fields use nullable
   two-branch `anyOf`, and infer nested object schemas when `type: object` is
@@ -635,7 +637,8 @@ Initial public release: structured JSON comparison with configurable
 comparators, Hungarian-algorithm list matching, confusion-matrix metrics, and
 HTML reporting.
 
-[Unreleased]: https://github.com/awslabs/stickler/compare/v0.6.0...dev
+[Unreleased]: https://github.com/awslabs/stickler/compare/v0.7.0...dev
+[0.7.0]: https://github.com/awslabs/stickler/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/awslabs/stickler/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/awslabs/stickler/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/awslabs/stickler/compare/v0.3.0...v0.4.0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,13 +37,24 @@ inside the release squash.
 git checkout dev && git pull origin dev --ff-only
 ```
 
-Edit **both** files (they must always match):
+Edit **all three** files (they must always match):
 
 - `pyproject.toml` → `version = "X.Y.Z"`
 - `src/stickler/__init__.py` → `__version__ = "X.Y.Z"`
+- `uv.lock` → the `version` line in the `name = "stickler-eval"` entry
+
+The lockfile records this package's own version, not just its dependencies, so
+leaving it behind fails CI: `uv lock --check` reports "the lockfile needs to be
+updated", and every workflow runs `uv sync --frozen`.
+
+Patch that one line **by hand**. Do not run `uv lock` to pick it up: in this
+repo it also rewrites `exclude-newer` to `0001-01-01` and strips platform
+markers from the CUDA and nvidia entries. See
+[AGENTS.md](./AGENTS.md#dependencies-and-uvlock).
 
 ```bash
-git add pyproject.toml src/stickler/__init__.py
+uv lock --check          # must pass before committing
+git add pyproject.toml src/stickler/__init__.py uv.lock
 git commit -m "chore: bump version to X.Y.Z for release"
 git push origin dev
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stickler-eval"
-version = "0.6.0"
+version = "0.7.0"
 description = "Structured object comparison and evaluation library"
 authors = [
     {name = "Spencer Romo", email = "sromo@amazon.com"},

--- a/src/stickler/__init__.py
+++ b/src/stickler/__init__.py
@@ -134,7 +134,7 @@ def __dir__() -> list:
     """Include lazily-available comparators in `dir(stickler)`."""
     return sorted(set(globals()) | set(__all__))
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 __all__ = [
     # Models and evaluation
     "StructuredModel",

--- a/uv.lock
+++ b/uv.lock
@@ -4007,7 +4007,7 @@ wheels = [
 
 [[package]]
 name = "stickler-eval"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
## Issue Reference

Release chore for 0.7.0. No issue.

## Description of Changes

Release prep for 0.7.0. No source changes: the only file under `src/` is the
one-line `__version__` bump.

### Changes Made

- `pyproject.toml`, `src/stickler/__init__.py` and `uv.lock` -> `0.7.0`. All
  three must agree; `uv.lock` records the workspace package's own version, so it
  moves with the other two.
- CHANGELOG `[Unreleased]` -> `## [0.7.0] - 2026-08-14`, with an empty
  `[Unreleased]` placeholder kept above it (matching what v0.6.0 did). Link refs
  updated: `[Unreleased]` now compares from `v0.7.0`, and `[0.7.0]` added.
- Repaired the CHANGELOG section structure, which drifted as entries accumulated
  across merges. `[Unreleased]` had grown **two separate `Fixed` blocks** with
  `Changed` between them, and **both deprecations sat under `Changed`** with no
  `Deprecated` section at all. The 0.7.0 section now follows Keep a Changelog
  order: Added, Changed, Deprecated, Fixed.

### Why These Changes Are Needed

The version bump gates the release. `pyproject.toml` still read `0.6.0`, and the
publish workflow runs `uv build` against whatever is checked out, so tagging
v0.7.0 without this would have built `stickler_eval-0.6.0` and PyPI would have
rejected the upload as an existing file.

The CHANGELOG restructure is bundled because per
[RELEASING.md](../../RELEASING.md) step 2 the dated section lands in the same
commit as the bump, and the misfiled deprecations would otherwise ship
unfindable under `Changed`.

## Testing

- [x] All existing tests pass
- [x] Manual testing completed
- [ ] Unit tests added/updated (n/a, no behavior change)
- [ ] Integration tests added/updated (n/a)

**Suite: 1856 passed, 2 skipped.** `uv lock --check` clean and `exclude-newer`
intact (patched the one version line by hand rather than running `uv lock`,
which has previously rewritten `exclude-newer` and stripped platform markers).

No changelog prose was lost. Verified by diffing non-blank line multisets before
and after: the only additions are the two new headings, two reflowed lines, and
the two link refs; the only removals are the duplicate `### Fixed` heading,
those same two lines pre-reflow, and the superseded link ref.

The only entry text that changed is a `**Deprecated (custom comparators):**`
prefix, now `**Custom comparators:**`, since it stutters under the `Deprecated`
heading it sits beneath.

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review of code completed
- [x] `CHANGELOG.md` entry added (this PR *is* the changelog change)
- [x] Documentation updated (if applicable)
- [ ] Tests added/updated for new functionality (n/a)
- [ ] All CI checks are passing (pending)
- [x] Ready for review

## Additional Notes

RELEASING.md step 2 says the bump commit goes directly on `dev` so it lands
inside the release squash. Routing it through a PR instead for review; same end
state, since it merges to `dev` before the release PR. Happy to update
RELEASING.md if this becomes the convention.

Ruff reports 16 findings on this branch, but **all 16 are pre-existing on `dev`**
(identical count on both) and all are in `examples/`: import sorting, f-strings
with no placeholders, one unused import. This branch adds none. They persist
because `lint.yaml` sets `continue-on-error: true`, which #171 addresses.

Not included in 0.7.0, deliberately: #240 (GitHub Actions major bumps), held so
the PyPI publish path runs on pins that have shipped before, and #146 (PEP 604
list detection), which turns a silent no-op into an import-time `ValueError`
whose suggested remedy needs verifying first.
