### PR TITLE
docs: close the threshold gaps left after #222 and retitle the Advanced page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,13 @@
 ## Testing
 - Test documentation and guidelines can be found in [tests/README.md](./tests/README.md).
 
+## Dependencies and `uv.lock`
+- `uv.lock` is committed deliberately. Do not gitignore or delete it: every CI workflow runs `uv sync --frozen`, which fails immediately if the lockfile is absent.
+- It does not constrain consumers of the published package. Installers resolve the `dependencies` ranges in `pyproject.toml`, which is what the wheel metadata carries; the lockfile is uv-specific and governs only this repo's dev and CI environments.
+- It also carries the dependency cooldown (`exclude-newer`, `exclude-newer-span`) that the semgrep supply-chain rules check for, so removing it regresses the security scan.
+- **Prefer hand-editing the lines you need over running `uv lock`.** In this repo `uv lock` rewrites `exclude-newer` to `0001-01-01` and strips platform markers from the CUDA and nvidia entries. If you do run it, diff the result and restore both. Verify any edit with `uv lock --check`, which is the authoritative consistency check.
+- The lockfile records this package's own `version`, so a release bump must update it alongside `pyproject.toml` and `src/stickler/__init__.py`. See [RELEASING.md](./RELEASING.md).
+
 ## README.md 
 - In addition to MKDocs, The project strives to maintain developer documentation distributed in README.md files throughout the codebase. This documentation exists to help human and AI coding assistants when working with the codebase.
 - When creating directories or working in a directory that does not have a README.md create a README.md file and document the final state of the code and logic that's in the directory. Do this in language that an AI coding assistant trying to understand the implementation and codebas would understand.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -475,6 +475,29 @@ Each release links to full notes on the
   two-branch `anyOf`, and infer nested object schemas when `type: object` is
   omitted ([#198](https://github.com/awslabs/stickler/pull/198))
 
+- The zero-threshold `UserWarning` now links to documentation instead of to an
+  issue tracker. Its target was
+  `github.com/awslabs/stickler/issues/234`, an interim placeholder chosen
+  because no docs section explained the cliff; the warning now points at
+  [The Zero-Threshold Trap](https://awslabs.github.io/stickler/Getting-Started/thresholds-and-metrics/#the-zero-threshold-trap),
+  written for it.
+
+  That section also records what is and is not invariant at `0.0`, since the
+  distinction is easy to overstate: no false discovery can ever be reported,
+  because FD means "compared and scored below threshold" and nothing scores
+  below `0.0`, but precision and recall are *not* both `1.0` in general, because
+  unmatched items are not subject to any threshold.
+
+  Two further threshold gaps are closed. `recall_with_fd` now documents that
+  **TP → FD and FN → FD move recall in opposite directions**, so raising
+  `match_threshold` does not reliably lower reported recall (checked
+  exhaustively: 0 cases raised, 6 equal, 34 fell). And
+  `Advanced/threshold-gated-evaluation.md` is retitled "How Below-Threshold
+  Pairs Are Classified", since it covers classification rather than only
+  recursion, and now defers to the Getting-Started explainer instead of
+  restating threshold semantics. The page URL is unchanged
+  ([#235](https://github.com/awslabs/stickler/issues/235))
+
 ## [0.6.0] - 2026-07-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Each release links to full notes on the
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-14
+
 ### Added
 
 - `PhoneComparator`, which compares phone numbers by the number they dial rather
@@ -100,6 +102,210 @@ Each release links to full notes on the
   embeddings), `docsplit` (document packet splitting), `reporting` (HTML report
   tables). `all` aggregates every extra except `bert`, whose ML stack is large
   enough that installing it unasked is a surprise
+
+### Changed
+
+- **Breaking:** `ExactComparator` is now truly exact. The default is
+  `case_sensitive=True` (was `False`), and punctuation/whitespace stripping
+  has been removed entirely. This fixes
+  [#199](https://github.com/awslabs/stickler/issues/199), where
+  `"SHP-2024-001"` incorrectly matched `"shp 2024 001"`.
+
+  **This lowers scores** on existing evaluation sets, and it reaches you even if
+  you never named `ExactComparator`. The zero-config path (`stickler.evaluate()`,
+  `eval_for()`, `from_pydantic()`) infers `ExactComparator` for id-shaped,
+  code-shaped, email, zip and boolean fields, so on a typical extraction model
+  it covers roughly half the fields:
+
+  ```python
+  class Invoice(BaseModel):           # plain pydantic, no stickler config
+      invoice_id: str                 # inferred -> ExactComparator
+      sku: str                        # inferred -> ExactComparator
+      email: str                      # inferred -> ExactComparator
+      zip_code: str                   # inferred -> ExactComparator
+      vendor_name: str                # inferred -> LevenshteinComparator
+  ```
+
+  With predictions differing only in case and punctuation
+  (`"SHP-2024-001"` vs `"shp 2024 001"`, `"98101-1234"` vs `"98101 1234"`):
+
+  | | before | after |
+  |---|---|---|
+  | the four inferred-Exact fields | 1.0 each | **0.0 each** |
+  | `overall_score` | 1.0 | **0.20** |
+
+  That is the intended correction -- those pairs are not equal, and reporting
+  them as perfect matches is the bug -- but if you track a metric across
+  releases, expect a step change at this version rather than a drift.
+
+  | what changed | before | after |
+  |---|---|---|
+  | `ExactComparator().compare("Hello", "hello")` | 1.0 | **0.0** |
+  | `ExactComparator().compare("ID-123", "ID 123")` | 1.0 | **0.0** |
+  | `ExactComparator().compare("SHP-2024-001", "shp 2024 001")` | 1.0 | **0.0** |
+
+  **Migration:** For case-insensitive matching, pass `case_sensitive=False`.
+
+  For punctuation or whitespace differences, `ExactComparator` is the wrong
+  tool. Use a similarity comparator with a threshold tuned to your data:
+
+  ```python
+  vendor: str = ComparableField(comparator=LevenshteinComparator(), threshold=0.8)
+  ```
+
+  Note that a threshold of `1.0` will **not** work here: `"ID-123"` vs
+  `"ID 123"` scores `0.833`, so requiring a perfect score still rejects it. Pick
+  a threshold below the score your real data produces, or write a comparator
+  that normalizes the way your domain requires.
+
+  The `case_sensitive=False` path now uses `str.casefold()` (Unicode case
+  folding) instead of `str.lower()`, correctly handling cases like
+  `"STRASSE"` vs `"straße"` ([#199](https://github.com/awslabs/stickler/issues/199))
+
+- `model_json_schema()` now describes the model's shape the way an equivalent
+  plain `BaseModel` would, so a configured `StructuredModel` can drive a
+  Strands agent's structured output without degrading the schema the LLM sees:
+  `required` is derived from the annotation (`shipment_id: str` renders
+  required even though `ComparableField` assigns a `None` default for
+  construction tolerance), required fields no longer widen to
+  `["type", "null"]` or carry a contradictory `default: null`, and comparison
+  configuration (`x-comparison`) is no longer emitted. Verified through
+  Strands' `convert_pydantic_to_tool_spec`: a configured `StructuredModel` and
+  its plain-`BaseModel` twin now produce the same tool spec.
+
+  Field-level `description`, `examples`, and `alias` still reach the rendered
+  schema, and the deliberate export path `to_json_schema()` still carries the
+  comparison configuration as `x-aws-stickler-*` extensions. Runtime behavior
+  is unchanged: predictions that omit fields still construct and score.
+
+  Code that read `x-comparison` out of `model_json_schema()` output should
+  read the field's `json_schema_extra` (as the engine does) or use
+  `to_json_schema()`.
+
+  Note a side effect: dropping the internal `extra_fields` property means
+  `from_json_schema(M.model_json_schema())` now parses for a model whose fields
+  are all required, where it previously raised `ValueError`. It still does
+  **not** round-trip -- the rebuilt model carries default thresholds, weights
+  and comparators, because a shape-only schema does not describe them. A model
+  with any `Optional` field still raises, on the nullable `anyOf` gap that
+  [#198](https://github.com/awslabs/stickler/pull/198) addresses, so most real
+  models are unaffected either way. `model_json_schema()` remains documented as
+  not round-trip-capable; use `to_json_schema()` or `to_stickler_config()` to
+  preserve configuration. Tracked in
+  [#214](https://github.com/awslabs/stickler/issues/214)
+  ([#188](https://github.com/awslabs/stickler/issues/188))
+
+- Optional fields built from a JSON Schema are now annotated `Optional[T]`
+  rather than `T`, so `to_json_schema()` exports them with a nullable type:
+
+  | | before | after |
+  |---|---|---|
+  | `to_json_schema()` | `{"type": "string"}` | `{"type": ["string", "null"]}` |
+  | `model_json_schema()` | `{"type": "string"}` | `{"anyOf": [{"type": "string"}, {"type": "null"}]}` |
+
+  The two spellings differ because `model_json_schema()` is Pydantic's own
+  rendering of `Optional[T]`, while `to_json_schema()` uses the list form.
+  Meaning is preserved and re-import is idempotent, but the exported bytes
+  differ from the input schema, which matters when feeding our output into a
+  validator or a codegen tool. `required` membership is unchanged
+  ([#159](https://github.com/awslabs/stickler/pull/159))
+
+- **Breaking:** the peripheral modules now require their extra. `pandas`,
+  `scipy`, `scikit-learn`, and `jinja2` are no longer core dependencies, so
+  `pip install stickler-eval` installs the comparison engine and nothing else.
+  Code that used these without installing an extra now raises `ImportError`
+  naming the extra to install:
+
+  | what you were using | now needs |
+  |---|---|
+  | `stickler.doc_split` (raises at import) | `stickler-eval[docsplit]` |
+  | `MarkdownUtil.table_df()` | `stickler-eval[reporting]` |
+  | `LLMComparator(...)` | `stickler-eval[llm]` |
+  | `SemanticComparator` cosine similarity | `stickler-eval[semantic]` |
+
+  Confidence calibration metrics are **not** affected: `scikit-learn` stays in
+  the core dependency set because calibration is core functionality, not an
+  add-on. The `confidence` extra is now empty and kept only so existing pins
+  keep resolving.
+
+  `pip install "stickler-eval[all]"` restores everything except `bert`.
+
+  Only `stickler.doc_split` fails at import time; the rest fail at first use.
+  `SemanticComparator` still constructs on a core install and raises when the
+  similarity function runs
+  ([#201](https://github.com/awslabs/stickler/issues/201))
+
+- Optional comparators are now imported lazily. `import stickler` no longer
+  pulls a scientific-computing stack: 421 modules on a core install, down from
+  1664, with none of pandas, scipy, scikit-learn, jinja2, torch, transformers,
+  strands, or boto3 on the path. `scikit-learn` is a core dependency but its
+  import stays inside `AUROCMetric.compute()`, so it costs nothing at import
+  time. `BERTComparator` no longer loads its model at import time. Accessing an
+  optional comparator whose extra is missing raises `AttributeError`, so
+  `hasattr()` gating keeps working
+  ([#187](https://github.com/awslabs/stickler/issues/187))
+
+- Relaxed the `scikit-learn` floor from `>=1.8.0` to `>=1.7.2`. 1.8.0 requires
+  Python 3.11+, so the old floor made the 3.10 support above unresolvable. The
+  lock pins 1.7.2 below 3.11 and 1.8.0 above
+
+### Deprecated
+
+- **Custom comparators:** the extension point for comparators is now
+  `_compare()` instead of `compare()`. `BaseComparator.compare()` is a
+  template method that applies the shared `None` policy and then delegates
+  to `_compare()`, so the policy is defined once and cannot drift between
+  comparators. Callers are unaffected -- `compare()`, `__call__`, and
+  `binary_compare()` are unchanged.
+
+  Custom comparators must rename their `compare()` to `_compare()` and can
+  delete any `None` handling it contains, since `_compare()` only ever
+  receives present values.
+
+  This is not a hard break. A deprecation shim keeps pre-rename comparators
+  working: one that implements `compare()` still constructs and behaves
+  exactly as written, and emits a `DeprecationWarning` naming the rename.
+  That holds whether it extends `BaseComparator` directly, extends a
+  concrete comparator, or inherits `compare()` from a mixin.
+
+  An un-migrated comparator does **not** receive the `None` policy, because
+  its `compare()` shadows the template method, so the rename is still
+  required. The shim is removed in 0.8.0, after which such a comparator
+  raises `TypeError` at construction
+  ([#215](https://github.com/awslabs/stickler/issues/215)).
+
+  Note that the pre-fix `(None, "") -> 1.0` result cannot be inherited: the
+  coercion was removed from Levenshtein's algorithm rather than guarded, so
+  an un-migrated subclass that delegates upward gets the corrected score.
+  Only a subclass that reimplemented the coercion in its own `compare()`
+  still returns the old value
+  ([#200](https://github.com/awslabs/stickler/issues/200))
+
+- `ComparableField(aggregate=...)` now emits a `DeprecationWarning` for *any*
+  explicit use, where previously only `aggregate=True` warned and
+  `aggregate=False` was silent. The parameter has no effect: aggregation is
+  applied at the comparison layer, and every node in `compare_with()` output
+  already carries an `aggregate` block summing the primitive field metrics
+  below it.
+
+  Callers passing `aggregate=False` had no signal the parameter was going away
+  and would have met a bare `TypeError` on removal. Remove the argument; there
+  is no replacement to adopt. Scheduled for removal in 0.8.0.
+
+  Reading a config does **not** count as explicit use: `to_stickler_config()`
+  writes the `aggregate` key for every field, so `model_from_json()` restores
+  the value without warning. Otherwise every exported-config round trip would
+  warn once per field, blaming stickler's own frame for a key the caller never
+  wrote, and would fail outright under `-W error::DeprecationWarning`. The
+  export format is unchanged and stays idempotent: `export -> import -> export`
+  reproduces the original, including for `aggregate=True`.
+
+  Also removed a dead branch in `ConfusionMatrixCalculator` that zeroed and
+  re-summed a list field's confusion matrix when the flag was set. It was
+  unreachable by construction -- guarded on the argument *not* being a list, in
+  a method only ever called with one (instrumented the whole suite: 0 calls) --
+  and left a live-looking code path keyed on a parameter that is going away
+  ([#226](https://github.com/awslabs/stickler/issues/226))
 
 ### Fixed
 
@@ -264,210 +470,6 @@ Each release links to full notes on the
   helpers, so a mocked dependency counts as available in both places rather
   than having `stickler.LLMComparator` resolve while
   `registry.get("LLMComparator")` reports it missing
-
-### Changed
-
-- **Breaking:** `ExactComparator` is now truly exact. The default is
-  `case_sensitive=True` (was `False`), and punctuation/whitespace stripping
-  has been removed entirely. This fixes
-  [#199](https://github.com/awslabs/stickler/issues/199), where
-  `"SHP-2024-001"` incorrectly matched `"shp 2024 001"`.
-
-  **This lowers scores** on existing evaluation sets, and it reaches you even if
-  you never named `ExactComparator`. The zero-config path (`stickler.evaluate()`,
-  `eval_for()`, `from_pydantic()`) infers `ExactComparator` for id-shaped,
-  code-shaped, email, zip and boolean fields, so on a typical extraction model
-  it covers roughly half the fields:
-
-  ```python
-  class Invoice(BaseModel):           # plain pydantic, no stickler config
-      invoice_id: str                 # inferred -> ExactComparator
-      sku: str                        # inferred -> ExactComparator
-      email: str                      # inferred -> ExactComparator
-      zip_code: str                   # inferred -> ExactComparator
-      vendor_name: str                # inferred -> LevenshteinComparator
-  ```
-
-  With predictions differing only in case and punctuation
-  (`"SHP-2024-001"` vs `"shp 2024 001"`, `"98101-1234"` vs `"98101 1234"`):
-
-  | | before | after |
-  |---|---|---|
-  | the four inferred-Exact fields | 1.0 each | **0.0 each** |
-  | `overall_score` | 1.0 | **0.20** |
-
-  That is the intended correction -- those pairs are not equal, and reporting
-  them as perfect matches is the bug -- but if you track a metric across
-  releases, expect a step change at this version rather than a drift.
-
-  | what changed | before | after |
-  |---|---|---|
-  | `ExactComparator().compare("Hello", "hello")` | 1.0 | **0.0** |
-  | `ExactComparator().compare("ID-123", "ID 123")` | 1.0 | **0.0** |
-  | `ExactComparator().compare("SHP-2024-001", "shp 2024 001")` | 1.0 | **0.0** |
-
-  **Migration:** For case-insensitive matching, pass `case_sensitive=False`.
-
-  For punctuation or whitespace differences, `ExactComparator` is the wrong
-  tool. Use a similarity comparator with a threshold tuned to your data:
-
-  ```python
-  vendor: str = ComparableField(comparator=LevenshteinComparator(), threshold=0.8)
-  ```
-
-  Note that a threshold of `1.0` will **not** work here: `"ID-123"` vs
-  `"ID 123"` scores `0.833`, so requiring a perfect score still rejects it. Pick
-  a threshold below the score your real data produces, or write a comparator
-  that normalizes the way your domain requires.
-
-  The `case_sensitive=False` path now uses `str.casefold()` (Unicode case
-  folding) instead of `str.lower()`, correctly handling cases like
-  `"STRASSE"` vs `"straße"` ([#199](https://github.com/awslabs/stickler/issues/199))
-
-- `model_json_schema()` now describes the model's shape the way an equivalent
-  plain `BaseModel` would, so a configured `StructuredModel` can drive a
-  Strands agent's structured output without degrading the schema the LLM sees:
-  `required` is derived from the annotation (`shipment_id: str` renders
-  required even though `ComparableField` assigns a `None` default for
-  construction tolerance), required fields no longer widen to
-  `["type", "null"]` or carry a contradictory `default: null`, and comparison
-  configuration (`x-comparison`) is no longer emitted. Verified through
-  Strands' `convert_pydantic_to_tool_spec`: a configured `StructuredModel` and
-  its plain-`BaseModel` twin now produce the same tool spec.
-
-  Field-level `description`, `examples`, and `alias` still reach the rendered
-  schema, and the deliberate export path `to_json_schema()` still carries the
-  comparison configuration as `x-aws-stickler-*` extensions. Runtime behavior
-  is unchanged: predictions that omit fields still construct and score.
-
-  Code that read `x-comparison` out of `model_json_schema()` output should
-  read the field's `json_schema_extra` (as the engine does) or use
-  `to_json_schema()`.
-
-  Note a side effect: dropping the internal `extra_fields` property means
-  `from_json_schema(M.model_json_schema())` now parses for a model whose fields
-  are all required, where it previously raised `ValueError`. It still does
-  **not** round-trip -- the rebuilt model carries default thresholds, weights
-  and comparators, because a shape-only schema does not describe them. A model
-  with any `Optional` field still raises, on the nullable `anyOf` gap that
-  [#198](https://github.com/awslabs/stickler/pull/198) addresses, so most real
-  models are unaffected either way. `model_json_schema()` remains documented as
-  not round-trip-capable; use `to_json_schema()` or `to_stickler_config()` to
-  preserve configuration. Tracked in
-  [#214](https://github.com/awslabs/stickler/issues/214)
-  ([#188](https://github.com/awslabs/stickler/issues/188))
-
-- Optional fields built from a JSON Schema are now annotated `Optional[T]`
-  rather than `T`, so `to_json_schema()` exports them with a nullable type:
-
-  | | before | after |
-  |---|---|---|
-  | `to_json_schema()` | `{"type": "string"}` | `{"type": ["string", "null"]}` |
-  | `model_json_schema()` | `{"type": "string"}` | `{"anyOf": [{"type": "string"}, {"type": "null"}]}` |
-
-  The two spellings differ because `model_json_schema()` is Pydantic's own
-  rendering of `Optional[T]`, while `to_json_schema()` uses the list form.
-  Meaning is preserved and re-import is idempotent, but the exported bytes
-  differ from the input schema, which matters when feeding our output into a
-  validator or a codegen tool. `required` membership is unchanged
-  ([#159](https://github.com/awslabs/stickler/pull/159))
-
-- **Breaking:** the peripheral modules now require their extra. `pandas`,
-  `scipy`, `scikit-learn`, and `jinja2` are no longer core dependencies, so
-  `pip install stickler-eval` installs the comparison engine and nothing else.
-  Code that used these without installing an extra now raises `ImportError`
-  naming the extra to install:
-
-  | what you were using | now needs |
-  |---|---|
-  | `stickler.doc_split` (raises at import) | `stickler-eval[docsplit]` |
-  | `MarkdownUtil.table_df()` | `stickler-eval[reporting]` |
-  | `LLMComparator(...)` | `stickler-eval[llm]` |
-  | `SemanticComparator` cosine similarity | `stickler-eval[semantic]` |
-
-  Confidence calibration metrics are **not** affected: `scikit-learn` stays in
-  the core dependency set because calibration is core functionality, not an
-  add-on. The `confidence` extra is now empty and kept only so existing pins
-  keep resolving.
-
-  `pip install "stickler-eval[all]"` restores everything except `bert`.
-
-  Only `stickler.doc_split` fails at import time; the rest fail at first use.
-  `SemanticComparator` still constructs on a core install and raises when the
-  similarity function runs
-  ([#201](https://github.com/awslabs/stickler/issues/201))
-
-- Optional comparators are now imported lazily. `import stickler` no longer
-  pulls a scientific-computing stack: 421 modules on a core install, down from
-  1664, with none of pandas, scipy, scikit-learn, jinja2, torch, transformers,
-  strands, or boto3 on the path. `scikit-learn` is a core dependency but its
-  import stays inside `AUROCMetric.compute()`, so it costs nothing at import
-  time. `BERTComparator` no longer loads its model at import time. Accessing an
-  optional comparator whose extra is missing raises `AttributeError`, so
-  `hasattr()` gating keeps working
-  ([#187](https://github.com/awslabs/stickler/issues/187))
-
-- Relaxed the `scikit-learn` floor from `>=1.8.0` to `>=1.7.2`. 1.8.0 requires
-  Python 3.11+, so the old floor made the 3.10 support above unresolvable. The
-  lock pins 1.7.2 below 3.11 and 1.8.0 above
-
-- **Deprecated (custom comparators):** the extension point for comparators is
-  now `_compare()` instead of `compare()`. `BaseComparator.compare()` is a
-  template method that applies the shared `None` policy and then delegates
-  to `_compare()`, so the policy is defined once and cannot drift between
-  comparators. Callers are unaffected -- `compare()`, `__call__`, and
-  `binary_compare()` are unchanged.
-
-  Custom comparators must rename their `compare()` to `_compare()` and can
-  delete any `None` handling it contains, since `_compare()` only ever
-  receives present values.
-
-  This is not a hard break. A deprecation shim keeps pre-rename comparators
-  working: one that implements `compare()` still constructs and behaves
-  exactly as written, and emits a `DeprecationWarning` naming the rename.
-  That holds whether it extends `BaseComparator` directly, extends a
-  concrete comparator, or inherits `compare()` from a mixin.
-
-  An un-migrated comparator does **not** receive the `None` policy, because
-  its `compare()` shadows the template method, so the rename is still
-  required. The shim is removed in 0.8.0, after which such a comparator
-  raises `TypeError` at construction
-  ([#215](https://github.com/awslabs/stickler/issues/215)).
-
-  Note that the pre-fix `(None, "") -> 1.0` result cannot be inherited: the
-  coercion was removed from Levenshtein's algorithm rather than guarded, so
-  an un-migrated subclass that delegates upward gets the corrected score.
-  Only a subclass that reimplemented the coercion in its own `compare()`
-  still returns the old value
-  ([#200](https://github.com/awslabs/stickler/issues/200))
-
-- `ComparableField(aggregate=...)` now emits a `DeprecationWarning` for *any*
-  explicit use, where previously only `aggregate=True` warned and
-  `aggregate=False` was silent. The parameter has no effect: aggregation is
-  applied at the comparison layer, and every node in `compare_with()` output
-  already carries an `aggregate` block summing the primitive field metrics
-  below it.
-
-  Callers passing `aggregate=False` had no signal the parameter was going away
-  and would have met a bare `TypeError` on removal. Remove the argument; there
-  is no replacement to adopt. Scheduled for removal in 0.8.0.
-
-  Reading a config does **not** count as explicit use: `to_stickler_config()`
-  writes the `aggregate` key for every field, so `model_from_json()` restores
-  the value without warning. Otherwise every exported-config round trip would
-  warn once per field, blaming stickler's own frame for a key the caller never
-  wrote, and would fail outright under `-W error::DeprecationWarning`. The
-  export format is unchanged and stays idempotent: `export -> import -> export`
-  reproduces the original, including for `aggregate=True`.
-
-  Also removed a dead branch in `ConfusionMatrixCalculator` that zeroed and
-  re-summed a list field's confusion matrix when the flag was set. It was
-  unreachable by construction -- guarded on the argument *not* being a list, in
-  a method only ever called with one (instrumented the whole suite: 0 calls) --
-  and left a live-looking code path keyed on a parameter that is going away
-  ([#226](https://github.com/awslabs/stickler/issues/226))
-
-### Fixed
 
 - Import Pydantic v2 JSON Schemas whose `Optional` fields use nullable
   two-branch `anyOf`, and infer nested object schemas when `type: object` is
@@ -635,7 +637,8 @@ Initial public release: structured JSON comparison with configurable
 comparators, Hungarian-algorithm list matching, confusion-matrix metrics, and
 HTML reporting.
 
-[Unreleased]: https://github.com/awslabs/stickler/compare/v0.6.0...dev
+[Unreleased]: https://github.com/awslabs/stickler/compare/v0.7.0...dev
+[0.7.0]: https://github.com/awslabs/stickler/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/awslabs/stickler/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/awslabs/stickler/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/awslabs/stickler/compare/v0.3.0...v0.4.0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,13 +37,24 @@ inside the release squash.
 git checkout dev && git pull origin dev --ff-only
 ```
 
-Edit **both** files (they must always match):
+Edit **all three** files (they must always match):
 
 - `pyproject.toml` → `version = "X.Y.Z"`
 - `src/stickler/__init__.py` → `__version__ = "X.Y.Z"`
+- `uv.lock` → the `version` line in the `name = "stickler-eval"` entry
+
+The lockfile records this package's own version, not just its dependencies, so
+leaving it behind fails CI: `uv lock --check` reports "the lockfile needs to be
+updated", and every workflow runs `uv sync --frozen`.
+
+Patch that one line **by hand**. Do not run `uv lock` to pick it up: in this
+repo it also rewrites `exclude-newer` to `0001-01-01` and strips platform
+markers from the CUDA and nvidia entries. See
+[AGENTS.md](./AGENTS.md#dependencies-and-uvlock).
 
 ```bash
-git add pyproject.toml src/stickler/__init__.py
+uv lock --check          # must pass before committing
+git add pyproject.toml src/stickler/__init__.py uv.lock
 git commit -m "chore: bump version to X.Y.Z for release"
 git push origin dev
 ```

--- a/docs/docs/Advanced/README.md
+++ b/docs/docs/Advanced/README.md
@@ -12,7 +12,7 @@ This section provides deep dives into Stickler's internal algorithms and advance
 
 - **[Hungarian Matching](hungarian-matching.md)** -- The optimal bipartite matching algorithm used to pair list elements before classification, including worked examples with `List[StructuredModel]`.
 
-- **[Threshold-Gated Evaluation](threshold-gated-evaluation.md)** -- How recursive field-level evaluation is gated by a similarity threshold so that only well-matched object pairs receive detailed analysis.
+- **[How Below-Threshold Pairs Are Classified](threshold-gated-evaluation.md)** -- What happens to an object pair that falls below the similarity threshold: it becomes an atomic False Discovery with no field-by-field breakdown.
 
 - **[Dynamic Model Creation](dynamic-models.md)** -- Creating `StructuredModel` classes at runtime from JSON Schema or custom JSON configuration, enabling configuration-driven evaluation without writing Python model code.
 

--- a/docs/docs/Advanced/aggregate-metrics.md
+++ b/docs/docs/Advanced/aggregate-metrics.md
@@ -108,4 +108,4 @@ print_metrics(result['confusion_matrix'])
 ## See Also
 
 - [Classification Logic](classification-logic.md) -- definitions of TP, FD, FA, FN, TN
-- [Threshold-Gated Evaluation](threshold-gated-evaluation.md) -- how list comparisons feed into aggregation
+- [How Below-Threshold Pairs Are Classified](threshold-gated-evaluation.md) -- how list comparisons feed into aggregation

--- a/docs/docs/Advanced/hungarian-matching.md
+++ b/docs/docs/Advanced/hungarian-matching.md
@@ -202,4 +202,4 @@ ELSE:
 ## See Also
 
 - [Classification Logic](classification-logic.md) -- full definitions of TP, FD, FA, FN, TN
-- [Threshold-Gated Evaluation](threshold-gated-evaluation.md) -- the recursive evaluation model in detail
+- [How Below-Threshold Pairs Are Classified](threshold-gated-evaluation.md) -- the recursive evaluation model in detail

--- a/docs/docs/Advanced/threshold-gated-evaluation.md
+++ b/docs/docs/Advanced/threshold-gated-evaluation.md
@@ -1,10 +1,16 @@
 ---
-title: Threshold-Gated Recursive Evaluation
+title: How Below-Threshold Pairs Are Classified
 ---
 
-# Threshold-Gated Recursive Evaluation
+# How Below-Threshold Pairs Are Classified
 
 When comparing `List[StructuredModel]` fields, Stickler only performs detailed nested-field analysis on object pairs whose overall similarity meets a configurable threshold. Pairs that fall below the threshold are classified as False Discovery (FD) and treated as atomic units -- no field-by-field breakdown is generated for them.
+
+> **New to thresholds?** Start with
+> [Thresholds and Metrics](../Getting-Started/thresholds-and-metrics.md), which
+> explains all four thresholds, which one wins where, and what each confusion-matrix
+> category means. This page is the mechanism reference for the gating behaviour
+> itself: what happens to a pair once it falls below the threshold.
 
 ## Core Principle
 
@@ -171,6 +177,7 @@ The `all_fields_matched` flag is `True` only when every field's raw similarity m
 
 ## See Also
 
+- [Thresholds and Metrics](../Getting-Started/thresholds-and-metrics.md) -- the explainer: all four thresholds, precedence, the metrics glossary, and the zero-threshold trap
 - [Hungarian Matching](hungarian-matching.md) -- the assignment algorithm that produces pairings
 - [Classification Logic](classification-logic.md) -- full definitions of TP, FD, FA, FN, TN
 - [Aggregate Metrics](aggregate-metrics.md) -- how metrics roll up through the result tree

--- a/docs/docs/Getting-Started/Contributing/architecture.md
+++ b/docs/docs/Getting-Started/Contributing/architecture.md
@@ -221,7 +221,7 @@ good_matched_pairs = [
 ]
 ```
 
-For user-facing threshold-gated evaluation documentation, see [Advanced > Threshold-Gated Evaluation](../../Advanced/threshold-gated-evaluation.md).
+For user-facing threshold-gated evaluation documentation, see [Advanced > How Below-Threshold Pairs Are Classified](../../Advanced/threshold-gated-evaluation.md).
 
 ## Score Aggregation
 

--- a/docs/docs/Getting-Started/thresholds-and-metrics.md
+++ b/docs/docs/Getting-Started/thresholds-and-metrics.md
@@ -181,6 +181,86 @@ With FD:       Recall = TP / (TP + FN + FD)
 result = gt.compare_with(pred, recall_with_fd=True)
 ```
 
+#### Two moves that push recall in opposite directions
+
+Because the default excludes FD from the recall denominator, *becoming* an FD
+affects recall differently depending on what the pair was before. These two are
+easy to conflate, and they go opposite ways:
+
+| move | numerator | denominator | default recall |
+|---|---|---|---|
+| TP → FD (you raised `match_threshold`) | `-1` | `-1` | falls, or stays equal |
+| FN → FD (the pair got matched instead of missed) | unchanged | `-1` | **rises** |
+
+A TP that becomes an FD loses a correct answer, so recall falls. An FN that
+becomes an FD was never in the numerator to begin with, so removing it from the
+denominator only makes the remaining hits look better.
+
+The practical consequence: **raising `match_threshold` does not reliably lower
+reported recall.** Checked exhaustively over `tp ∈ 1..4` and `fn ∈ 0..3`, a
+TP → FD move raised recall in 0 cases, left it equal in 6, and lowered it in 34.
+But an FN → FD move raises it. If you track recall across releases or across
+threshold changes, set `recall_with_fd=True` so both moves count against you and
+the number means one thing.
+
+---
+
+## The Zero-Threshold Trap
+
+Setting a `threshold` or `match_threshold` to exactly `0.0` reports perfect
+scores for wholly incorrect output. Stickler emits a `UserWarning` when it sees
+one.
+
+The threshold test is `>=`, so `0.0` is satisfied by **every** score, including
+`0.0` itself. Every compared pair becomes a true positive:
+
+```python
+class Doc(StructuredModel):
+    match_threshold = 0.0          # UserWarning
+    name: str
+
+gt   = Doc(name="Acme Corporation")
+pred = Doc(name="totally wrong")
+
+result = gt.compare_with(pred, include_confusion_matrix=True)
+# precision 1.0, recall 1.0, f1 1.0 -- for an answer that is entirely wrong
+```
+
+Nothing errors and the numbers look ideal, which makes this the hardest
+misconfiguration to notice.
+
+**It is a cliff, not a slope.** `0.01` classifies correctly; only exactly `0.0`
+misbehaves. This is one broken value rather than a "low thresholds are risky"
+heuristic, which is why the warning fires only for `0.0`.
+
+What is genuinely invariant at `0.0` is that **no false discovery can ever be
+reported**, since FD means "compared and scored below threshold" and nothing
+scores below `0.0`. Perfect precision and recall are *not* invariant, and it is
+worth knowing why, because it is easy to over-claim here. Unmatched items are not
+subject to any threshold, so:
+
+- 2 ground-truth objects against 3 predictions still yields an FA, giving
+  precision `0.667`
+- 2 against 1 still yields an FN, giving recall `0.5`
+
+**`match_threshold = 0.0` warns unconditionally**, because the value is used two
+ways: as the object-matching threshold for a `List[StructuredModel]` element,
+*and* as the default field threshold for any field with no explicit config. A
+plainly annotated `name: str` inherits it, so a standalone model with no list
+anywhere still reports `1.0` across the board. Declaring the field with
+`ComparableField()` instead takes an earlier branch that supplies a hardcoded
+`0.5`, which is why the value can look inert when probed that way (see
+[#237](https://github.com/awslabs/stickler/issues/237)).
+
+**Fix:** use a small positive value.
+
+```python
+match_threshold = 0.01    # accepts weak matches, still classifies correctly
+```
+
+The warning fires once per configured site, so a bulk run over many documents
+does not emit one per document.
+
 ---
 
 ## Worked Example
@@ -309,5 +389,5 @@ Recall (with FD) = TP / (TP + FN + FD) = 5 / (5 + 1 + 1) = 0.714
 ## See Also
 
 - [Classification Logic](../Advanced/classification-logic.md) — detailed definitions
-- [Threshold-Gated Evaluation](../Advanced/threshold-gated-evaluation.md) — how recursion works
+- [How Below-Threshold Pairs Are Classified](../Advanced/threshold-gated-evaluation.md) — the gating mechanism in detail
 - [Hungarian Matching](../Advanced/hungarian-matching.md) — list pairing algorithm

--- a/docs/docs/Guides/Evaluation/understanding-results.md
+++ b/docs/docs/Guides/Evaluation/understanding-results.md
@@ -133,6 +133,8 @@ Of all the values that should have been found, what fraction did the model find 
 
 Note: When `recall_with_fd=True` is passed to `compare_with()`, the formula changes to `TP / (TP + FN + FD)`, penalizing incorrect values in addition to missing ones.
 
+Under the default (`recall_with_fd=False`), be aware that a pair *becoming* an FD moves recall in opposite directions depending on what it was before: a TP that becomes an FD lowers recall, while an FN that becomes an FD **raises** it. See [Two moves that push recall in opposite directions](../../Getting-Started/thresholds-and-metrics.md#two-moves-that-push-recall-in-opposite-directions) before comparing recall across releases or threshold changes.
+
 ### F1 Score
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stickler-eval"
-version = "0.6.0"
+version = "0.7.0"
 description = "Structured object comparison and evaluation library"
 authors = [
     {name = "Spencer Romo", email = "sromo@amazon.com"},

--- a/src/stickler/__init__.py
+++ b/src/stickler/__init__.py
@@ -134,7 +134,7 @@ def __dir__() -> list:
     """Include lazily-available comparators in `dir(stickler)`."""
     return sorted(set(globals()) | set(__all__))
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 __all__ = [
     # Models and evaluation
     "StructuredModel",

--- a/src/stickler/structured_object_evaluator/models/threshold_helper.py
+++ b/src/stickler/structured_object_evaluator/models/threshold_helper.py
@@ -4,8 +4,16 @@ from typing import Any, Optional
 
 from stickler.utils.deprecation import warn_once
 
-#: Where the `>=` cliff and what to use instead are explained.
-THRESHOLD_DOCS_URL = "https://github.com/awslabs/stickler/issues/234"
+#: Where the `>=` cliff and what to use instead are explained. Points at the
+#: docs rather than issue #234, which was the interim target while the section
+#: did not exist yet ([#235](https://github.com/awslabs/stickler/issues/235)).
+#: The anchor is load-bearing: `tests/.../test_threshold_zero_warning.py`
+#: asserts the literal, and `docs/.../thresholds-and-metrics.md` must keep a
+#: heading that slugifies to `the-zero-threshold-trap`.
+THRESHOLD_DOCS_URL = (
+    "https://awslabs.github.io/stickler/Getting-Started/"
+    "thresholds-and-metrics/#the-zero-threshold-trap"
+)
 
 # What a zero threshold actually guarantees: nothing the comparison touches can
 # be reported as a false discovery, because FD means "compared and scored below

--- a/tests/structured_object_evaluator/test_threshold_zero_warning.py
+++ b/tests/structured_object_evaluator/test_threshold_zero_warning.py
@@ -13,6 +13,7 @@ See https://github.com/awslabs/stickler/issues/234
 """
 
 import gc
+import re
 import warnings
 from typing import List
 
@@ -61,11 +62,13 @@ class TestFieldThreshold:
         assert "0.01" in message, "the warning must suggest a usable alternative"
         # Assert the literal target, not `THRESHOLD_DOCS_URL in message` --
         # that compares the constant to itself and passes for any value,
-        # including a URL that explains nothing. The old target was a docs page
-        # whose only mention of zero was "raw similarity score (0.0 -- 1.0)".
-        assert "github.com/awslabs/stickler/issues/234" in message, (
-            "the warning must link somewhere that explains the zero-threshold cliff"
-        )
+        # including a URL that explains nothing. This now points at the docs
+        # section written for it in #235; before that section existed the target
+        # was issue #234, because the only docs mention of zero was "raw
+        # similarity score (0.0 -- 1.0)", which explains nothing.
+        assert (
+            "thresholds-and-metrics/#the-zero-threshold-trap" in message
+        ), "the warning must link somewhere that explains the zero-threshold cliff"
         assert THRESHOLD_DOCS_URL in message, "the constant must be what is emitted"
 
     def test_message_claims_no_metric_outcome(self):
@@ -435,6 +438,12 @@ class TestJsonConfigPath:
 
         An earlier attempt keyed dedup on ``id(DynamicClass)`` and interpolated
         it, printing "DynamicModel#4355291632 sets ...".
+
+        The docs URL is stripped before the check rather than the check being
+        relaxed: it legitimately contains a ``#`` fragment
+        (``...#the-zero-threshold-trap``), and a blanket "no ``#``" assertion
+        over the whole message would have to be dropped to accommodate it,
+        which would stop catching the ``Name#address`` pattern this guards.
         """
         config = {
             "match_threshold": 0.0,
@@ -450,10 +459,11 @@ class TestJsonConfigPath:
         with pytest.warns(UserWarning) as record:
             StructuredModel.model_from_json(config)
 
-        message = str(record[0].message)
-        assert "#" not in message
-        assert not any(ch.isdigit() and len(part) > 8 for part in message.split() for ch in part[:1]), (
-            "no long numeric token that could be an address"
+        prose = str(record[0].message).replace(THRESHOLD_DOCS_URL, "")
+
+        assert "#" not in prose, "an object address may be interpolated as Name#id"
+        assert not re.search(r"\d{6,}", prose), (
+            "a long digit run in user-visible text is probably an object address"
         )
 
     def test_anonymous_configs_are_distinguishable_in_the_message(self):

--- a/uv.lock
+++ b/uv.lock
@@ -4007,7 +4007,7 @@ wheels = [
 
 [[package]]
 name = "stickler-eval"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
## Issue Reference

Fixes #235

## Description of Changes

Fills the remainder that #222 did not cover, and points the zero-threshold
warning somewhere that explains itself.

> **Stacked on #245.** Branched from `release/0.7.0` so the CHANGELOG entry lands
> in the dated 0.7.0 section rather than conflicting with it. Merge #245 first;
> until then the diff here shows both. Reviewable on its own once #245 lands.

### Changes Made

- **The warning now links to docs, not a bug report.** `THRESHOLD_DOCS_URL` pointed at
  `github.com/awslabs/stickler/issues/234`, an interim target chosen because no docs
  section explained the cliff. It now points at **The Zero-Threshold Trap**, written
  for it.
- **`recall_with_fd` documents the two opposite moves.** TP → FD and FN → FD push recall
  in opposite directions.
- **`Advanced/threshold-gated-evaluation.md` retitled** to "How Below-Threshold Pairs
  Are Classified", and now defers to the Getting-Started explainer instead of restating
  threshold semantics.
- **Inbound link labels updated** across `Advanced/README.md`, `aggregate-metrics.md`,
  `hungarian-matching.md`, `Contributing/architecture.md` and `thresholds-and-metrics.md`.
- **`understanding-results.md`** links to the direction contrast rather than restating it
  a third time.

### Why These Changes Are Needed

The new section is what #236's runtime warning had nowhere to land on. Sending a user who
misconfigured a threshold to an issue tracker is not documentation.

The recall direction matters because it is genuinely easy to invert: a paragraph on #225
stated it backwards, and catching that needed an exhaustive check. The consequence is
counterintuitive and worth writing down: **raising `match_threshold` does not reliably
lower reported recall.**

| move | numerator | denominator | default recall |
|---|---|---|---|
| TP → FD (raised `match_threshold`) | `-1` | `-1` | falls, or stays equal |
| FN → FD (pair matched instead of missed) | unchanged | `-1` | **rises** |

Verified over `tp ∈ 1..4`, `fn ∈ 0..3`: **0 cases raised recall, 6 equal, 34 fell** for
TP → FD, while FN → FD raises it.

The new section also records what is *actually* invariant at `0.0`, because it is easy to
overstate. No false discovery can ever be reported, since FD means "compared and scored
below threshold" and nothing scores below `0.0`. But precision and recall are **not** both
`1.0` in general: unmatched items bypass the threshold entirely, so 2 GT against 3
predictions still gives precision `0.667`, and 2 against 1 still gives recall `0.5`.

## Two deliberate deviations from the acceptance criteria

**1. The file is not renamed, only retitled.** The criterion says "`threshold-gated-evaluation.md`
is renamed, with `.nav.yml` and inbound links updated". The page is **live on `main`**, so
renaming the file breaks
`awslabs.github.io/stickler/Advanced/threshold-gated-evaluation/`, and no redirect plugin is
installed. The stated complaint was that the name "names the mechanism rather than the
reader's question", and the title and nav label are what readers actually see. `.nav.yml`
needs no change because `awesome-nav` reads the frontmatter title, which I verified in the
built site. Say the word and I'll do the file rename plus `mkdocs-redirects`.

**2. Not the suggested title.** The issue proposed "How Thresholds Affect Your Metrics".
That collides with the Getting-Started page **"Thresholds and Metrics"** that #222 added
*after* this issue was written. Two near-identically named pages, one the explainer and one
the mechanism reference, would be worse than the status quo. "How Below-Threshold Pairs Are
Classified" keeps the reader's-question framing and the classification-not-just-recursion
point without the collision.

## Testing

- [x] All existing tests pass
- [x] Manual testing completed
- [x] Unit tests added/updated

**1856 passed, 2 skipped.** Ruff clean. **`mkdocs build` warnings unchanged at 9**, all
pre-existing.

One test needed care rather than relaxing. `test_warning_text_carries_no_internal_identity`
asserted `"#" not in message` as a proxy for "no `id()` leaked into user-visible text",
guarding a real past bug that printed `DynamicModel#4355291632`. The new URL has a `#`
fragment. Rather than dropping the assertion, the URL is stripped before the check, so the
guard still fires on the pattern it exists for. Verified both failure modes are still
caught:

```
real message           -> PASSES
id leak (Name#addr)     -> CAUGHT
bare address            -> CAUGHT
```

Both new anchors were verified against the built HTML, since `THRESHOLD_DOCS_URL`
hard-codes one of them. The heading was chosen to slugify cleanly: "The Zero-Threshold Trap"
gives `#the-zero-threshold-trap`, where the more natural "The `threshold = 0.0` Trap" would
have produced `#the-threshold-00-trap`.

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review of code completed
- [x] Documentation updated
- [x] `CHANGELOG.md` entry added
- [x] Tests added/updated for new functionality
- [ ] All CI checks are passing (pending)
- [x] Ready for review

## Additional Notes

The `THRESHOLD_DOCS_URL` anchor is now load-bearing in two places: the test asserts the
literal, and the docs heading must keep slugifying to `the-zero-threshold-trap`. There's a
comment on the constant saying so.

Acceptance criteria status:

- [x] FN→FD versus TP→FD contrast appears wherever `recall_with_fd` is explained
- [x] `threshold=0.0` trap documented, and #236's warning links to it
- [~] Page retitled rather than file-renamed, with link labels updated (see deviation 1)
- [x] Advanced pages link to the explainer instead of restating threshold semantics
- [x] `mkdocs build` warning count unchanged (9)
