### PR TITLE
Rc/strands evals field rollup

### DIFF
--- a/examples/integrations/strands_evals/README.md
+++ b/examples/integrations/strands_evals/README.md
@@ -1,0 +1,60 @@
+# Stickler as a Strands Evals evaluator
+
+Reference implementation of the integration requested in
+[strands-agents/evals#310](https://github.com/strands-agents/evals/issues/310),
+proposed in [stickler discussion #164](https://github.com/awslabs/stickler/discussions/164).
+
+## What is here
+
+| File | Purpose |
+|---|---|
+| `stickler_evaluator.py` | `StructuredOutputEvaluator`, a `strands_evals.evaluators.Evaluator` subclass that scores structured output field by field via stickler. Written in the shape it would take upstream as `src/strands_evals/evaluators/stickler.py`. |
+| `../../notebooks/Strands_Evals_Integration.ipynb` | Runnable demo: imports this module, runs it in the stock `Case`/`Experiment` harness, contrasts it with `Equals`, and shows the audit trail. Offline (stub agent), no credentials needed. |
+
+## The gap it fills
+
+Strands Evals' deterministic evaluators compare structured output with
+`Equals`: whole-object `==`, scoring 0.0 or 1.0. An extraction that gets nine
+of ten fields right scores the same as one that gets none right, and a
+reordered list counts as wrong.
+
+Stickler compares field by field: dates as dates, amounts as numbers, free
+text fuzzily, lists matched order-independently (Hungarian), with per-field
+thresholds. Same determinism, no LLM judge, no credentials, no per-call cost,
+but the score reflects how wrong the output actually is and names which fields
+to look at.
+
+## Try it
+
+```bash
+pip install "stickler-eval>=0.5.0" strands-agents-evals
+```
+
+```python
+from strands_evals import Case, Experiment
+from stickler_evaluator import StructuredOutputEvaluator
+
+experiment = Experiment(
+    cases=[Case(name="doc-1", input=document, expected_output=labeled_invoice)],
+    evaluators=[StructuredOutputEvaluator(Invoice)],
+)
+report = experiment.run_evaluations(
+    lambda case: agent(case.input, structured_output_model=Invoice).structured_output
+)
+print(report.overall_score, report.reasons)
+```
+
+## Proposed upstream shape
+
+- Module lands at `src/strands_evals/evaluators/stickler.py`, gated behind an
+  optional extra (`stickler = ["stickler-eval>=0.5.0"]`), matching the existing
+  `langfuse` / `langchain` extras pattern. The guarded import and the
+  actionable `ImportError` are already written for that.
+- Deterministic-only, extending the direction of the deterministic-evaluators
+  epic ([evals#109](https://github.com/strands-agents/evals/issues/109)).
+- Stickler-side prerequisites for a frictionless install are already handled:
+  the `strands-agents` upper pin is lifted, so `stickler-eval[llm]` and
+  `strands-agents-evals` co-install. Stickler's `requires-python` is `>=3.12`
+  against their `>=3.10`; the suite passes unmodified on 3.11, so lowering the
+  floor to 3.11 is available if they want it (3.10 is blocked by
+  `scikit-learn>=1.8`).

--- a/examples/integrations/strands_evals/README.md
+++ b/examples/integrations/strands_evals/README.md
@@ -44,6 +44,25 @@ report = experiment.run_evaluations(
 print(report.overall_score, report.reasons)
 ```
 
+## Field-level rollup across a dataset
+
+`EvaluationOutput` carries only four scalar fields, and Strands Evals has no
+post-evaluation aggregation hook, so the per-field rollup that is the point of
+this integration cannot cross the harness boundary. The evaluator exposes it
+directly via `aggregate()`, which keeps that logic in the class rather than an
+inline loop in the caller:
+
+```python
+evaluator = StructuredOutputEvaluator(Invoice)
+rollup = evaluator.aggregate((gt, pred) for gt, pred in pairs)
+# {field: {mean, worst, perfect, count, below_threshold, comparator}}, worst mean first
+```
+
+This is a temporary shape: the `TODO` in `aggregate()` marks migration to
+stickler's stateful bulk path (`BulkStructuredModelEvaluator` /
+`aggregate_from_comparisons`), which accumulates a confusion matrix
+incrementally instead of holding every per-field score in memory.
+
 ## Proposed upstream shape
 
 - Module lands at `src/strands_evals/evaluators/stickler.py`, gated behind an

--- a/examples/integrations/strands_evals/stickler_evaluator.py
+++ b/examples/integrations/strands_evals/stickler_evaluator.py
@@ -1,0 +1,154 @@
+"""Field-level structured-output evaluation for Strands Evals, via stickler.
+
+Reference implementation of the integration requested in
+strands-agents/evals#310. Written in the shape it would take inside
+``strands-agents/evals`` (``src/strands_evals/evaluators/stickler.py``), behind
+an optional extra:
+
+    [project.optional-dependencies]
+    stickler = ["stickler-eval>=0.5.0"]
+
+Why: Strands Evals' deterministic evaluators compare structured output with
+``Equals`` (whole-object ``==``, scoring 0.0 or 1.0). An extraction that gets
+nine of ten fields right is indistinguishable from one that gets none right,
+and a reordered list counts as wrong. Stickler compares field by field with
+type-aware comparators, order-independent list matching, and per-field
+thresholds, so the score reflects how wrong the output actually is and names
+which fields to look at.
+
+Usage:
+
+    from strands_evals import Case, Experiment
+
+    experiment = Experiment(
+        cases=[Case(name="doc-1", input=doc, expected_output=labeled_invoice)],
+        evaluators=[StructuredOutputEvaluator(Invoice)],
+    )
+    report = experiment.run_evaluations(
+        lambda case: agent(case.input, structured_output_model=Invoice).structured_output
+    )
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Type
+
+from pydantic import BaseModel
+from strands_evals.evaluators import Evaluator
+from strands_evals.types.evaluation import EvaluationData, EvaluationOutput
+
+try:
+    import stickler
+
+    STICKLER_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised by the extras gate
+    STICKLER_AVAILABLE = False
+
+
+class StructuredOutputEvaluator(Evaluator):
+    """Score structured output against ground truth, field by field.
+
+    Deterministic and offline: no LLM judge, no credentials, no per-call cost.
+    Comparison configuration is inferred from the Pydantic model itself (the
+    same model the agent already uses for structured output), so no schema or
+    annotation work is required. Every inferred decision is inspectable via
+    :meth:`explain`.
+
+    Args:
+        model_cls: The Pydantic model the agent emits, e.g. the class passed as
+            ``structured_output_model``.
+        match_threshold: Similarity at or above which an object counts as a
+            match. Drives ``test_pass`` and the per-element matching of
+            ``List[Model]`` fields.
+        weight_hints: When True, weight fields by name-based importance
+            heuristics (ids and amounts count for more). Off by default so
+            weights stay uniform and metrics are not skewed by guessed
+            business criticality.
+        name: Optional evaluator name, forwarded to ``Evaluator``.
+
+    Maps stickler's result onto ``EvaluationOutput``:
+
+    - ``score``: weighted mean of per-field scores (``overall_score``)
+    - ``test_pass``: every field met its threshold (``matched``)
+    - ``reason``: the lowest-scoring fields, so a failure is actionable
+    - ``label``: the model name, to group results by output type
+    """
+
+    def __init__(
+        self,
+        model_cls: Type[BaseModel],
+        *,
+        match_threshold: float = 0.7,
+        weight_hints: bool = False,
+        name: Optional[str] = None,
+    ) -> None:
+        if not STICKLER_AVAILABLE:
+            raise ImportError(
+                "StructuredOutputEvaluator requires the 'stickler-eval' package. "
+                'Install it with: pip install "strands-agents-evals[stickler]"'
+            )
+        super().__init__(name=name)
+        self.model_cls = model_cls
+        self.spec = stickler.eval_for(
+            model_cls,
+            match_threshold=match_threshold,
+            weight_hints=weight_hints,
+        )
+
+    def evaluate(self, evaluation_case: EvaluationData) -> list[EvaluationOutput]:
+        """Compare one case's actual output against its expected output."""
+        expected = self._coerce(evaluation_case.expected_output, "expected_output")
+        actual = self._coerce(evaluation_case.actual_output, "actual_output")
+        result = self.spec.evaluate(expected, actual)
+
+        return [
+            EvaluationOutput(
+                score=result.overall_score,
+                test_pass=result.matched,
+                reason=self._reason(result),
+                label=self.model_cls.__name__,
+            )
+        ]
+
+    def explain(self) -> Dict[str, Dict[str, Any]]:
+        """Per-field comparison config and why it was chosen.
+
+        Keyed by dotted path (``line_items.sku``), so nested decisions are
+        auditable too. Useful for justifying scores in a report, and for
+        deciding which fields to configure explicitly.
+        """
+        return self.spec.explain()
+
+    def _coerce(self, value: Any, which: str) -> BaseModel:
+        """Accept a model instance, a dict, or a JSON string."""
+        if isinstance(value, self.model_cls):
+            return value
+        if isinstance(value, BaseModel):
+            # A different model class that carries the same fields.
+            return self.model_cls.model_validate(value.model_dump())
+        if isinstance(value, dict):
+            return self.model_cls.model_validate(value)
+        if isinstance(value, str):
+            return self.model_cls.model_validate_json(value)
+        raise TypeError(
+            f"{type(self).__name__} needs {which} as a {self.model_cls.__name__} "
+            f"instance, dict, or JSON string; got {type(value).__name__}"
+        )
+
+    @staticmethod
+    def _reason(result: Any, limit: int = 4) -> str:
+        """Name the weakest fields so a low score is actionable."""
+        imperfect = sorted(
+            (
+                (field, score)
+                for field, score in result.field_scores.items()
+                if score < 1.0
+            ),
+            key=lambda pair: pair[1],
+        )
+        if not imperfect:
+            return "all fields matched"
+        listed = "; ".join(f"{field}={score:.2f}" for field, score in imperfect[:limit])
+        if len(imperfect) > limit:
+            listed += f"; (+{len(imperfect) - limit} more)"
+        return f"weakest fields: {listed}"

--- a/examples/integrations/strands_evals/stickler_evaluator.py
+++ b/examples/integrations/strands_evals/stickler_evaluator.py
@@ -31,7 +31,9 @@ Usage:
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Type
+import statistics
+from collections import defaultdict
+from typing import Any, Dict, Iterable, Optional, Type
 
 from pydantic import BaseModel
 from strands_evals.evaluators import Evaluator
@@ -118,6 +120,54 @@ class StructuredOutputEvaluator(Evaluator):
         deciding which fields to configure explicitly.
         """
         return self.spec.explain()
+
+    def aggregate(
+        self, pairs: Iterable[tuple[Any, Any]]
+    ) -> Dict[str, Dict[str, Any]]:
+        """Roll up per-field scores across a dataset of (expected, actual) pairs.
+
+        Strands Evals has no post-evaluation aggregation hook, and ``EvaluationOutput``
+        carries only four scalar fields, so the field-level rollup that is the whole
+        point of this integration cannot cross the harness boundary. This method keeps
+        that rollup inside the evaluator instead of forcing callers to re-loop over
+        results, returning per field: ``mean``, ``worst``, ``perfect`` (count scoring
+        1.0), ``count``, ``below_threshold`` (count under the field's threshold), and
+        the chosen ``comparator``.
+
+        TODO: replace this bespoke loop with stickler's stateful bulk path
+        (``stickler.structured_object_evaluator.BulkStructuredModelEvaluator`` /
+        ``aggregate_from_comparisons``), which accumulates a confusion matrix
+        incrementally instead of holding every per-field score in memory. Kept inline
+        for now because that path returns confusion-matrix metrics rather than the
+        mean/worst/perfect view this demo reports.
+        """
+        config = self.spec.explain()
+        scores: Dict[str, list] = defaultdict(list)
+        below_threshold: Dict[str, int] = defaultdict(int)
+
+        for expected, actual in pairs:
+            result = self.spec.evaluate(
+                self._coerce(expected, "expected_output"),
+                self._coerce(actual, "actual_output"),
+            )
+            for field, score in result.field_scores.items():
+                scores[field].append(score)
+            for field, entry in result.explain().items():
+                if "score" in entry and entry["score"] < entry["threshold"]:
+                    below_threshold[field] += 1
+
+        rollup = {}
+        for field, field_scores in scores.items():
+            rollup[field] = {
+                "mean": statistics.mean(field_scores),
+                "worst": min(field_scores),
+                "perfect": sum(1 for s in field_scores if s == 1.0),
+                "count": len(field_scores),
+                "below_threshold": below_threshold[field],
+                "comparator": config.get(field, {}).get("comparator", "unknown"),
+            }
+        # Sort worst mean first: the fields an engineer should look at.
+        return dict(sorted(rollup.items(), key=lambda kv: kv[1]["mean"]))
 
     def _coerce(self, value: Any, which: str) -> BaseModel:
         """Accept a model instance, a dict, or a JSON string."""

--- a/examples/notebooks/Strands_Evals_FCC_Demo.ipynb
+++ b/examples/notebooks/Strands_Evals_FCC_Demo.ipynb
@@ -1,0 +1,442 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c88b711f",
+   "metadata": {},
+   "source": [
+    "# Stickler + Strands Evals on a real extraction dataset\n",
+    "\n",
+    "Strands Evals scores structured output with `Equals` — whole-object equality, 0.0 or 1.0. On real\n",
+    "documents almost nothing matches the labels exactly, so `Equals` collapses to a near-constant near-zero\n",
+    "and cannot rank extractors or say which field is broken. Stickler scores the same outputs field by\n",
+    "field, so it does both.\n",
+    "\n",
+    "53 FCC political-advertising invoices, extracted by Claude Haiku 4.5 from OCR text, scored by `Equals`\n",
+    "and by stickler on identical outputs. Requires AWS credentials with Bedrock access.\n",
+    "\n",
+    "- **Setup** — imports, then one data-processing cell (dataset -> model -> extraction -> cases)\n",
+    "- **The payoff** — `Equals` vs `StructuredOutputEvaluator`\n",
+    "- **Which field is broken** — per-field rollup from the evaluator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ffe99c21",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "`stickler.eval_for(Model)` compiles a field-level comparison plan from a Pydantic model.\n",
+    "`StructuredOutputEvaluator` wraps it as a Strands Evals `Evaluator`, imported from\n",
+    "[../integrations/strands_evals/](../integrations/strands_evals/) so the demo and the proposed upstream\n",
+    "code stay in sync.\n",
+    "\n",
+    "```\n",
+    "uv run --with strands-agents-evals jupyter lab\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "080bffaf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T20:15:08.920794Z",
+     "iopub.status.busy": "2026-08-14T20:15:08.920683Z",
+     "iopub.status.idle": "2026-08-14T20:15:12.267275Z",
+     "shell.execute_reply": "2026-08-14T20:15:12.266424Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "stickler-eval         0.5.0\n",
+      "strands-agents-evals  1.0.3\n",
+      "strands-agents        1.50.2\n"
+     ]
+    }
+   ],
+   "source": [
+    "import importlib.metadata as md\n",
+    "import json\n",
+    "import sys\n",
+    "import urllib.parse\n",
+    "import urllib.request\n",
+    "from concurrent.futures import ThreadPoolExecutor, as_completed\n",
+    "from pathlib import Path\n",
+    "from typing import List, Optional\n",
+    "\n",
+    "import boto3\n",
+    "from pydantic import BaseModel, Field\n",
+    "from strands import Agent\n",
+    "from strands.models import BedrockModel\n",
+    "\n",
+    "import stickler\n",
+    "from strands_evals import Case, Experiment\n",
+    "from strands_evals.evaluators import Equals\n",
+    "\n",
+    "sys.path.insert(0, str((Path.cwd() / \"..\" / \"integrations\" / \"strands_evals\").resolve()))\n",
+    "from stickler_evaluator import StructuredOutputEvaluator  # noqa: E402\n",
+    "\n",
+    "for dist in (\"stickler-eval\", \"strands-agents-evals\", \"strands-agents\"):\n",
+    "    print(f\"{dist:<21} {md.version(dist)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b948c851",
+   "metadata": {},
+   "source": [
+    "## Data: dataset -> model -> extraction -> cases\n",
+    "\n",
+    "One cell, in the order the pipeline runs:\n",
+    "\n",
+    "1. **Dataset** — 53 invoices from [RealKIE-FCC-Verified](https://huggingface.co/datasets/amazon-agi/RealKIE-FCC-Verified), fetched over HTTP (documents with >25 line items are skipped; Hungarian matching is cubic in list length).\n",
+    "2. **Model** — a plain `FCCInvoice`; every nullable field is `Optional` because on scanned invoices those fields are legitimately absent, and the evaluator must score \"correctly returned nothing\" as a success.\n",
+    "3. **Extraction** — a Strands agent reads OCR text and fills `FCCInvoice`, 8 documents at a time. Live billable Bedrock calls on every run.\n",
+    "4. **Cases** — one per document; `task` replays the stored extraction so both evaluators score identical outputs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "582f22bf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T20:15:12.269981Z",
+     "iopub.status.busy": "2026-08-14T20:15:12.269727Z",
+     "iopub.status.idle": "2026-08-14T20:15:58.903847Z",
+     "shell.execute_reply": "2026-08-14T20:15:58.903266Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "extracting 53 documents via claude-haiku-4-5-20251001-v1:0 (billable)...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    10/53\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    20/53\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    30/53\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    40/53\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    50/53\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    53/53\n",
+      "ready: 53 cases\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Dataset ---------------------------------------------------------------\n",
+    "DATASET = \"amazon-agi/RealKIE-FCC-Verified\"\n",
+    "MAX_LINE_ITEMS = 25\n",
+    "\n",
+    "\n",
+    "def fetch_rows() -> List[dict]:\n",
+    "    base = (\n",
+    "        \"https://datasets-server.huggingface.co/rows\"\n",
+    "        f\"?dataset={urllib.parse.quote(DATASET, safe='')}&config=default&split=test\"\n",
+    "    )\n",
+    "    rows, offset = [], 0\n",
+    "    while True:\n",
+    "        with urllib.request.urlopen(f\"{base}&offset={offset}&length=25\", timeout=60) as resp:\n",
+    "            payload = json.load(resp)\n",
+    "        batch = payload.get(\"rows\", [])\n",
+    "        rows.extend(item[\"row\"] for item in batch)\n",
+    "        total = payload.get(\"num_rows_total\")\n",
+    "        offset += 25\n",
+    "        if not batch or (total is not None and len(rows) >= total):\n",
+    "            return rows\n",
+    "\n",
+    "\n",
+    "all_rows = fetch_rows()\n",
+    "scored_rows = [r for r in all_rows if len(r[\"json_response\"].get(\"LineItems\") or []) <= MAX_LINE_ITEMS]\n",
+    "\n",
+    "\n",
+    "# --- Model -----------------------------------------------------------------\n",
+    "class FCCLineItem(BaseModel):\n",
+    "    LineItemDescription: Optional[str] = None\n",
+    "    LineItemStartDate: Optional[str] = None\n",
+    "    LineItemEndDate: Optional[str] = None\n",
+    "    LineItemDays: Optional[str] = None\n",
+    "    LineItemRate: Optional[float] = None\n",
+    "\n",
+    "\n",
+    "class FCCInvoice(BaseModel):\n",
+    "    Agency: str\n",
+    "    Advertiser: str\n",
+    "    GrossTotal: Optional[float] = None\n",
+    "    PaymentTerms: Optional[str] = None\n",
+    "    AgencyCommission: Optional[float] = None\n",
+    "    NetAmountDue: Optional[float] = None\n",
+    "    LineItems: List[FCCLineItem] = Field(default_factory=list)\n",
+    "\n",
+    "\n",
+    "GROUND_TRUTH = {r[\"id\"]: FCCInvoice.model_validate(r[\"json_response\"]) for r in scored_rows}\n",
+    "\n",
+    "\n",
+    "# --- Extraction (live Bedrock) ---------------------------------------------\n",
+    "MODEL = \"us.anthropic.claude-haiku-4-5-20251001-v1:0\"\n",
+    "OCR_CHAR_LIMIT = 12_000\n",
+    "MAX_WORKERS = 8\n",
+    "\n",
+    "# Uses the profile the kernel was launched with; relaunch with AWS_PROFILE=<profile> if unset.\n",
+    "SESSION = boto3.Session(region_name=\"us-east-1\")\n",
+    "SESSION.client(\"sts\").get_caller_identity()   # free, fails fast if the token is stale\n",
+    "BEDROCK = BedrockModel(model_id=MODEL, boto_session=SESSION)\n",
+    "\n",
+    "EXTRACT_PROMPT = (\n",
+    "    \"Extract the invoice fields from this FCC political advertising invoice. Return null for any \"\n",
+    "    \"field not shown on the document. Transcribe dates exactly as printed. Include every row of the \"\n",
+    "    \"line-item table.\\n\\nDOCUMENT:\\n{text}\"\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def extract(row: dict) -> FCCInvoice:\n",
+    "    agent = Agent(model=BEDROCK, system_prompt=\"You extract invoice data.\", callback_handler=None)\n",
+    "    result = agent(EXTRACT_PROMPT.format(text=row[\"text\"][:OCR_CHAR_LIMIT]), structured_output_model=FCCInvoice)\n",
+    "    if result.structured_output is None:\n",
+    "        raise ValueError(\"agent returned no structured output\")\n",
+    "    return result.structured_output\n",
+    "\n",
+    "\n",
+    "print(f\"extracting {len(scored_rows)} documents via {MODEL.split('.')[-1]} (billable)...\")\n",
+    "\n",
+    "PREDICTIONS = {}\n",
+    "with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:\n",
+    "    futures = {pool.submit(extract, row): row for row in scored_rows}\n",
+    "    for done, future in enumerate(as_completed(futures), 1):\n",
+    "        PREDICTIONS[futures[future][\"id\"]] = future.result()\n",
+    "        if done % 10 == 0 or done == len(scored_rows):\n",
+    "            print(f\"    {done}/{len(scored_rows)}\")\n",
+    "\n",
+    "\n",
+    "# --- Cases -----------------------------------------------------------------\n",
+    "cases = [\n",
+    "    Case(\n",
+    "        name=row[\"id\"][:12],\n",
+    "        input=row[\"text\"][:OCR_CHAR_LIMIT],\n",
+    "        expected_output=GROUND_TRUTH[row[\"id\"]],\n",
+    "        metadata={\"doc_id\": row[\"id\"]},\n",
+    "    )\n",
+    "    for row in scored_rows\n",
+    "]\n",
+    "\n",
+    "\n",
+    "def task(case: Case) -> FCCInvoice:\n",
+    "    return PREDICTIONS[case.metadata[\"doc_id\"]]\n",
+    "\n",
+    "\n",
+    "print(f\"ready: {len(cases)} cases\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "090dbe4f",
+   "metadata": {},
+   "source": [
+    "## The payoff: `Equals` vs `StructuredOutputEvaluator`\n",
+    "\n",
+    "The demo. Same cases, same harness, same extractions — only the evaluator differs. `Equals` is the\n",
+    "strongest deterministic evaluator Strands Evals ships for structured output.\n",
+    "\n",
+    "`run_evaluations` wraps `asyncio.run`, which raises inside a Jupyter kernel, so the async variant is\n",
+    "used here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2396c26b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T20:15:58.905516Z",
+     "iopub.status.busy": "2026-08-14T20:15:58.905366Z",
+     "iopub.status.idle": "2026-08-14T20:15:59.387483Z",
+     "shell.execute_reply": "2026-08-14T20:15:59.386965Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "53 documents\n",
+      "  stickler overall 0.783\n",
+      "  equals   overall 0.000\n",
+      "\n",
+      "document        stickler  equals   weakest fields\n",
+      "------------------------------------------------------------------------------\n",
+      "3aac2d4d386a       0.371     0.0   weakest fields: Agency=0.00; Advertise\n",
+      "ad34d418249c       0.486     0.0   weakest fields: GrossTotal=0.00; Agenc\n",
+      "f3eb65041a1a       0.504     0.0   weakest fields: GrossTotal=0.00; Agenc\n",
+      "75986ca8ed4b       0.506     0.0   weakest fields: Agency=0.00; Advertise\n",
+      "2de731d64adf       0.514     0.0   weakest fields: PaymentTerms=0.00; Age\n",
+      "caa7473ca263       0.543     0.0   weakest fields: Advertiser=0.00; Payme\n",
+      "7ec895784100       0.571     0.0   weakest fields: Agency=0.00; Advertise\n",
+      "c86d3402da03       0.599     0.0   weakest fields: GrossTotal=0.00; NetAm\n",
+      "cfa6bc56d5a2       0.608     0.0   weakest fields: Agency=0.00; PaymentTe\n",
+      "21762bcc6102       0.623     0.0   weakest fields: PaymentTerms=0.00; Age\n",
+      "b55d327a4141       0.634     0.0   weakest fields: Agency=0.00; NetAmount\n",
+      "03f65053aea2       0.639     0.0   weakest fields: Agency=0.00; PaymentTe\n",
+      "536c5c90c803       0.649     0.0   weakest fields: PaymentTerms=0.00; Age\n",
+      "99bcbdbef048       0.654     0.0   weakest fields: PaymentTerms=0.00; Net\n",
+      "cd3fc7791eda       0.656     0.0   weakest fields: Agency=0.00; PaymentTe\n",
+      "... 38 more\n",
+      "\n",
+      "distinct scores   stickler  51   equals   1\n",
+      "Equals resolves the corpus into one or two values; stickler spreads it across the range, so only\n",
+      "stickler can rank extractors, detect a regression, or point at a field.\n"
+     ]
+    }
+   ],
+   "source": [
+    "stickler_eval = StructuredOutputEvaluator(FCCInvoice)\n",
+    "\n",
+    "stickler_report = await Experiment(cases=cases, evaluators=[stickler_eval]).run_evaluations_async(task, max_workers=1)\n",
+    "equals_report = await Experiment(cases=cases, evaluators=[Equals()]).run_evaluations_async(task, max_workers=1)\n",
+    "\n",
+    "stickler_scores = dict(zip((c[\"name\"] for c in stickler_report.cases), stickler_report.scores))\n",
+    "equals_scores = dict(zip((c[\"name\"] for c in equals_report.cases), equals_report.scores))\n",
+    "reasons = dict(zip((c[\"name\"] for c in stickler_report.cases), stickler_report.reasons))\n",
+    "\n",
+    "print(f\"{len(cases)} documents\")\n",
+    "print(f\"  stickler overall {stickler_report.overall_score:.3f}\")\n",
+    "print(f\"  equals   overall {equals_report.overall_score:.3f}\\n\")\n",
+    "\n",
+    "SHOW = 15\n",
+    "ranked = sorted(stickler_scores, key=stickler_scores.get)\n",
+    "print(f\"{'document':14} {'stickler':>9} {'equals':>7}   weakest fields\")\n",
+    "print(\"-\" * 78)\n",
+    "for name in ranked[:SHOW]:\n",
+    "    print(f\"{name:14} {stickler_scores[name]:>9.3f} {equals_scores[name]:>7.1f}   {reasons[name][:38]}\")\n",
+    "print(f\"... {len(ranked) - SHOW} more\\n\")\n",
+    "\n",
+    "s_distinct = len({round(v, 4) for v in stickler_scores.values()})\n",
+    "e_distinct = len({round(v, 4) for v in equals_scores.values()})\n",
+    "print(f\"distinct scores   stickler {s_distinct:>3}   equals {e_distinct:>3}\")\n",
+    "print(\"Equals resolves the corpus into one or two values; stickler spreads it across the range, so only\")\n",
+    "print(\"stickler can rank extractors, detect a regression, or point at a field.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e794601",
+   "metadata": {},
+   "source": [
+    "## Which field is broken\n",
+    "\n",
+    "A document score says how bad the extractor is; a per-field rollup says what to fix. `EvaluationOutput`\n",
+    "carries only four scalar fields, so this rollup cannot cross the Strands harness boundary — the\n",
+    "evaluator exposes it directly via `aggregate()`, keeping the logic in the class instead of an inline\n",
+    "loop in the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "468fe8f1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T20:15:59.389093Z",
+     "iopub.status.busy": "2026-08-14T20:15:59.388988Z",
+     "iopub.status.idle": "2026-08-14T20:15:59.804650Z",
+     "shell.execute_reply": "2026-08-14T20:15:59.804110Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "field                  mean  worst   perfect  below thr  comparator\n",
+      "----------------------------------------------------------------------------------\n",
+      "PaymentTerms          0.642  0.000   34/53           19  Levenshtein\n",
+      "LineItems             0.681  0.000    5/53           25  Hungarian (per-element StructuredModel)\n",
+      "Agency                0.746  0.000   36/53           13  Levenshtein\n",
+      "NetAmountDue          0.792  0.000   42/53           11  Numeric\n",
+      "Advertiser            0.828  0.000   30/53            7  Levenshtein\n",
+      "AgencyCommission      0.849  0.000   45/53            8  Numeric\n",
+      "GrossTotal            0.943  0.000   50/53            3  Numeric\n",
+      "\n",
+      "Worst field: PaymentTerms (0.642) -- the effort belongs here, not on fields already scoring high.\n"
+     ]
+    }
+   ],
+   "source": [
+    "rollup = stickler_eval.aggregate((GROUND_TRUTH[c.metadata[\"doc_id\"]], PREDICTIONS[c.metadata[\"doc_id\"]]) for c in cases)\n",
+    "\n",
+    "print(f\"{'field':<20} {'mean':>6} {'worst':>6} {'perfect':>9} {'below thr':>10}  comparator\")\n",
+    "print(\"-\" * 82)\n",
+    "for field, m in rollup.items():\n",
+    "    print(f\"{field:<20} {m['mean']:>6.3f} {m['worst']:>6.3f} \"\n",
+    "          f\"{m['perfect']:>4}/{m['count']:<4} {m['below_threshold']:>10}  \"\n",
+    "          f\"{m['comparator'].replace('Comparator', '')}\")\n",
+    "\n",
+    "worst = next(iter(rollup))   # aggregate() returns worst mean first\n",
+    "print(f\"\\nWorst field: {worst} ({rollup[worst]['mean']:.3f}) -- the effort belongs here, \"\n",
+    "      f\"not on fields already scoring high.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (stickler)",
+   "language": "python",
+   "name": "stickler"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/Strands_Evals_Integration.ipynb
+++ b/examples/notebooks/Strands_Evals_Integration.ipynb
@@ -1,0 +1,344 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "source": [
+    "# Stickler + Strands Evals: field-level structured-output evaluation\n",
+    "\n",
+    "[strands-agents/evals#310](https://github.com/strands-agents/evals/issues/310) asks for a stickler integration; this notebook is the working proof.\n",
+    "\n",
+    "**The gap.** Strands Evals ships deterministic evaluators for structured output, but the strongest is `Equals`: whole-object `==`, scoring 0.0 or 1.0. An extraction that gets 9 of 10 fields right scores identically to one that gets none right, and reordered list items count as wrong.\n",
+    "\n",
+    "**The fix.** [Stickler](https://github.com/awslabs/stickler) compares structured objects field by field: type-aware comparators (dates as dates, amounts as numbers, free text fuzzily), order-independent list matching, and confusion-matrix metrics. Its zero-config `stickler.evaluate()` needs nothing but the Pydantic model the agent already uses.\n",
+    "\n",
+    "**The integration.** One `Evaluator` subclass, ~30 lines, shown below. Everything else is stock Strands Evals: `Case`, `Experiment`, `EvaluationReport`.\n",
+    "\n",
+    "> Runs fully offline: the \"agent\" is a stub returning realistic extractions, so no Bedrock credentials are needed. Swap in a real agent with one line (shown at the end).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import datetime\n",
+    "from typing import List, Optional\n",
+    "\n",
+    "import strands_evals\n",
+    "from pydantic import BaseModel\n",
+    "\n",
+    "import stickler\n",
+    "\n",
+    "print(\"stickler\", stickler.__version__, \"| strands-evals\", strands_evals.__version__ if hasattr(strands_evals, \"__version__\") else \"1.x\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "metadata": {},
+   "source": [
+    "## 1. The model your agent already uses\n",
+    "\n",
+    "Nothing stickler-specific: this is the plain Pydantic model you would hand to\n",
+    "`agent(prompt, structured_output_model=Invoice)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class LineItem(BaseModel):\n",
+    "    sku: str\n",
+    "    description: str\n",
+    "    quantity: int\n",
+    "    unit_price: float\n",
+    "\n",
+    "\n",
+    "class Invoice(BaseModel):\n",
+    "    invoice_id: str\n",
+    "    vendor_name: str\n",
+    "    invoice_date: datetime.date\n",
+    "    total_amount: float\n",
+    "    notes: Optional[str] = None\n",
+    "    line_items: List[LineItem] = []"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72eea5119410473aa328ad9291626812",
+   "metadata": {},
+   "source": [
+    "## 2. The integration: one Evaluator subclass\n",
+    "\n",
+    "The whole adapter is [examples/integrations/strands_evals/stickler_evaluator.py](../integrations/strands_evals/stickler_evaluator.py),\n",
+    "written in the shape it would take inside `strands-agents/evals` as\n",
+    "`src/strands_evals/evaluators/stickler.py`. It subclasses their `Evaluator`,\n",
+    "reads their `EvaluationData`, and returns their `EvaluationOutput`:\n",
+    "\n",
+    "| stickler | strands-evals `EvaluationOutput` |\n",
+    "|---|---|\n",
+    "| `overall_score` (weighted field average) | `score` |\n",
+    "| `matched` (every field at/above its threshold) | `test_pass` |\n",
+    "| lowest-scoring fields | `reason` |\n",
+    "\n",
+    "`stickler.eval_for(Invoice)` compiles the field-level comparison plan once\n",
+    "(per-field comparators inferred from types and names); each `evaluate()` call\n",
+    "reuses it. Accepts model instances, dicts, or JSON strings as either side."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8edb47106e1a46a883d545849b8ab81b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "# The evaluator lives in examples/integrations/strands_evals/ so the demo and\n",
+    "# the code proposed upstream are the same code, not two copies.\n",
+    "sys.path.insert(0, \"../integrations/strands_evals\")\n",
+    "from stickler_evaluator import StructuredOutputEvaluator  # noqa: E402\n",
+    "\n",
+    "print(StructuredOutputEvaluator.__doc__.strip().split(\"\\n\")[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
+   "metadata": {},
+   "source": [
+    "## 3. Cases and a stand-in agent\n",
+    "\n",
+    "Three labeled documents. The stub returns what a real extraction agent\n",
+    "plausibly would: one perfect, one with the usual small variations\n",
+    "(abbreviated vendor, reworded notes, reordered list), one badly wrong."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from strands_evals import Case, Experiment\n",
+    "\n",
+    "GROUND_TRUTH = {\n",
+    "    \"doc-perfect\": Invoice(\n",
+    "        invoice_id=\"INV-2024-0042\", vendor_name=\"Acme Corporation\",\n",
+    "        invoice_date=datetime.date(2024, 3, 15), total_amount=1247.50,\n",
+    "        notes=\"Net 30 payment terms\",\n",
+    "        line_items=[\n",
+    "            LineItem(sku=\"WM-100\", description=\"Wireless Mouse\", quantity=2, unit_price=29.99),\n",
+    "            LineItem(sku=\"UC-050\", description=\"USB-C Cable 1m\", quantity=5, unit_price=12.99),\n",
+    "        ],\n",
+    "    ),\n",
+    "    \"doc-close\": Invoice(\n",
+    "        invoice_id=\"INV-2024-0043\", vendor_name=\"Globex Corporation\",\n",
+    "        invoice_date=datetime.date(2024, 4, 1), total_amount=890.00,\n",
+    "        notes=\"Payment due in 45 days\",\n",
+    "        line_items=[\n",
+    "            LineItem(sku=\"KB-220\", description=\"Mechanical Keyboard\", quantity=3, unit_price=89.00),\n",
+    "            LineItem(sku=\"MP-010\", description=\"Mouse Pad XL\", quantity=7, unit_price=8.99),\n",
+    "        ],\n",
+    "    ),\n",
+    "    \"doc-wrong\": Invoice(\n",
+    "        invoice_id=\"INV-2024-0044\", vendor_name=\"Initech LLC\",\n",
+    "        invoice_date=datetime.date(2024, 5, 20), total_amount=15300.00,\n",
+    "        notes=\"Prepaid\",\n",
+    "        line_items=[LineItem(sku=\"SRV-01\", description=\"Consulting\", quantity=40, unit_price=382.50)],\n",
+    "    ),\n",
+    "}\n",
+    "\n",
+    "AGENT_OUTPUTS = {\n",
+    "    \"doc-perfect\": GROUND_TRUTH[\"doc-perfect\"].model_copy(deep=True),\n",
+    "    \"doc-close\": Invoice(\n",
+    "        invoice_id=\"INV-2024-0043\",\n",
+    "        vendor_name=\"Globex Corp\",                      # abbreviated\n",
+    "        invoice_date=datetime.date(2024, 4, 1),\n",
+    "        total_amount=890.00,\n",
+    "        notes=\"due in 45 days\",                          # reworded\n",
+    "        line_items=[                                     # reordered\n",
+    "            LineItem(sku=\"MP-010\", description=\"XL Mouse Pad\", quantity=7, unit_price=8.99),\n",
+    "            LineItem(sku=\"KB-220\", description=\"Mechanical Keyboard\", quantity=3, unit_price=89.00),\n",
+    "        ],\n",
+    "    ),\n",
+    "    \"doc-wrong\": Invoice(\n",
+    "        invoice_id=\"INV-2024-0099\",                      # wrong id\n",
+    "        vendor_name=\"Initrode\",                          # wrong vendor\n",
+    "        invoice_date=datetime.date(2024, 5, 2),          # wrong date\n",
+    "        total_amount=1530.00,                            # off by 10x\n",
+    "        notes=None,\n",
+    "        line_items=[],                                   # missed entirely\n",
+    "    ),\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def agent_task(case: Case) -> Invoice:\n",
+    "    # Real agent: return agent(case.input, structured_output_model=Invoice).structured_output\n",
+    "    return AGENT_OUTPUTS[case.name]\n",
+    "\n",
+    "\n",
+    "cases = [\n",
+    "    Case(name=name, input=f\"Extract the invoice from document {name}\", expected_output=gt)\n",
+    "    for name, gt in GROUND_TRUTH.items()\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7623eae2785240b9bd12b16a66d81610",
+   "metadata": {},
+   "source": [
+    "## 4. Run it: stock Strands Evals harness"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cdc8c89c7104fffa095e18ddfef8986",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "experiment = Experiment(cases=cases, evaluators=[StructuredOutputEvaluator(Invoice)])\n",
+    "report = experiment.run_evaluations(agent_task)\n",
+    "\n",
+    "for case, score, passed, reason in zip(report.cases, report.scores, report.test_passes, report.reasons):\n",
+    "    print(f\"{case['name']:14} score={score:.3f}  pass={str(passed):5}  {reason}\")\n",
+    "print(f\"\\noverall_score: {report.overall_score:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b118ea5561624da68c537baed56e602f",
+   "metadata": {},
+   "source": [
+    "Contrast with what `Equals` (the current deterministic evaluator) reports on\n",
+    "the same three cases: 1.0, 0.0, 0.0. The `doc-close` extraction, which any\n",
+    "human would call a near-perfect job, is indistinguishable from `doc-wrong`.\n",
+    "Field-level scoring separates them, and `reason` names exactly which fields to\n",
+    "look at."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "938c804e27f84196a10c8828c723f798",
+   "metadata": {},
+   "source": [
+    "## 5. Every decision is auditable\n",
+    "\n",
+    "Nobody configured a comparator above, but every choice is inspectable and\n",
+    "defensible (a requirement for eval numbers that end up in front of\n",
+    "stakeholders):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "504fb2a444614c0babb325280ed9130a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spec = stickler.eval_for(Invoice)\n",
+    "for field, info in spec.explain().items():\n",
+    "    print(f\"{field:24} {info['comparator']:40} threshold={info['threshold']}  src={info['source']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59bbdb311c014d738909a11f9e486628",
+   "metadata": {},
+   "source": [
+    "And for a specific pair, `result.explain()` adds what actually happened,\n",
+    "distinguishing a near-miss from a total mismatch:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b43b363d81ae4b689946ece5c682cd59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = spec.evaluate(GROUND_TRUTH[\"doc-close\"], AGENT_OUTPUTS[\"doc-close\"])\n",
+    "entry = result.explain()[\"vendor_name\"]\n",
+    "print({k: entry[k] for k in (\"score\", \"raw_similarity\", \"verdict\") if k in entry})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a65eabff63a45729fe45fb5ade58bdc",
+   "metadata": {},
+   "source": [
+    "## 6. Graduating beyond zero-config\n",
+    "\n",
+    "When a team disagrees with an inferred decision, the same inference is\n",
+    "available as a regular `StructuredModel` constructor. Export its config, edit\n",
+    "any comparator, threshold, or weight, and rebuild: every existing stickler\n",
+    "tool (bulk evaluation, HTML reports) takes it from there:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3933fab20d04ec698c2621248eb3be0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from stickler import StructuredModel\n",
+    "\n",
+    "InvoiceEval = StructuredModel.from_pydantic(Invoice)\n",
+    "config = InvoiceEval.to_stickler_config()\n",
+    "config[\"fields\"][\"vendor_name\"][\"threshold\"] = 0.6   # e.g. relax the name threshold\n",
+    "Tuned = StructuredModel.model_from_json(config)\n",
+    "\n",
+    "# Rebuilt models take the JSON wire form (ISO strings for dates):\n",
+    "gt = Tuned.from_json(GROUND_TRUTH[\"doc-close\"].model_dump(mode=\"json\"))\n",
+    "pred = Tuned.from_json(AGENT_OUTPUTS[\"doc-close\"].model_dump(mode=\"json\"))\n",
+    "print(\"tuned vendor_name score:\", gt.compare_with(pred)[\"field_scores\"][\"vendor_name\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4dd4641cc4064e0191573fe9c69df29b",
+   "metadata": {},
+   "source": [
+    "## Proposed upstream shape\n",
+    "\n",
+    "Per [evals#310](https://github.com/strands-agents/evals/issues/310) and\n",
+    "[stickler discussion #164](https://github.com/awslabs/stickler/discussions/164):\n",
+    "\n",
+    "- `StructuredOutputEvaluator` lands in `strands_evals/evaluators/`, gated\n",
+    "  behind an optional extra: `pip install \"strands-agents-evals[stickler]\"`\n",
+    "  (`stickler = [\"stickler-eval>=0.5.0\"]`), matching the existing\n",
+    "  `langfuse`/`langchain` extras pattern.\n",
+    "- Deterministic-only (no LLM comparators), extending the direction of the\n",
+    "  deterministic-evaluators epic (evals#109): cost-free, reproducible, no\n",
+    "  credentials.\n",
+    "- To run against a live agent, replace the stub:\n",
+    "  `return agent(case.input, structured_output_model=Invoice).structured_output`\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dev = [
     "matplotlib>=3.8.0",
 ]
 llm = [
-    "strands-agents>=1.0.0,<=1.16.0"
+    "strands-agents>=1.0.0"
 ]
 bert = [
     "evaluate>=0.4.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2,19 +2,12 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.13'",
+    "python_full_version < '3.13'",
 ]
 
 [options]
-exclude-newer = "2026-07-07T13:31:42.498833Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -639,7 +632,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/c8/b2589d68acf7e3d63e2be330b84bc25712e97ed799affbca7edd7eae25d6/cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e865447abfb83d6a98ad5130ed3c70b1fc295ae3eeee39fd07b4ddb0671b6788", size = 5722404, upload-time = "2026-03-11T00:12:44.041Z" },
@@ -670,34 +663,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -1794,7 +1787,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1806,7 +1799,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1836,9 +1829,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1850,7 +1843,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3173,7 +3166,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.10" },
     { name = "scikit-learn", specifier = ">=1.8.0,<2.0.0" },
     { name = "scipy", specifier = ">=1.12.0,<2.0.0" },
-    { name = "strands-agents", marker = "extra == 'llm'", specifier = ">=1.0.0,<=1.16.0" },
+    { name = "strands-agents", marker = "extra == 'llm'", specifier = ">=1.0.0" },
     { name = "torch", marker = "extra == 'bert'", specifier = ">=2.2.0" },
 ]
 provides-extras = ["dev", "llm", "bert", "semantic"]
@@ -3210,7 +3203,7 @@ test = [
 
 [[package]]
 name = "strands-agents"
-version = "1.16.0"
+version = "1.48.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -3222,12 +3215,13 @@ dependencies = [
     { name = "opentelemetry-instrumentation-threading" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
+    { name = "pyyaml" },
     { name = "typing-extensions" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/bd/160ad34c1b635ee534f0dd8de009097fff849101a847a0ae160b73f7aa41/strands_agents-1.16.0.tar.gz", hash = "sha256:661e1fcf7e86e11277b5b15c827ca5abe00dfc425bb39036f85c0ebffedd11d7", size = 512502, upload-time = "2025-11-12T21:11:17.753Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/1e/834e4a63c6ad039d10924b5ba8c0651ccb24d7e28fd8c07c1a09b859120f/strands_agents-1.48.0.tar.gz", hash = "sha256:bfbf5af9d8f1cb348b617d5f8d17b949ef3c3fdd74fa8c849f1fda46885449c2", size = 1174326, upload-time = "2026-07-17T14:03:45.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/a3/f5a2f9810f51f7d204ec395d6ba324680b5d4b3c6589b22ebd4082bcba0b/strands_agents-1.16.0-py3-none-any.whl", hash = "sha256:6668771902b26fdd40ee616f9ba023199defc5d2e0b084c3705c918b6788c507", size = 253753, upload-time = "2025-11-12T21:11:15.549Z" },
+    { url = "https://files.pythonhosted.org/packages/25/67/67d1e267405f6ae119cc0412891f66997a5a97eed2dbba18fc430a9ac00a/strands_agents-1.48.0-py3-none-any.whl", hash = "sha256:7118a644e844ab6ef77f4bc9883b7082b2e7a309bcd689cc5ef5345e07abcc9e", size = 612156, upload-time = "2026-07-17T14:03:43.06Z" },
 ]
 
 [[package]]
@@ -3423,8 +3417,8 @@ name = "uvicorn"
 version = "0.42.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "sys_platform != 'emscripten'" },
-    { name = "h11", marker = "sys_platform != 'emscripten'" },
+    { name = "click" },
+    { name = "h11" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/ad/4a96c425be6fb67e0621e62d86c402b4a17ab2be7f7c055d9bd2f638b9e2/uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775", size = 85393, upload-time = "2026-03-16T06:19:50.077Z" }
 wheels = [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a demo notebook showing stickler's field-level StructuredOutputEvaluator
against Strands Evals' Equals evaluator on invoice field extraction.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
