### PR TITLE
fix(auto): explain() misreports how StructuredModel fields are compared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,16 +310,37 @@ Each release links to full notes on the
 ### Fixed
 
 - `explain()` now describes how a nested `StructuredModel` field is actually
-  compared, instead of reporting an inert comparator. On a configured
-  `StructuredModel`, a `List[StructuredModel]` field reported
-  `LevenshteinComparator` and a single nested-model field did the same, both
-  taken from the `ComparableField` default that the engine never consults (and
-  that the field is forbidden from setting). They now report
-  `"Hungarian (per-element StructuredModel)"` and
-  `"recursive (nested StructuredModel)"` respectively, matching the labels the
-  zero-config inference path already used. Scores are unaffected; only the audit
-  trail was wrong. Plain `BaseModel` classes routed through inference were
-  already correct.
+  compared. On a configured `StructuredModel`, both a `List[StructuredModel]`
+  field and a single nested-model field reported `LevenshteinComparator`, taken
+  from a `ComparableField` default the engine never consults. Three values on
+  those rows were inert, not just the comparator:
+
+  | reported | actual |
+  |---|---|
+  | `comparator: LevenshteinComparator` | never runs; the element's own fields are compared |
+  | `threshold: 0.5` | the element class's `match_threshold` is the real gate |
+  | `clip_under_threshold: True` | a below-threshold list score is not clipped |
+
+  All three now describe the comparison, using the same labels and values the
+  zero-config inference path emits, so `explain()` reads the same whether the
+  model was configured or inferred: `"Hungarian (per-element StructuredModel)"`
+  for a list, `"StructuredModelComparator"` for a single nested model, the
+  element's `match_threshold`, and `clip_under_threshold: False`.
+
+  A comparator on a *single* nested-model field is accepted rather than rejected
+  (only the list form raises) and then ignored, so the `why` trail now names it.
+  Otherwise the structural label would hide a dead setting that the old,
+  incorrect label at least made visible.
+
+  The inference path had one of the same inaccuracies: its `model_list` rows
+  reported `clip_under_threshold: True`, where its own `model` rows correctly
+  said `False`. Corrected, so the two agree.
+
+  Scores are unaffected throughout; only the audit trail was wrong.
+
+  Still outstanding: `explain()` omits the nested dotted paths (`items.sku`) for
+  a configured `StructuredModel`, where the inference path includes them
+  ([#254](https://github.com/awslabs/stickler/issues/254)).
 
 - Zero-config evaluation no longer scores formatting-only differences in
   `email`, `url` and `phone` fields as complete mismatches. The name-token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,6 +309,18 @@ Each release links to full notes on the
 
 ### Fixed
 
+- `explain()` now describes how a nested `StructuredModel` field is actually
+  compared, instead of reporting an inert comparator. On a configured
+  `StructuredModel`, a `List[StructuredModel]` field reported
+  `LevenshteinComparator` and a single nested-model field did the same, both
+  taken from the `ComparableField` default that the engine never consults (and
+  that the field is forbidden from setting). They now report
+  `"Hungarian (per-element StructuredModel)"` and
+  `"recursive (nested StructuredModel)"` respectively, matching the labels the
+  zero-config inference path already used. Scores are unaffected; only the audit
+  trail was wrong. Plain `BaseModel` classes routed through inference were
+  already correct.
+
 - Zero-config evaluation no longer scores formatting-only differences in
   `email`, `url` and `phone` fields as complete mismatches. The name-token
   inference rules route those fields to comparators chosen for them, and when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -312,29 +312,35 @@ Each release links to full notes on the
 - `explain()` now describes how a nested `StructuredModel` field is actually
   compared. On a configured `StructuredModel`, both a `List[StructuredModel]`
   field and a single nested-model field reported `LevenshteinComparator`, taken
-  from a `ComparableField` default the engine never consults. Three values on
-  those rows were inert, not just the comparator:
+  from a `ComparableField` default the engine never consults. Both now report the
+  structural label the zero-config inference path already used, so `explain()`
+  names the same comparator whichever way the model was built:
+  `"Hungarian (per-element StructuredModel)"` for a list,
+  `"StructuredModelComparator"` for a single nested model.
 
-  | reported | actual |
-  |---|---|
-  | `comparator: LevenshteinComparator` | never runs; the element's own fields are compared |
-  | `threshold: 0.5` | the element class's `match_threshold` is the real gate |
-  | `clip_under_threshold: True` | a below-threshold list score is not clipped |
+  The two kinds report `threshold` and `clip_under_threshold` from different
+  sources, because the engine treats them differently:
 
-  All three now describe the comparison, using the same labels and values the
-  zero-config inference path emits, so `explain()` reads the same whether the
-  model was configured or inferred: `"Hungarian (per-element StructuredModel)"`
-  for a list, `"StructuredModelComparator"` for a single nested model, the
-  element's `match_threshold`, and `clip_under_threshold: False`.
+  | | `threshold` | `clip_under_threshold` |
+  |---|---|---|
+  | single nested model | the field's own, which the dispatcher reads and which does clip | the field's own, which is honoured |
+  | `List[StructuredModel]` | the **element class's** `match_threshold`, since `__init_subclass__` rejects a field threshold here | always `False`; structured lists are never clipped |
+
+  A list field has two gates rather than one, so the `why` trail names both: the
+  element's `match_threshold` splits pairs into TP and FD, while the field's own
+  threshold decides whether per-item rows are produced at all. A pair can be
+  recursed into without counting as a match.
 
   A comparator on a *single* nested-model field is accepted rather than rejected
-  (only the list form raises) and then ignored, so the `why` trail now names it.
-  Otherwise the structural label would hide a dead setting that the old,
-  incorrect label at least made visible.
+  (only the list form raises) and then ignored, so the `why` trail names it,
+  keeping a dead setting visible where the structural label would hide it. It
+  stays silent when nothing was chosen, since `ComparableField()` stores a
+  `LevenshteinComparator` by default and a bare annotation gets a synthesised
+  `StructuredModelComparator`.
 
-  The inference path had one of the same inaccuracies: its `model_list` rows
-  reported `clip_under_threshold: True`, where its own `model` rows correctly
-  said `False`. Corrected, so the two agree.
+  The inference path had a related inaccuracy: its `model_list` rows reported
+  `clip_under_threshold: True`, where its own `model` rows correctly said
+  `False`. Corrected.
 
   Scores are unaffected throughout; only the audit trail was wrong.
 

--- a/src/stickler/auto/builder.py
+++ b/src/stickler/auto/builder.py
@@ -166,6 +166,11 @@ def _collect_specs(
                 result[path] = InferredSpec(
                     comparator_name="Hungarian (per-element StructuredModel)",
                     threshold=match_threshold,
+                    # Nested comparisons are never clipped, the same as the
+                    # `model` branch above. Leaving the default True reported a
+                    # flag the engine contradicts: a list scoring below the
+                    # threshold percolates its score up rather than becoming 0.
+                    clip_under_threshold=False,
                     provenance=["type:List[BaseModel] -> Hungarian object matching"],
                 )
                 element, _ = unwrap_optional(_list_element(annotation))

--- a/src/stickler/auto/facade.py
+++ b/src/stickler/auto/facade.py
@@ -22,6 +22,9 @@ from typing import Any, Dict, Type, Union
 
 from pydantic import BaseModel
 
+from ..structured_object_evaluator.models.configuration_helper import (
+    ConfigurationHelper,
+)
 from ..structured_object_evaluator.models.structured_model import StructuredModel
 from .builder import specs_for, structured_model_for
 
@@ -170,13 +173,12 @@ class EvalSpec:
     def _explain_structured(self) -> Dict[str, Dict[str, Any]]:
         """Explain a passthrough StructuredModel from its explicit config."""
         out: Dict[str, Dict[str, Any]] = {}
-        for name in self.source_cls.model_fields:
+        for name, field in self.source_cls.model_fields.items():
             if name == "extra_fields":
                 continue
             info = self.source_cls._get_comparison_info(name)
-            comparator = getattr(info, "comparator", None)
             out[name] = {
-                "comparator": type(comparator).__name__ if comparator else "default",
+                "comparator": self._structured_comparator_label(name, field, info),
                 "threshold": info.threshold,
                 "weight": info.weight,
                 "clip_under_threshold": info.clip_under_threshold,
@@ -184,6 +186,26 @@ class EvalSpec:
                 "why": ["explicit: configured on the StructuredModel class"],
             }
         return out
+
+    def _structured_comparator_label(self, name: str, field: Any, info: Any) -> str:
+        """Name what actually compares this field.
+
+        A ``StructuredModel`` field has no single comparator: nested models
+        recurse into their own fields, and a ``List[StructuredModel]`` is
+        matched element-by-element with the Hungarian algorithm and then
+        compared recursively. The ``comparator`` on its ``ComparableField`` is
+        an inert default the engine never consults (and one the field is
+        forbidden from setting), so reporting it would misdescribe the
+        comparison. Mirror the labels :mod:`.builder` uses for the inferred
+        path so both explains read the same.
+        """
+        annotation = field.annotation
+        if self.source_cls._is_list_of_structured_model_type(annotation):
+            return "Hungarian (per-element StructuredModel)"
+        if ConfigurationHelper.is_structured_field_type(field):
+            return "recursive (nested StructuredModel)"
+        comparator = getattr(info, "comparator", None)
+        return type(comparator).__name__ if comparator else "default"
 
 
 def eval_for(

--- a/src/stickler/auto/facade.py
+++ b/src/stickler/auto/facade.py
@@ -177,35 +177,87 @@ class EvalSpec:
             if name == "extra_fields":
                 continue
             info = self.source_cls._get_comparison_info(name)
-            out[name] = {
-                "comparator": self._structured_comparator_label(name, field, info),
+            out[name] = self._structured_row(field, info)
+        return out
+
+    def _structured_row(self, field: Any, info: Any) -> Dict[str, Any]:
+        """One explain() row for a field on a configured StructuredModel.
+
+        A nested-model field has no single comparator: the element recurses into
+        its own fields, and a ``List[StructuredModel]`` is matched
+        element-by-element with Hungarian first. The comparator, threshold and
+        clip flag on its ``ComparableField`` are inert defaults the engine never
+        consults, so reporting them describes nothing:
+
+        - the comparator is unused (and ``__init_subclass__`` rejects one
+          outright on the list form),
+        - the real gate is the *element class's* ``match_threshold``, not the
+          field's ``threshold``, which ``__init_subclass__`` also rejects on the
+          list form and which therefore only ever holds a default,
+        - below-threshold list scores are not clipped, whatever the flag says.
+
+        Labels and values mirror :mod:`.builder` exactly, so ``explain()`` reads
+        the same whether the model was configured or inferred.
+        """
+        annotation = field.annotation
+        is_list = self.source_cls._is_list_of_structured_model_type(annotation)
+        is_nested = is_list or ConfigurationHelper.is_structured_field_type(field)
+
+        if not is_nested:
+            comparator = getattr(info, "comparator", None)
+            return {
+                "comparator": type(comparator).__name__ if comparator else "default",
                 "threshold": info.threshold,
                 "weight": info.weight,
                 "clip_under_threshold": info.clip_under_threshold,
                 "source": "explicit",
                 "why": ["explicit: configured on the StructuredModel class"],
             }
-        return out
 
-    def _structured_comparator_label(self, name: str, field: Any, info: Any) -> str:
-        """Name what actually compares this field.
+        element = _structured_element(annotation)
+        why = ["explicit: configured on the StructuredModel class"]
+        if is_list:
+            comparator_name = "Hungarian (per-element StructuredModel)"
+            why.append("type:List[StructuredModel] -> Hungarian object matching")
+        else:
+            comparator_name = "StructuredModelComparator"
+            why.append("type:nested StructuredModel -> recursive comparison")
 
-        A ``StructuredModel`` field has no single comparator: nested models
-        recurse into their own fields, and a ``List[StructuredModel]`` is
-        matched element-by-element with the Hungarian algorithm and then
-        compared recursively. The ``comparator`` on its ``ComparableField`` is
-        an inert default the engine never consults (and one the field is
-        forbidden from setting), so reporting it would misdescribe the
-        comparison. Mirror the labels :mod:`.builder` uses for the inferred
-        path so both explains read the same.
-        """
-        annotation = field.annotation
-        if self.source_cls._is_list_of_structured_model_type(annotation):
-            return "Hungarian (per-element StructuredModel)"
-        if ConfigurationHelper.is_structured_field_type(field):
-            return "recursive (nested StructuredModel)"
-        comparator = getattr(info, "comparator", None)
-        return type(comparator).__name__ if comparator else "default"
+        # A comparator on a single nested-model field is accepted by
+        # __init_subclass__ and then ignored by the engine. Say so, rather than
+        # letting the generic label hide a setting that does nothing.
+        declared = getattr(info, "comparator", None)
+        if declared is not None and not is_list:
+            why.append(
+                f"ignored: comparator={type(declared).__name__} is not consulted "
+                f"for a nested model; the element's own fields are compared"
+            )
+
+        return {
+            "comparator": comparator_name,
+            # The element class's own match_threshold is what gates the pairing.
+            "threshold": getattr(element, "match_threshold", self._match_threshold),
+            "weight": info.weight,
+            # Nested comparisons are never clipped; the score percolates up.
+            "clip_under_threshold": False,
+            "source": "explicit",
+            "why": why,
+        }
+
+
+def _structured_element(annotation: Any) -> Any:
+    """The StructuredModel class a nested or list-of-nested field holds."""
+    element = ConfigurationHelper._extract_structured_class_from_list(annotation)
+    if element is not None:
+        return element
+    unwrapped, _ = _unwrap_optional_annotation(annotation)
+    return unwrapped
+
+
+def _unwrap_optional_annotation(annotation: Any) -> Any:
+    from .builder import unwrap_optional
+
+    return unwrap_optional(annotation)
 
 
 def eval_for(

--- a/src/stickler/auto/facade.py
+++ b/src/stickler/auto/facade.py
@@ -28,6 +28,12 @@ from ..structured_object_evaluator.models.configuration_helper import (
 from ..structured_object_evaluator.models.structured_model import StructuredModel
 from .builder import specs_for, structured_model_for
 
+#: Comparator names that mean "nothing was chosen". ``ComparableField()`` stores
+#: a ``LevenshteinComparator`` when none is given, and a bare annotation on a
+#: nested model gets a synthesised ``StructuredModelComparator``, so seeing
+#: either says nothing about the author's intent.
+_DEFAULT_COMPARATORS = frozenset({"LevenshteinComparator", "StructuredModelComparator"})
+
 
 class EvalResult:
     """Flat, friendly view over a stickler comparison result.
@@ -183,21 +189,28 @@ class EvalSpec:
     def _structured_row(self, field: Any, info: Any) -> Dict[str, Any]:
         """One explain() row for a field on a configured StructuredModel.
 
-        A nested-model field has no single comparator: the element recurses into
-        its own fields, and a ``List[StructuredModel]`` is matched
-        element-by-element with Hungarian first. The comparator, threshold and
-        clip flag on its ``ComparableField`` are inert defaults the engine never
-        consults, so reporting them describes nothing:
+        Both nested kinds share one fact: there is no single comparator. The
+        element recurses into its own fields, and a ``List[StructuredModel]`` is
+        matched element-by-element with Hungarian first. So the comparator label
+        is structural, and matches what :mod:`.builder` emits for the inferred
+        path.
 
-        - the comparator is unused (and ``__init_subclass__`` rejects one
-          outright on the list form),
-        - the real gate is the *element class's* ``match_threshold``, not the
-          field's ``threshold``, which ``__init_subclass__`` also rejects on the
-          list form and which therefore only ever holds a default,
-        - below-threshold list scores are not clipped, whatever the flag says.
+        They differ in everything else, and the difference is not cosmetic. The
+        engine consults ``threshold`` and ``clip_under_threshold`` for a single
+        nested model but not for a list, so the two branches report different
+        sources for those keys:
 
-        Labels and values mirror :mod:`.builder` exactly, so ``explain()`` reads
-        the same whether the model was configured or inferred.
+        - **Single nested model.** ``ComparisonDispatcher`` reads
+          ``info.threshold`` and hands it to ``FieldComparator``, which clips to
+          0.0 when the raw score falls short and ``info.clip_under_threshold`` is
+          set. Both knobs move the score, so both are reported verbatim.
+        - **List of nested models.** ``__init_subclass__`` rejects a
+          ``threshold`` here, so the field's own value is always an unused
+          default; the element class's ``match_threshold`` is what splits pairs
+          into TP and FD. Structured lists are never clipped
+          (``structured_list_comparator.py``: "For structured lists, we NEVER
+          clip under threshold"), so the flag is reported ``False`` regardless
+          of what the field carries.
         """
         annotation = field.annotation
         is_list = self.source_cls._is_list_of_structured_model_type(annotation)
@@ -214,50 +227,52 @@ class EvalSpec:
                 "why": ["explicit: configured on the StructuredModel class"],
             }
 
-        element = _structured_element(annotation)
         why = ["explicit: configured on the StructuredModel class"]
-        if is_list:
-            comparator_name = "Hungarian (per-element StructuredModel)"
-            why.append("type:List[StructuredModel] -> Hungarian object matching")
-        else:
-            comparator_name = "StructuredModelComparator"
-            why.append("type:nested StructuredModel -> recursive comparison")
 
-        # A comparator on a single nested-model field is accepted by
-        # __init_subclass__ and then ignored by the engine. Say so, rather than
-        # letting the generic label hide a setting that does nothing.
+        if is_list:
+            element = ConfigurationHelper._extract_structured_class_from_list(annotation)
+            why.append("type:List[StructuredModel] -> Hungarian object matching")
+            # Two gates, not one. The element's match_threshold decides TP vs FD;
+            # the field's own threshold decides whether per-item rows are emitted
+            # at all (confusion_matrix_calculator: "Use field's threshold, not
+            # class's match_threshold", then the threshold-gated recursion). A
+            # pair can therefore be recursed into without counting as a match.
+            why.append(
+                f"gates: element match_threshold={element.match_threshold} splits "
+                f"TP from FD; the field's threshold={info.threshold} gates whether "
+                f"per-item rows are produced"
+            )
+            return {
+                "comparator": "Hungarian (per-element StructuredModel)",
+                "threshold": element.match_threshold,
+                "weight": info.weight,
+                "clip_under_threshold": False,
+                "source": "explicit",
+                "why": why,
+            }
+
+        why.append("type:nested StructuredModel -> recursive comparison")
+        # A comparator here is accepted by __init_subclass__ (only the list form
+        # raises) and then ignored by the engine. Naming it keeps a dead setting
+        # visible, which the structural label would otherwise hide. Skip the two
+        # values that mean "nothing was chosen": ComparableField() stores a
+        # LevenshteinComparator when none is given, and a bare annotation gets a
+        # synthesised StructuredModelComparator, so neither indicates intent.
         declared = getattr(info, "comparator", None)
-        if declared is not None and not is_list:
+        if declared is not None and type(declared).__name__ not in _DEFAULT_COMPARATORS:
             why.append(
                 f"ignored: comparator={type(declared).__name__} is not consulted "
                 f"for a nested model; the element's own fields are compared"
             )
-
         return {
-            "comparator": comparator_name,
-            # The element class's own match_threshold is what gates the pairing.
-            "threshold": getattr(element, "match_threshold", self._match_threshold),
+            "comparator": "StructuredModelComparator",
+            # The engine really does read these two for a nested model.
+            "threshold": info.threshold,
             "weight": info.weight,
-            # Nested comparisons are never clipped; the score percolates up.
-            "clip_under_threshold": False,
+            "clip_under_threshold": info.clip_under_threshold,
             "source": "explicit",
             "why": why,
         }
-
-
-def _structured_element(annotation: Any) -> Any:
-    """The StructuredModel class a nested or list-of-nested field holds."""
-    element = ConfigurationHelper._extract_structured_class_from_list(annotation)
-    if element is not None:
-        return element
-    unwrapped, _ = _unwrap_optional_annotation(annotation)
-    return unwrapped
-
-
-def _unwrap_optional_annotation(annotation: Any) -> Any:
-    from .builder import unwrap_optional
-
-    return unwrap_optional(annotation)
 
 
 def eval_for(

--- a/tests/auto/test_risk_surface.py
+++ b/tests/auto/test_risk_surface.py
@@ -366,6 +366,43 @@ class TestExplainContract:
         # not a fallback derived from the list annotation itself.
         assert ex["prices"]["comparator"] == "NumericComparator"
 
+    def test_structured_model_fields_report_how_they_compare(self):
+        """A StructuredModel field has no single comparator, and explain() on a
+        configured StructuredModel must say so rather than reporting the inert
+        ComparableField default (which the field is forbidden from setting).
+
+        The pre-fix bug reported LevenshteinComparator for both a nested model
+        and a List[StructuredModel], describing a comparator the engine never
+        runs. See the two explain paths in auto/facade.py.
+        """
+        from stickler import ComparableField, ExactComparator, StructuredModel
+
+        class Line(StructuredModel):
+            sku: str = ComparableField(comparator=ExactComparator())
+
+        class Addr(StructuredModel):
+            city: str = ComparableField(comparator=ExactComparator())
+
+        class Order(StructuredModel):
+            order_id: str = ComparableField(comparator=ExactComparator())
+            addr: Addr = ComparableField()
+            opt_addr: Optional[Addr] = ComparableField()
+            items: List[Line] = ComparableField()
+
+        ex = stickler.eval_for(Order).explain()
+
+        # A real leaf comparator is still named.
+        assert ex["order_id"]["comparator"] == "ExactComparator"
+        # A List[StructuredModel] is matched element-by-element, then recursed.
+        assert ex["items"]["comparator"] == "Hungarian (per-element StructuredModel)"
+        # A single nested model recurses into its own fields.
+        assert ex["addr"]["comparator"] == "recursive (nested StructuredModel)"
+        assert ex["opt_addr"]["comparator"] == "recursive (nested StructuredModel)"
+        # Whatever the label, it must never be the inert default the field
+        # cannot legally carry.
+        for structured_field in ("items", "addr", "opt_addr"):
+            assert ex[structured_field]["comparator"] != "LevenshteinComparator"
+
     def test_every_explained_comparator_is_instantiable(self):
         from stickler.structured_object_evaluator.models.comparator_registry import (
             get_global_registry,

--- a/tests/auto/test_risk_surface.py
+++ b/tests/auto/test_risk_surface.py
@@ -369,16 +369,18 @@ class TestExplainContract:
     def test_structured_model_fields_report_how_they_compare(self):
         """A StructuredModel field has no single comparator, and explain() on a
         configured StructuredModel must say so rather than reporting the inert
-        ComparableField default (which the field is forbidden from setting).
+        ComparableField default.
 
         The pre-fix bug reported LevenshteinComparator for both a nested model
         and a List[StructuredModel], describing a comparator the engine never
-        runs. See the two explain paths in auto/facade.py.
+        runs.
         """
         from stickler import ComparableField, ExactComparator, StructuredModel
 
         class Line(StructuredModel):
             sku: str = ComparableField(comparator=ExactComparator())
+
+            match_threshold = 0.85
 
         class Addr(StructuredModel):
             city: str = ComparableField(comparator=ExactComparator())
@@ -393,15 +395,105 @@ class TestExplainContract:
 
         # A real leaf comparator is still named.
         assert ex["order_id"]["comparator"] == "ExactComparator"
-        # A List[StructuredModel] is matched element-by-element, then recursed.
+        # Structural rows use the SAME strings builder.py emits for the inferred
+        # path, so explain() reads the same either way. Inventing new labels here
+        # would create a divergence in the audit trail, and would also slip past
+        # test_every_explained_comparator_is_instantiable below, whose skip-list
+        # knows only these two.
         assert ex["items"]["comparator"] == "Hungarian (per-element StructuredModel)"
-        # A single nested model recurses into its own fields.
-        assert ex["addr"]["comparator"] == "recursive (nested StructuredModel)"
-        assert ex["opt_addr"]["comparator"] == "recursive (nested StructuredModel)"
-        # Whatever the label, it must never be the inert default the field
-        # cannot legally carry.
+        assert ex["addr"]["comparator"] == "StructuredModelComparator"
+        assert ex["opt_addr"]["comparator"] == "StructuredModelComparator"
         for structured_field in ("items", "addr", "opt_addr"):
             assert ex[structured_field]["comparator"] != "LevenshteinComparator"
+
+    def test_structured_rows_report_the_threshold_that_actually_gates(self):
+        """threshold and clip_under_threshold must not be inert defaults either.
+
+        Replacing only the comparator left these two reading off the same
+        ComparableField the engine ignores: a user setting match_threshold=0.85
+        on the element class saw threshold 0.5, and clip_under_threshold=True was
+        contradicted by behaviour, since a below-threshold list score percolates
+        up rather than being clipped to 0.
+        """
+        from stickler import ComparableField, ExactComparator, StructuredModel
+
+        class Line(StructuredModel):
+            sku: str = ComparableField(comparator=ExactComparator())
+
+            match_threshold = 0.85
+
+        class Order(StructuredModel):
+            items: List[Line] = ComparableField()
+
+        row = stickler.eval_for(Order).explain()["items"]
+
+        assert row["threshold"] == 0.85, "must be the element's real gate"
+        assert row["clip_under_threshold"] is False
+
+    def test_nested_rows_agree_across_both_explain_paths(self):
+        """The configured and inferred paths must describe one behaviour once.
+
+        This is the whole point of the change: a caller diffing explain() across
+        a tuned StructuredModel and a plain BaseModel of the same shape should
+        not see two names for the same comparison.
+        """
+        from stickler import ComparableField, ExactComparator, StructuredModel
+
+        class SLine(StructuredModel):
+            sku: str = ComparableField(comparator=ExactComparator())
+
+        class SAddr(StructuredModel):
+            city: str = ComparableField(comparator=ExactComparator())
+
+        class SOrder(StructuredModel):
+            addr: SAddr = ComparableField()
+            items: List[SLine] = ComparableField()
+
+        class PLine(BaseModel):
+            sku: str
+
+        class PAddr(BaseModel):
+            city: str
+
+        class POrder(BaseModel):
+            addr: PAddr
+            items: List[PLine]
+
+        configured = stickler.eval_for(SOrder).explain()
+        inferred = stickler.eval_for(POrder).explain()
+
+        for path in ("addr", "items"):
+            assert configured[path]["comparator"] == inferred[path]["comparator"], path
+            assert (
+                configured[path]["clip_under_threshold"]
+                == inferred[path]["clip_under_threshold"]
+            ), path
+
+    def test_an_ignored_comparator_on_a_nested_field_is_still_visible(self):
+        """A comparator on a single nested-model field is accepted and ignored.
+
+        __init_subclass__ rejects one on a List[StructuredModel] but not on a
+        single nested model, where the engine silently disregards it. Reporting a
+        generic structural label removed the only trace of that dead setting, so
+        the provenance trail now names it.
+        """
+        from stickler import BaseComparator, ComparableField, StructuredModel
+
+        class Always37(BaseComparator):
+            def _compare(self, value1, value2):
+                return 0.37
+
+        class Child(StructuredModel):
+            city: str = ComparableField()
+
+        class Parent(StructuredModel):
+            child: Child = ComparableField(comparator=Always37())
+
+        row = stickler.eval_for(Parent).explain()["child"]
+
+        assert row["comparator"] == "StructuredModelComparator"
+        assert any("Always37" in reason for reason in row["why"]), row["why"]
+        assert any("ignored" in reason for reason in row["why"]), row["why"]
 
     def test_every_explained_comparator_is_instantiable(self):
         from stickler.structured_object_evaluator.models.comparator_registry import (

--- a/tests/auto/test_risk_surface.py
+++ b/tests/auto/test_risk_surface.py
@@ -430,12 +430,15 @@ class TestExplainContract:
         assert row["threshold"] == 0.85, "must be the element's real gate"
         assert row["clip_under_threshold"] is False
 
-    def test_nested_rows_agree_across_both_explain_paths(self):
-        """The configured and inferred paths must describe one behaviour once.
+    def test_nested_comparator_labels_agree_across_both_explain_paths(self):
+        """Both paths must name the same comparator for the same behaviour.
 
-        This is the whole point of the change: a caller diffing explain() across
-        a tuned StructuredModel and a plain BaseModel of the same shape should
-        not see two names for the same comparison.
+        Scoped to `comparator` deliberately. `threshold` and
+        `clip_under_threshold` are NOT invariant across the paths for a single
+        nested model, and asserting they were would lock in a misreport: the
+        engine reads the field's own values there, and a hand-written
+        `ComparableField()` defaults `clip_under_threshold` to True where
+        `builder.py` installs False. The two differ because the models differ.
         """
         from stickler import ComparableField, ExactComparator, StructuredModel
 
@@ -464,10 +467,72 @@ class TestExplainContract:
 
         for path in ("addr", "items"):
             assert configured[path]["comparator"] == inferred[path]["comparator"], path
-            assert (
-                configured[path]["clip_under_threshold"]
-                == inferred[path]["clip_under_threshold"]
-            ), path
+
+    def test_a_nested_row_predicts_whether_the_score_was_clipped(self):
+        """The nested row's threshold and clip flag must be the ones that ran.
+
+        Generalising the list-only "inert defaults" argument to this branch
+        replaced accurate values with inaccurate ones: the engine does read
+        `info.threshold` and `info.clip_under_threshold` for a single nested
+        model, so a row hardcoding the element's match_threshold and False
+        reported a clip flag the engine contradicted, and left a 0.0 score with
+        no explanation.
+        """
+        from stickler import ComparableField, ExactComparator, StructuredModel
+
+        class Kid(StructuredModel):
+            a: str = ComparableField(comparator=ExactComparator())
+            b: str = ComparableField(comparator=ExactComparator())
+            c: str = ComparableField(comparator=ExactComparator())
+
+            match_threshold = 0.85
+
+        gt_kid = Kid(a="x", b="y", c="z")
+        pred_kid = Kid(a="x", b="Q", c="Q")  # raw similarity 1/3
+
+        for kwargs in (
+            {},
+            {"threshold": 0.3},
+            {"clip_under_threshold": False},
+            {"threshold": 0.9},
+        ):
+            Fam = type(
+                "Fam",
+                (StructuredModel,),
+                {"__annotations__": {"one": Kid}, "one": ComparableField(**kwargs)},
+            )
+            spec = stickler.eval_for(Fam)
+            score = spec.evaluate(Fam(one=gt_kid), Fam(one=pred_kid)).field_scores["one"]
+            row = spec.explain()["one"]
+
+            would_clip = score == 0.0
+            row_says = (1 / 3) < row["threshold"] and row["clip_under_threshold"]
+            assert would_clip == row_says, (
+                f"{kwargs}: score={score}, row reported "
+                f"threshold={row['threshold']} clip={row['clip_under_threshold']}"
+            )
+
+    def test_a_list_row_reports_the_element_gate_and_names_the_other(self):
+        """A list field has two gates and the row must not hide either."""
+        from stickler import ComparableField, ExactComparator, StructuredModel
+
+        class Line(StructuredModel):
+            sku: str = ComparableField(comparator=ExactComparator())
+
+            match_threshold = 0.85
+
+        class Order(StructuredModel):
+            items: List[Line] = ComparableField()
+
+        row = stickler.eval_for(Order).explain()["items"]
+
+        # The element's match_threshold splits TP from FD.
+        assert row["threshold"] == 0.85
+        # Structured lists are never clipped, whatever the field carries.
+        assert row["clip_under_threshold"] is False
+        # The field's own threshold still gates whether per-item rows appear, so
+        # it must not vanish from the trail just because it is not the headline.
+        assert any("gates:" in reason for reason in row["why"]), row["why"]
 
     def test_an_ignored_comparator_on_a_nested_field_is_still_visible(self):
         """A comparator on a single nested-model field is accepted and ignored.
@@ -494,6 +559,22 @@ class TestExplainContract:
         assert row["comparator"] == "StructuredModelComparator"
         assert any("Always37" in reason for reason in row["why"]), row["why"]
         assert any("ignored" in reason for reason in row["why"]), row["why"]
+
+        # ...but it must stay silent when nothing was chosen. ComparableField()
+        # stores a LevenshteinComparator when none is given, and a bare
+        # annotation gets a synthesised StructuredModelComparator, so an
+        # unconditional note would warn about a comparator the user never picked
+        # and, for the bare case, have the row disown the very comparator it
+        # reports.
+        class Quiet(StructuredModel):
+            chosen_nothing: Child = ComparableField()
+            no_field_at_all: Child
+
+        quiet = stickler.eval_for(Quiet).explain()
+        for field_name in ("chosen_nothing", "no_field_at_all"):
+            assert not any(
+                "ignored" in reason for reason in quiet[field_name]["why"]
+            ), f"{field_name}: {quiet[field_name]['why']}"
 
     def test_every_explained_comparator_is_instantiable(self):
         from stickler.structured_object_evaluator.models.comparator_registry import (


### PR DESCRIPTION
On a configured StructuredModel, EvalSpec.explain() read the comparator off each field's ComparableField. For a List[StructuredModel] that is an inert LevenshteinComparator default the engine never runs -- object lists are matched element-by-element with Hungarian and compared recursively -- and the field is in fact forbidden from carrying a comparator at all (__init_subclass__ raises). A single nested-model field had the same problem. explain() also omitted the nested dotted paths for these fields.

_explain_structured now labels a List[StructuredModel] field "Hungarian (per-element StructuredModel)" and a single nested model "recursive (nested StructuredModel)", the same strings the inference path in builder.py already emits, so both explain paths read consistently.

No scores change; this is the audit trail only. Plain BaseModel classes routed through inference were already correct. Present on 0.6.0, so not a 0.7.0 regression, but explain() is the justification surface for a score and should not name a comparator that never ran.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
