### PR TITLE
fix: export DateComparator and BBoxIoUComparator from the package root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ Each release links to full notes on the
 
 ### Added
 
+- `DateComparator` and `BBoxIoUComparator` are now exported from the top-level
+  `stickler` namespace, alongside every other comparator. Both were reachable
+  only as `from stickler.comparators import DateComparator`, so the obvious
+  import failed with an `ImportError` that gave no hint the name existed one
+  level down. Neither had ever been exported from the package root, dating from
+  when each was added ([#141](https://github.com/awslabs/stickler/pull/141) and
+  [#151](https://github.com/awslabs/stickler/pull/151)).
+
+  Purely additive: both are core and were already imported eagerly by
+  `stickler.comparators`, so `import stickler` is unchanged at 523 modules.
+  `tests/test_top_level_exports.py` now derives the expected set from
+  `stickler.comparators` rather than a hand-maintained list, which is what let
+  the gap survive ([#252](https://github.com/awslabs/stickler/issues/252))
+
 - `PhoneComparator`, which compares phone numbers by the number they dial rather
   than as strings. `"206-555-0100"`, `"(206) 555-0100"`, `"+1-206-555-0100"` and
   `"2065550100"` all compare equal; extensions are reconciled

--- a/src/stickler/__init__.py
+++ b/src/stickler/__init__.py
@@ -15,6 +15,8 @@ from .auto import EvalResult, EvalSpec, eval_for, evaluate
 
 # Always-available comparators (core deps)
 from .comparators.base import BaseComparator
+from .comparators.bbox import BBoxIoUComparator
+from .comparators.date import DateComparator
 from .comparators.exact import ExactComparator
 from .comparators.fuzzy import FuzzyComparator
 from .comparators.levenshtein import LevenshteinComparator
@@ -154,6 +156,8 @@ __all__ = [
     "BaseComparator",
     "ExactComparator",
     "PhoneComparator",
+    "DateComparator",
+    "BBoxIoUComparator",
     "FuzzyComparator",
     "LevenshteinComparator",
     "NumericComparator",

--- a/tests/test_top_level_exports.py
+++ b/tests/test_top_level_exports.py
@@ -14,10 +14,13 @@ import stickler
 # Mapping of public name -> canonical source module
 ALWAYS_AVAILABLE_EXPORTS = {
     "BaseComparator": "stickler.comparators.base",
+    "BBoxIoUComparator": "stickler.comparators.bbox",
+    "DateComparator": "stickler.comparators.date",
     "ExactComparator": "stickler.comparators.exact",
     "FuzzyComparator": "stickler.comparators.fuzzy",
     "LevenshteinComparator": "stickler.comparators.levenshtein",
     "NumericComparator": "stickler.comparators.numeric",
+    "PhoneComparator": "stickler.comparators.phone",
     "SemanticComparator": "stickler.comparators.semantic",
     "StructuredModelComparator": "stickler.comparators.structured",
 }
@@ -77,6 +80,33 @@ class TestAllConsistency:
         """All always-available comparators must be in __all__."""
         for name in ALWAYS_AVAILABLE_EXPORTS:
             assert name in stickler.__all__
+
+    def test_no_eager_comparator_is_missing_from_the_top_level(self):
+        """The two namespaces must agree, derived rather than hand-listed.
+
+        `ALWAYS_AVAILABLE_EXPORTS` above is maintained by hand, which is why
+        three comparators were absent from it and one of them
+        (`DateComparator`) went unexported from the package root for two
+        releases. `BBoxIoUComparator` had the same gap. This test derives the
+        expectation from `stickler.comparators` instead, so adding a comparator
+        to one namespace and not the other fails rather than passing quietly.
+
+        Scoped to eagerly imported comparators. `BERTComparator` and
+        `LLMComparator` come through the lazy `__getattr__` because they need
+        extras, and `TestOptionalGating` covers those.
+        """
+        import stickler.comparators as comparators
+
+        def comparator_names(namespace):
+            return {n for n in dir(namespace) if n.endswith("Comparator")}
+
+        lazy = {"BERTComparator", "LLMComparator"}
+        missing = comparator_names(comparators) - comparator_names(stickler) - lazy
+
+        assert not missing, (
+            f"in stickler.comparators but not at the top level: {sorted(missing)}. "
+            f"Add the import and the __all__ entry to src/stickler/__init__.py."
+        )
 
     def test_numeric_exact_c_not_in_all(self):
         """NumericExactC is a compat alias - not re-exported at top level."""


### PR DESCRIPTION
## Issue Reference

Fixes #252

## Description of Changes

`DateComparator` and `BBoxIoUComparator` were reachable only through the submodule,
while every other comparator is also exported from the package root.

```python
from stickler import DateComparator
# ImportError: cannot import name 'DateComparator' from 'stickler'
```

### Changes Made

- `src/stickler/__init__.py`: import both, add both to `__all__`.
- `tests/test_top_level_exports.py`: add the three comparators missing from its
  hand-maintained list, and add a test that **derives** the expected set instead.
- CHANGELOG entry under 0.7.0.

### Why These Changes Are Needed

Neither had ever been exported from the root. `git log -S "from .comparators.date import"`
over `src/stickler/__init__.py` finds no prior occurrence. Both arrived in feature PRs
that wired the comparator into `stickler.comparators` and stopped there: `DateComparator`
in 4a5fb4d (#141), `BBoxIoUComparator` in 80595a3 (#151). `PhoneComparator`, added later
under the same conditions, *did* get the export, which is what made the inconsistency
visible.

The docs and examples import comparators from the root throughout, so a reader reasonably
expects the whole set to be there.

It also made `DateComparator` look less supported than it is, and dates are one of the
field types where a dedicated comparator matters most. Edit distance ranks them backwards:

```
gt         pred          Levenshtein   DateComparator
10/05/16   2016-10-05          0.100            1.000   same date, ISO form
10/05/16   10/5/16             0.875            1.000   same date, unpadded
10/05/16   10/06/16            0.875            0.000   DIFFERENT date
```

A *different* date scores higher than the same date reformatted, so no threshold
separates them.

## Why the existing test did not catch it

`tests/test_top_level_exports.py` checked a hand-maintained dict,
`ALWAYS_AVAILABLE_EXPORTS`. Three comparators were absent from it:
`DateComparator`, `BBoxIoUComparator` and `PhoneComparator`. So it validated only what
someone had remembered to list, which is how a gap survives two releases.

All three are now in that dict, and there is a new test that derives the expectation:

```python
missing = comparator_names(stickler.comparators) - comparator_names(stickler) - lazy
assert not missing
```

Scoped to eagerly imported comparators; `BERTComparator` and `LLMComparator` come through
the lazy `__getattr__` because they need extras, and `TestOptionalGating` already covers
those.

**Verified load-bearing.** With the fix reverted:

```
AssertionError: in stickler.comparators but not at the top level:
['BBoxIoUComparator', 'DateComparator']. Add the import and the __all__ entry
to src/stickler/__init__.py.
```

## Testing

- [x] Unit tests added/updated
- [x] All existing tests pass
- [x] Manual testing completed

**1860 passed, 2 skipped**, against **1856** on `dev`: the new derived test plus three
parametrized identity cases for the newly listed comparators. Ruff clean.

**No import-weight change.** `import stickler` is 523 modules both with dev's `__init__.py`
and with this one, measured by swapping the file and re-importing. Both comparators are core
and were already imported eagerly by `stickler.comparators`, so nothing new is loaded.

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review of code completed
- [x] `CHANGELOG.md` entry added under 0.7.0
- [x] Tests added/updated for new functionality
- [ ] All CI checks are passing (pending)
- [x] Ready for review

## Additional Notes

Three files, +48/-0, purely additive. Extracted from #251, where I hit this while using
`DateComparator` in the Strands Evals live-agent example. #251 will rebase on this rather
than carrying the same change.
