### PR TITLE
fix(auto): emit nested dotted paths for configured StructuredModel in explain()

### DIFF
--- a/src/stickler/auto/builder.py
+++ b/src/stickler/auto/builder.py
@@ -141,18 +141,40 @@ def _collect_specs(
         return
     _visiting.add(cls)
     try:
+        is_structured = isinstance(cls, type) and issubclass(cls, StructuredModel)
         for name, field_info in cls.model_fields.items():
+            if name in _RESERVED_FIELD_NAMES:
+                continue
             path = f"{prefix}{name}"
             annotation, _ = unwrap_optional(field_info.annotation)
             kind = _field_kind(annotation)
-            if kind == "model":
+            if is_structured:
+                info = cls._get_comparison_info(name)
+                comparator = getattr(info, "comparator", None)
+                if kind == "model":
+                    comp_name = (
+                        type(comparator).__name__
+                        if comparator
+                        else "StructuredModelComparator"
+                    )
+                elif kind == "model_list":
+                    comp_name = (
+                        type(comparator).__name__
+                        if comparator
+                        else "Hungarian (per-element StructuredModel)"
+                    )
+                else:
+                    comp_name = (
+                        type(comparator).__name__ if comparator else "default"
+                    )
                 result[path] = InferredSpec(
-                    comparator_name="StructuredModelComparator",
-                    threshold=match_threshold,
-                    clip_under_threshold=False,
-                    provenance=["type:nested BaseModel -> recursive comparison"],
+                    comparator_name=comp_name,
+                    threshold=info.threshold,
+                    weight=info.weight,
+                    clip_under_threshold=info.clip_under_threshold,
+                    provenance=["explicit: configured on the StructuredModel class"],
                 )
-                if not issubclass(annotation, StructuredModel):
+                if kind == "model":
                     _collect_specs(
                         annotation,
                         f"{path}.",
@@ -162,14 +184,8 @@ def _collect_specs(
                         result,
                         _visiting,
                     )
-            elif kind == "model_list":
-                result[path] = InferredSpec(
-                    comparator_name="Hungarian (per-element StructuredModel)",
-                    threshold=match_threshold,
-                    provenance=["type:List[BaseModel] -> Hungarian object matching"],
-                )
-                element, _ = unwrap_optional(_list_element(annotation))
-                if not issubclass(element, StructuredModel):
+                elif kind == "model_list":
+                    element, _ = unwrap_optional(_list_element(annotation))
                     _collect_specs(
                         element,
                         f"{path}.",
@@ -179,6 +195,38 @@ def _collect_specs(
                         result,
                         _visiting,
                     )
+            elif kind == "model":
+                result[path] = InferredSpec(
+                    comparator_name="StructuredModelComparator",
+                    threshold=match_threshold,
+                    clip_under_threshold=False,
+                    provenance=["type:nested BaseModel -> recursive comparison"],
+                )
+                _collect_specs(
+                    annotation,
+                    f"{path}.",
+                    weight_hints,
+                    match_threshold,
+                    registry,
+                    result,
+                    _visiting,
+                )
+            elif kind == "model_list":
+                result[path] = InferredSpec(
+                    comparator_name="Hungarian (per-element StructuredModel)",
+                    threshold=match_threshold,
+                    provenance=["type:List[BaseModel] -> Hungarian object matching"],
+                )
+                element, _ = unwrap_optional(_list_element(annotation))
+                _collect_specs(
+                    element,
+                    f"{path}.",
+                    weight_hints,
+                    match_threshold,
+                    registry,
+                    result,
+                    _visiting,
+                )
             elif kind == "primitive_list":
                 # Report the element spec (the same one _field_definition
                 # installs) so the audit trail matches the built model.

--- a/src/stickler/auto/facade.py
+++ b/src/stickler/auto/facade.py
@@ -147,10 +147,6 @@ class EvalSpec:
         ``source`` is a coarse label (``type`` / ``name-token`` / ``degrade``,
         or ``explicit`` for a passthrough ``StructuredModel``).
         """
-        if isinstance(self.source_cls, type) and issubclass(
-            self.source_cls, StructuredModel
-        ):
-            return self._explain_structured()
         out: Dict[str, Dict[str, Any]] = {}
         for name, spec in specs_for(
             self.source_cls,
@@ -169,21 +165,7 @@ class EvalSpec:
 
     def _explain_structured(self) -> Dict[str, Dict[str, Any]]:
         """Explain a passthrough StructuredModel from its explicit config."""
-        out: Dict[str, Dict[str, Any]] = {}
-        for name in self.source_cls.model_fields:
-            if name == "extra_fields":
-                continue
-            info = self.source_cls._get_comparison_info(name)
-            comparator = getattr(info, "comparator", None)
-            out[name] = {
-                "comparator": type(comparator).__name__ if comparator else "default",
-                "threshold": info.threshold,
-                "weight": info.weight,
-                "clip_under_threshold": info.clip_under_threshold,
-                "source": "explicit",
-                "why": ["explicit: configured on the StructuredModel class"],
-            }
-        return out
+        return self.explain()
 
 
 def eval_for(

--- a/src/stickler/auto/inference.py
+++ b/src/stickler/auto/inference.py
@@ -89,6 +89,8 @@ class InferredSpec:
             if entry.startswith("degrade"):
                 return "degrade"
         for entry in self.provenance:
+            if entry.startswith("explicit"):
+                return "explicit"
             if entry.startswith("name-token"):
                 return "name-token"
         return "type"

--- a/tests/auto/test_risk_surface.py
+++ b/tests/auto/test_risk_surface.py
@@ -341,6 +341,73 @@ class TestStructuredModelPassthrough:
         pred = Wrap(inner=SM(code="X-1"), label="a")
         assert stickler.evaluate(gt, pred).overall_score == pytest.approx(1.0)
 
+    def test_explain_nested_structured_models(self):
+        from stickler.comparators.exact import ExactComparator
+
+        class Line(StructuredModel):
+            sku: str = ComparableField(comparator=ExactComparator())
+
+        class Order(StructuredModel):
+            order_id: str = ComparableField(comparator=ExactComparator())
+            items: List[Line] = ComparableField()
+
+        ex = stickler.eval_for(Order).explain()
+        assert set(ex.keys()) == {"order_id", "items", "items.sku"}
+        assert ex["items.sku"]["source"] == "explicit"
+        assert ex["items.sku"]["comparator"] == "ExactComparator"
+
+    def test_explain_shape_parity_between_structured_and_inferred(self):
+        from stickler.comparators.exact import ExactComparator
+
+        class SLine(StructuredModel):
+            sku: str = ComparableField(comparator=ExactComparator())
+
+        class SOrder(StructuredModel):
+            order_id: str = ComparableField(comparator=ExactComparator())
+            items: List[SLine] = ComparableField()
+
+        class PLine(BaseModel):
+            sku: str
+
+        class POrder(BaseModel):
+            order_id: str
+            items: List[PLine]
+
+        s_keys = set(stickler.eval_for(SOrder).explain().keys())
+        p_keys = set(stickler.eval_for(POrder).explain().keys())
+        assert s_keys == p_keys == {"order_id", "items", "items.sku"}
+
+    def test_explain_single_nested_structured_model(self):
+        from stickler.comparators.exact import ExactComparator
+
+        class Customer(StructuredModel):
+            name: str = ComparableField(comparator=ExactComparator(), threshold=1.0)
+
+        class Account(StructuredModel):
+            account_id: str = ComparableField(comparator=ExactComparator())
+            customer: Customer = ComparableField()
+
+        ex = stickler.eval_for(Account).explain()
+        assert set(ex.keys()) == {"account_id", "customer", "customer.name"}
+        assert ex["customer.name"]["source"] == "explicit"
+        assert ex["customer.name"]["comparator"] == "ExactComparator"
+        assert ex["customer.name"]["threshold"] == 1.0
+
+    def test_explain_mixed_basemodel_wrapping_structured_model(self):
+        from stickler.comparators.exact import ExactComparator
+
+        class SM(StructuredModel):
+            code: str = ComparableField(comparator=ExactComparator(), threshold=1.0)
+
+        class Wrap(BaseModel):
+            inner: SM
+            label: str
+
+        ex = stickler.eval_for(Wrap).explain()
+        assert set(ex.keys()) == {"label", "inner", "inner.code"}
+        assert ex["inner.code"]["source"] == "explicit"
+        assert ex["inner.code"]["comparator"] == "ExactComparator"
+
 
 class TestExplainContract:
     """explain() must describe what is actually installed, at every depth."""


### PR DESCRIPTION
## Problem
When evaluating configured \StructuredModel\ subclasses or models with nested \StructuredModel\ fields, \_collect_specs\ previously skipped recursion into child models and \_explain_structured\ only looked at top-level \model_fields\. As a result, \xplain()\ omitted nested dotted paths (e.g. \items.sku\) for configured models, causing structural and audit divergence between configured models and zero-config inferred models (#254).

## Solution
- Recurse into nested \model\ and \model_list\ types in \_collect_specs\ regardless of whether the model is a configured \StructuredModel\ or an inferred \BaseModel\, capturing explicit comparator, threshold, weight, and clipping metadata for configured fields.
- Centralize \EvalSpec.explain()\ key generation to use \specs_for(self.source_cls, ...)\.
- Added unit tests in \	ests/auto/test_risk_surface.py\ covering:
  - Nested \StructuredModel\ list fields (asserting dotted path emission and explicit metadata)
  - Single nested \StructuredModel\ fields
  - Dotted-key shape parity between configured and zero-config inferred models
  - Mixed models (\BaseModel\ wrapping a \StructuredModel\)

Fixes #254