### PR TITLE
chore: ignore OpenSpec scaffolding and docs working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ dist/
 .working/
 .temp/
 .data/
+
+# Openspec
+openspec/
+.claude/commands/opsx/
+.claude/skills/openspec-*

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,2 @@
 site/
+working/


### PR DESCRIPTION
## What

Adds four ignore rules for artifacts that local agent tooling generates in the working tree.

**Root `.gitignore`**

| Path | Why |
|---|---|
| `openspec/` | Spec/change workspace created by the OpenSpec workflow tooling |
| `.claude/commands/opsx/` | Slash commands installed by that same tooling |
| `.claude/skills/openspec-*` | Skill definitions installed alongside them |

**`docs/.gitignore`**

- `working/` — scratch area used while drafting documentation.
- Also adds the trailing newline the file was missing.

## Why

These paths are per-developer, machine-local, and regenerated on demand. Left untracked-but-visible they clutter `git status`, make it easy to lose a real change in the noise, and create a real risk of sweeping someone's local tool installation into a commit via `git add -A`.

## Notes

- No tracked files are affected — every newly ignored path was already untracked, verified with `git ls-files`, so nothing is removed from the index and no history is rewritten.
- The `.claude/` rules are deliberately narrow rather than ignoring `.claude/` wholesale, so any intentionally shared project-level Claude configuration stays trackable.