### PR TITLE
fix: delete the dead _HAS_BOTO3 probe (#257)

### DIFF
--- a/src/stickler/comparators/utils.py
+++ b/src/stickler/comparators/utils.py
@@ -1,10 +1,4 @@
-import importlib.util
 import json
-
-# Probed rather than imported: boto3 is only needed to call Bedrock, and a
-# module-level import puts it on the `import stickler` path via
-# comparators/semantic.py. The real import happens in the function below.
-_HAS_BOTO3 = importlib.util.find_spec("boto3") is not None
 
 
 def generate_bedrock_embedding(
@@ -25,6 +19,12 @@ def generate_bedrock_embedding(
     Raises:
         Exception: If the embedding generation fails after the maximum number of retries.
     """
+    # Imported here rather than at module scope: boto3 is only needed to call
+    # Bedrock, and this module is on the `import stickler` path via
+    # comparators/semantic.py, so a module-level import would pull boto3 into
+    # every import of the package. Do not probe for it at module scope either --
+    # `importlib.util.find_spec` raises for an installed module whose
+    # `__spec__` is None, which broke `import stickler` outright (#257).
     try:
         import boto3
         from botocore.config import Config

--- a/tests/test_lazy_import_allowlists.py
+++ b/tests/test_lazy_import_allowlists.py
@@ -214,6 +214,47 @@ def test_registry_constructs_when_a_dependency_is_mocked():
         assert stickler._dependency_available("strands") is True
 
 
+def test_a_boto3_shim_without_a_module_spec_does_not_break_the_import():
+    """An optional dependency must never be probed at module scope.
+
+    ``comparators/utils.py`` used to run
+    ``importlib.util.find_spec("boto3")`` at import time, and that module is on
+    the ``import stickler`` path via ``comparators/semantic.py``. ``find_spec``
+    raises ``ValueError`` -- rather than returning None -- for an installed
+    module whose ``__spec__`` is None, which is what a hand-rolled shim looks
+    like, so the whole package became unimportable in such an environment
+    (#257).
+
+    The probe is gone, so this asserts the property rather than the line: with a
+    spec-less boto3 shim installed, reimporting the package succeeds.
+    """
+    shim = types.ModuleType("boto3")
+    shim.__spec__ = None
+
+    with mock.patch.dict(sys.modules, {"boto3": shim}):
+        # The precondition this regresses on: the call the old probe made raises.
+        with pytest.raises(ValueError):
+            importlib.util.find_spec("boto3")
+
+        importlib.reload(stickler)
+        importlib.reload(importlib.import_module("stickler.comparators.utils"))
+
+    # Leave the module registry as the rest of the session found it.
+    importlib.reload(stickler)
+
+
+def test_no_module_scope_boto3_availability_flag_remains():
+    """The removed probe left no successor.
+
+    A module-level flag is the shape of the bug: computing it requires
+    inspecting boto3 at import time. Availability is reported by the
+    ``ImportError`` that ``generate_bedrock_embedding`` raises instead.
+    """
+    import stickler.comparators.utils as utils
+
+    assert not [name for name in vars(utils) if "BOTO3" in name.upper()]
+
+
 def test_registered_comparators_cannot_redirect_the_import_path():
     """A user registering a comparator supplies a class, not a module path.
 


### PR DESCRIPTION
Closes #257. First of six PRs clearing the 0.7.0 release-candidate review findings on #256.

## Why

`src/stickler/comparators/utils.py` ran `importlib.util.find_spec("boto3")` at module scope, and that module is on the `import stickler` path via `comparators/semantic.py`.

`find_spec` raises `ValueError` — rather than returning `None` — for an installed module whose `__spec__` is `None`, which is what a hand-rolled boto3 shim looks like. So `import stickler` failed outright on `dev` in such an environment, where it imports fine on `main`.

The probe's result, `_HAS_BOTO3`, had zero readers anywhere in `src/` or `tests/`. It bought nothing and broke the package entry point.

## What changed

- Deleted `_HAS_BOTO3` and the now-unused `import importlib.util` (its only reader in the file, so leaving it fails ruff `F401`).
- Moved the comment's surviving rationale to the in-function boto3 import, which is the load-bearing decision: importing boto3 inside `generate_bedrock_embedding` is what keeps it off the package import path. The new comment also records why a module-scope probe is not an acceptable substitute.
- Added two regression tests to `tests/test_lazy_import_allowlists.py`, which is where the project already guards this class of bug. They assert the *property*, not the deleted line: with a spec-less boto3 shim in `sys.modules`, reimporting `stickler` succeeds; and no module-scope boto3 availability flag has reappeared.

## Verification

- `grep -rn "_HAS_BOTO3" src/ tests/` prints nothing.
- `pytest tests/test_core_import_weight.py tests/test_lazy_import_allowlists.py` — 49 passed, 2 skipped. boto3 is still absent from the import path.
- `pytest tests/` — 1846 passed, 11 skipped.
- `ruff check` and `ruff format --check` clean on both touched files.

No public API change; no behavior change beyond restoring importability.