### PR TITLE
fix: PhoneComparator scores identical values 1.0 (#258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,29 +42,37 @@ Each release links to full notes on the
   (`206-555-0101`) scores `0.917` while the same number reformatted scores
   `0.786`, so no threshold separates them.
 
-  Unparseable **or invalid** input scores `0.0`, including when both sides are
-  identical. libphonenumber parses `"0000000000"` and renders it as E164, so a
-  parse-only check would report a placeholder on both sides as a successful
-  match; validity is checked with `is_valid_number`. `"N/A"` on both sides is a
-  field that was not extracted, not a phone number that matched. Genuinely
-  absent values are unaffected, since the shared `None` policy resolves those
-  before any comparator runs.
+  When **neither** side is a usable number, the comparison falls back to exact
+  string equality, so two identical values are never reported as maximally
+  different. Not every correctly extracted phone number is dialable under the
+  configured region: a UK national format read as `"US"`, an extension fragment
+  such as `"ext 4021"`, and any 555-area-code documentation number are all
+  unusable *as numbers* while being exactly what the document said. The fallback
+  is equality, not leniency -- `"N/A"` against `"unknown"` scores `0.0`, and when
+  exactly **one** side is a usable number the score is `0.0`, because one side
+  found a number and the other did not.
 
-  This rejects the number most documentation reaches for. `"555-123-4567"` puts
-  **555 in the area-code position**, and 555 is not a real area code -- NANP has
-  never assigned it, which is precisely why writers use it -- so it scores `0.0`
-  even against itself. Fixtures want a real area code with the `555`
-  **exchange** instead: `"206-555-0100"` is fictional by convention (555-01xx is
-  set aside for fiction) while being structurally valid.
+  Validity is still checked with `is_valid_number` rather than parseability.
+  libphonenumber parses `"0000000000"` and renders it as E164, so a parse-only
+  check would report a placeholder pair as a *canonical phone match* and would
+  match two different placeholders that canonicalize alike. Under the fallback
+  such a pair matches itself as a string instead: the score is the same and the
+  claim behind it is honest. Genuinely absent values are unaffected, since the
+  shared `None` policy resolves those before any comparator runs.
+
+  Fixtures still want a real area code with the `555` **exchange** rather than
+  555 in the area-code position: `"206-555-0100"` is fictional by convention
+  (555-01xx is set aside for fiction) while being structurally valid, so it
+  compares as a number rather than as a string.
 
   Extensions are compared separately, because E164 omits them:
   `"+12065550100x89"` and `"+12065550100x90"` reach different people and do not
   match.
 
   An unrecognised `region` raises `ValueError` at construction. `region="UK"`
-  (the ISO code is `"GB"`) would otherwise make every national-format number
-  score `0.0` with no error, which reads as total extraction failure rather than
-  a typo.
+  (the ISO code is `"GB"`) would otherwise leave every national-format number
+  comparing as a string rather than as a number, with no error -- quieter than a
+  typo has any right to be.
 
   This adds `phonenumberslite` to the core dependencies: the metadata-only build
   of the libphonenumber port, 450 KB, zero dependencies, Apache-2.0

--- a/src/stickler/auto/README.md
+++ b/src/stickler/auto/README.md
@@ -83,7 +83,8 @@ call yields both `field_scores`/`overall_score` **and** precision/recall/f1/accu
    as whole words in the snake/camelCase-split field name; trailing digits are
    shed (`isbn13`→`isbn`) and simple plurals singularized (`ids`→`id`).
    Highlights: `id/sku/code`→Exact (w 3.0), `amount/price/total`→Numeric\@0.95
-   (w 2.5, numeric fields only), `email/url/zip/phone`→Exact,
+   (w 2.5, numeric fields only), `email/url`→Exact,
+   `zip/postal/postcode`→Exact (case-sensitive), `phone`→Phone\@1.0,
    `name/vendor/customer`→Levenshtein\@0.85,
    `date/due/created/...`→Date\@0.95 (date/datetime fields only),
    `address`→Fuzzy(token_sort), `notes/description/summary`→Fuzzy(token_set)\@0.6
@@ -98,6 +99,13 @@ call yields both `field_scores`/`overall_score` **and** precision/recall/f1/accu
    unparseable values silently scores identical strings 0.0, which is the worst
    failure mode a metrics API can have. `bool`/`Enum`/`Literal` are never
    token-refined at all (nothing sharpens an exact match).
+
+   **The gate is on the declared type, not the value.** `phone: str` passes the
+   gate, so the gate cannot catch a *value* that fails to parse -- which is how
+   `PhoneComparator` came to score identical unparseable numbers 0.0 through
+   this path (#258). Any token rule whose comparator can reject an individual
+   value therefore needs a same-value fallback of its own; the type gate is not
+   enough on its own.
 
 Every decision is recorded in `InferredSpec.provenance` and surfaced by
 `EvalResult.explain()` / `EvalSpec.explain()`.

--- a/src/stickler/comparators/phone.py
+++ b/src/stickler/comparators/phone.py
@@ -28,16 +28,19 @@ class PhoneComparator(BaseComparator):
     round: a *different* number scores higher than the same number reformatted,
     so no threshold separates them.
 
-    Both sides must be **valid** numbers, not merely parseable. libphonenumber
-    parses ``"0000000000"``, ``"1234567"`` and ``"1111111111"`` and renders each
-    as E164, so a parse-only check scores those ``1.0`` against themselves -- a
-    placeholder on both sides reported as a successful match. Validity is
-    checked with ``is_valid_number``, which rejects them.
+    A **valid** number, not merely a parseable one, is what counts as usable
+    here. libphonenumber parses ``"0000000000"``, ``"1234567"`` and
+    ``"1111111111"`` and renders each as E164, so a parse-only check would
+    report a placeholder pair as a *canonical phone match*. Validity is checked
+    with ``is_valid_number``, which rejects them; such a pair still scores
+    ``1.0`` against itself, but as a string match rather than a number match.
+    The score is the same and the claim behind it is honest.
 
-    This also rejects the number most documentation reaches for.
-    ``"555-123-4567"`` puts **555 in the area-code position**, and 555 is not a
-    real area code -- NANP has never assigned it, which is exactly why writers
-    use it. libphonenumber is correct to call it invalid.
+    This also makes the number most documentation reaches for unusable *as a
+    number*. ``"555-123-4567"`` puts **555 in the area-code position**, and 555
+    is not a real area code -- NANP has never assigned it, which is exactly why
+    writers use it. libphonenumber is correct to call it invalid, so it is
+    compared as a string (see below) rather than dialed.
 
     What *is* usable for fixtures is a real area code with the ``555``
     **exchange**: ``"206-555-0100"`` is fictional by long-standing convention
@@ -46,12 +49,23 @@ class PhoneComparator(BaseComparator):
     enforce the 01xx line range -- ``"206-555-1234"`` validates too -- so the
     convention is yours to keep, not something the library checks.
 
-    Unparseable or invalid input scores ``0.0``, including when both sides are
-    identical. ``"N/A"`` on both sides is not a phone number that matched, it is
-    a field that was not extracted, and reporting it as a true positive inflates
-    the metric. Genuinely absent values never reach here: the shared ``None``
-    policy in :class:`BaseComparator` resolves those first, and the comparison
-    layer treats ``None``/``""`` on both sides as a true negative.
+    When **neither** side is a usable number, the comparison falls back to
+    exact string equality. Two identical values are never reported as maximally
+    different: a UK national number read under ``region="US"``, an extension
+    fragment such as ``"ext 4021"``, and any 555-area-code documentation number
+    are all unusable *as numbers* here while being perfectly extracted, and
+    scoring those ``0.0`` deflates precision and recall with no signal why
+    (issue #258).
+
+    The fallback is equality, not leniency. ``"N/A"`` against ``"unknown"``
+    scores ``0.0``: two values that both failed to extract are not a match. And
+    when **exactly one** side is a usable number, the score is ``0.0`` -- one
+    side found a number and the other did not, which is a genuine extraction
+    mismatch and the signal this comparator exists to report.
+
+    Genuinely absent values never reach here: the shared ``None`` policy in
+    :class:`BaseComparator` resolves those first, and the comparison layer
+    treats ``None``/``""`` on both sides as a true negative before scoring.
 
     Example:
         ```python
@@ -59,8 +73,12 @@ class PhoneComparator(BaseComparator):
         comparator.compare("206-555-0100", "(206) 555-0100")     # 1.0
         comparator.compare("+1-206-555-0100", "2065550100")       # 1.0
         comparator.compare("206-555-0100", "206-555-0101")        # 0.0
-        comparator.compare("N/A", "N/A")                          # 0.0
-        comparator.compare("0000000000", "0000000000")            # 0.0 (not valid)
+
+        # Neither side is a usable number: string equality decides
+        comparator.compare("N/A", "N/A")                          # 1.0
+        comparator.compare("0000000000", "0000000000")            # 1.0 (as a string)
+        comparator.compare("N/A", "unknown")                      # 0.0 (not leniency)
+        comparator.compare("206-555-0100", "N/A")                 # 0.0 (one side real)
 
         # Extensions are significant: they reach a different person
         comparator.compare("+12065550100x89", "+12065550100x89")  # 1.0
@@ -157,15 +175,24 @@ class PhoneComparator(BaseComparator):
             str2: Second value, never None
 
         Returns:
-            1.0 if both are valid numbers with the same E164 form and the same
-            extension, 0.0 otherwise
+            1.0 if both sides are valid numbers with the same E164 form and the
+            same extension, or if neither side is a usable number and the two
+            values are identical strings. 0.0 otherwise -- including when
+            exactly one side is a usable number.
         """
         first = self._canonical(str1)
-        if first is None:
-            return 0.0
-
         second = self._canonical(str2)
-        if second is None:
+
+        # Neither side is a usable number. Fall back to string equality so two
+        # identical values are never reported as maximally different (#258): a
+        # UK national number under region="US", an extension fragment, and any
+        # 555-area-code example are all unparseable here yet correctly
+        # extracted. Equality, not leniency -- "N/A" vs "unknown" stays 0.0.
+        if first is None and second is None:
+            return 1.0 if str(str1) == str(str2) else 0.0
+
+        # Exactly one side is a real number: a genuine extraction mismatch.
+        if first is None or second is None:
             return 0.0
 
         return 1.0 if first == second else 0.0

--- a/tests/auto/test_risk_surface.py
+++ b/tests/auto/test_risk_surface.py
@@ -156,13 +156,12 @@ class TestIdentityInvariant:
             ("updated_by", str, "Jane Smith"),
             ("days_past_due", int, -5),
             ("fee_applied", bool, True),
-            # Real area code (206) with the fictional 555 exchange. "555" in the
-            # area-code position was never assigned by NANP, so PhoneComparator
-            # rejects such a number as invalid and scores it 0.0 even against
-            # itself -- deliberately, since a placeholder on both sides is not a
-            # successful extraction (#243 review). This case tests token/type
-            # conflict resolution rather than phone validity, so it uses a number
-            # that is structurally real.
+            # Real area code (206) with the fictional 555 exchange, so it is
+            # structurally valid and matches canonically. This case tests
+            # token/type conflict resolution rather than phone validity; values
+            # PhoneComparator cannot parse are covered by
+            # TestPhoneFieldsNeverDeflateTheMetric below, which pins that they
+            # too score 1.0 against themselves (#258).
             ("phone_num", str, "(206) 555-0100"),
             ("isbn13", str, "978-3-16-148410-0"),
             ("created", bool, True),
@@ -181,6 +180,70 @@ class TestIdentityInvariant:
             f"{field_name}: identical value {identical_value!r} scored "
             f"{result.field_scores[field_name]}"
         )
+
+
+class TestPhoneFieldsNeverDeflateTheMetric:
+    """A perfectly extracted phone field scores 1.0, whatever shape it has.
+
+    The `phone` name token routes every *phone*-named str field to
+    PhoneComparator(region="US") at threshold 1.0, and evaluate()/eval_for()
+    take no region or per-field override. So a comparator that scores identical
+    values 0.0 deflated precision and recall on any non-US or extension-bearing
+    corpus, with .explain() reporting the routing as a deliberate choice --
+    which made the cause harder to find rather than easier.
+
+    Unit tests on PhoneComparator alone would not have caught this: the defect
+    is the routing plus the comparator together.
+
+    See https://github.com/awslabs/stickler/issues/258
+    """
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "555-123-4567",  # 555 area code: never assigned, so invalid
+            "020 7183 8750",  # valid UK national format, read under region="US"
+            "ext 4021",  # invalid in every region
+            "+1-206-555-0100",  # valid, E164
+            "(206) 555-0100",  # valid, national format under region="US"
+        ],
+    )
+    def test_an_identical_phone_field_scores_one(self, value):
+        class C(BaseModel):
+            phone: Optional[str] = None
+
+        result = stickler.evaluate(C(phone=value), C(phone=value))
+
+        assert result.field_scores["phone"] == pytest.approx(1.0), (
+            f"identical phone {value!r} scored {result.field_scores['phone']}"
+        )
+
+    def test_the_phone_token_really_is_installing_phone_comparison(self):
+        """Guard the guard: if routing changed, the test above is vacuous.
+
+        It would then pass through ExactComparator, which also scores identical
+        values 1.0, and stop pinning anything about PhoneComparator.
+        """
+
+        class C(BaseModel):
+            phone: Optional[str] = None
+
+        assert "Phone" in stickler.eval_for(C).explain()["phone"]["comparator"]
+
+    def test_a_different_phone_still_does_not_match(self):
+        """The fallback is equality, so real mismatches are still reported."""
+
+        class C(BaseModel):
+            phone: Optional[str] = None
+
+        assert stickler.evaluate(
+            C(phone="206-555-0100"), C(phone="206-555-0101")
+        ).field_scores["phone"] == pytest.approx(0.0)
+
+        # One side extracted a number, the other did not.
+        assert stickler.evaluate(C(phone="206-555-0100"), C(phone="N/A")).field_scores[
+            "phone"
+        ] == pytest.approx(0.0)
 
 
 class TestWireContract:

--- a/tests/common/comparators/test_phone.py
+++ b/tests/common/comparators/test_phone.py
@@ -68,21 +68,75 @@ class TestRegion:
 
 
 class TestUnparseableInput:
-    """Sentinel strings are not phone numbers that matched.
+    """When neither side is a usable number, string equality decides.
+
+    This inverts what 0.7.0rc asserted. Rejecting *every* unparseable pair also
+    rejected values that were extracted perfectly -- a UK national number under
+    region="US", an extension fragment, a 555-area-code documentation number --
+    and reported two identical strings as maximally different, deflating
+    precision and recall with no signal why. The fallback is equality, so a
+    placeholder pair still never canonicalizes into a fake number match.
 
     Genuinely absent values never reach here -- BaseComparator resolves None
     first, and the comparison layer treats None/"" on both sides as a true
-    negative. What is left is extraction noise, and reporting it as a true
-    positive would inflate the metric.
+    negative.
+
+    See https://github.com/awslabs/stickler/issues/258
     """
 
     @pytest.mark.parametrize("value", ["N/A", "n/a", "unknown", "not a phone", "-", ""])
-    def test_identical_unparseable_values_do_not_match(self, value):
-        assert PhoneComparator().compare(value, value) == 0.0
+    def test_identical_unparseable_values_match(self, value):
+        assert PhoneComparator().compare(value, value) == 1.0
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "555-123-4567",  # 555 area code: never assigned, so invalid
+            "020 7183 8750",  # UK national format, read under region="US"
+            "ext 4021",  # not a number in any region
+        ],
+    )
+    def test_a_correctly_extracted_but_unusable_number_matches_itself(self, value):
+        """The three shapes issue #258 reported, each scored 0.0 before."""
+        assert PhoneComparator().compare(value, value) == 1.0
+
+    def test_different_unparseable_values_do_not_match(self):
+        """The fallback is equality, not leniency.
+
+        Two values that both failed to extract are not a match just because
+        neither is a phone number.
+        """
+        assert PhoneComparator().compare("N/A", "unknown") == 0.0
+        assert PhoneComparator().compare("ext 4021", "ext 4022") == 0.0
 
     def test_one_side_unparseable_does_not_match(self):
         assert PhoneComparator().compare("206-555-0100", "N/A") == 0.0
         assert PhoneComparator().compare("N/A", "206-555-0100") == 0.0
+
+    def test_one_side_unparseable_does_not_match_in_either_order(self):
+        """Both sides are canonicalized before branching.
+
+        The pre-#258 body returned early on the first side and never inspected
+        the second, so the two argument orders took different code paths.
+        """
+        phone = PhoneComparator()
+
+        for usable in ("206-555-0100", "+12065550100x89"):
+            for unusable in ("N/A", "020 7183 8750", ""):
+                assert phone.compare(usable, unusable) == 0.0
+                assert phone.compare(unusable, usable) == 0.0
+
+    def test_two_empty_strings_match(self):
+        """Recorded explicitly rather than left to fall out of the fallback.
+
+        `BaseComparator.compare` special-cases None but not "", so an empty
+        string reaches `_compare`. It scores 1.0 here, and end-to-end metrics
+        are unaffected either way: the comparison layer resolves
+        empty-on-both-sides as a true negative before scoring. A carve-out
+        would reintroduce the "two identical values score 0.0" branch this
+        change exists to remove.
+        """
+        assert PhoneComparator().compare("", "") == 1.0
 
     def test_a_valid_number_is_unaffected(self):
         assert PhoneComparator().compare("206-555-0100", "2065550100") == 1.0
@@ -151,18 +205,34 @@ class TestNonePolicyAndSerialization:
 class TestValidityNotJustParseability:
     """libphonenumber parses strings that are not real numbers.
 
-    `parse` accepts "0000000000" and formats it as E164, so a parse-only check
-    scores it 1.0 against itself -- a placeholder reported as a successful
-    extraction, inflating precision and recall in zero-config runs. Raised in
-    review of #243.
+    `parse` accepts "0000000000" and formats it as E164. Validity is still
+    checked with `is_valid_number`, so such a value is never treated as a
+    *number*: a placeholder pair matches itself as a string, via the #258
+    fallback, and a placeholder against a real number still scores 0.0. Raised
+    in review of #243.
     """
 
     @pytest.mark.parametrize(
         "sentinel",
         ["0000000000", "1234567", "1111111111", "5555555555", "999-999-9999"],
     )
-    def test_numeric_placeholders_do_not_match_themselves(self, sentinel):
-        assert PhoneComparator().compare(sentinel, sentinel) == 0.0
+    def test_numeric_placeholders_match_themselves_as_strings(self, sentinel):
+        """1.0 by string equality, not by canonicalizing into a fake E164.
+
+        The distinction is load-bearing rather than pedantic: it is why
+        `is_valid_number` stays. A parse-only check would score a placeholder
+        pair 1.0 as a canonical *phone match*, and would also match two
+        *different* placeholders that happen to canonicalize alike.
+        """
+        assert PhoneComparator().compare(sentinel, sentinel) == 1.0
+
+    def test_a_placeholder_against_a_real_number_still_fails(self):
+        """Validity still decides which side counts as a number."""
+        assert PhoneComparator().compare("0000000000", "206-555-0100") == 0.0
+        assert PhoneComparator().compare("206-555-0100", "0000000000") == 0.0
+
+    def test_two_different_placeholders_do_not_match(self):
+        assert PhoneComparator().compare("0000000000", "1111111111") == 0.0
 
     def test_those_sentinels_really_do_parse(self):
         """Guard the guard: if they stopped parsing, the test above is vacuous."""
@@ -177,7 +247,7 @@ class TestValidityNotJustParseability:
         # ...but is not a real number, which is what the guard checks.
         assert phonenumbers.is_valid_number(parsed) is False
 
-    def test_555_in_the_area_code_position_is_not_valid(self):
+    def test_555_in_the_area_code_position_is_not_a_dialable_number(self):
         """Why examples use 206-555-0100 rather than 555-123-4567.
 
         "555-123-4567" puts 555 where the area code goes, and 555 has never
@@ -186,11 +256,17 @@ class TestValidityNotJustParseability:
 
         A real area code with the 555 *exchange* is fictional by convention and
         structurally valid, so it is what fixtures should use.
+
+        Both self-compares score 1.0, by different routes: the valid number
+        matches canonically, the documentation number matches as a string
+        (#258). What the invalidity still buys is the line below -- 555-123-4567
+        never canonicalizes, so it cannot collide with a real number.
         """
         phone = PhoneComparator()
 
-        assert phone.compare("555-123-4567", "555-123-4567") == 0.0
+        assert phone.compare("555-123-4567", "555-123-4567") == 1.0
         assert phone.compare("206-555-0100", "206-555-0100") == 1.0
+        assert phone.compare("555-123-4567", "206-555-0100") == 0.0
 
 
 class TestExtensionsAreSignificant:


### PR DESCRIPTION
Closes #258. Second of six PRs clearing the 0.7.0 release-candidate review findings on #256. **This is the release blocker.**

## The defect

`PhoneComparator` returned `0.0` for two byte-identical values whenever neither side was a valid number under the configured region. Verified against the release candidate:

| value | self-compare on `dev` | on `main` (Exact) |
|---|---|---|
| `'555-123-4567'` | 0.0 | 1.0 |
| `'020 7183 8750'` | 0.0 | 1.0 |
| `'ext 4021'` | 0.0 | 1.0 |
| `'(206) 555-0100'` | 1.0 | 1.0 |

Reachable with zero configuration: the `phone` name token routes every `*phone*`-named `str` field to `PhoneComparator(region="US")` at threshold 1.0. `evaluate()` and `eval_for()` accept only `weight_hints` and `match_threshold`, so there was no region override to work around it — and no single region setting would fix a mixed-region corpus anyway (`region="US"` zeroes a valid UK number, `region="GB"` zeroes a valid US one, and `"ext 4021"` is invalid under every region). Meanwhile `explain()` reported the routing as a deliberate choice, which made the cause harder to find rather than easier.

## The fix

`_compare` now canonicalizes **both** sides before branching — the old body returned early on the first side and never inspected the second — and falls back to string equality when neither side is usable:

- both sides unusable → `1.0 if str(str1) == str(str2) else 0.0`
- exactly one side usable → `0.0` (one side found a number, the other did not)
- both usable → canonical comparison, unchanged

**The fallback is equality, not leniency.** `"N/A"` vs `"unknown"` is still `0.0`.

**Fixed in the comparator, not the token table.** Deleting the `phone` token rule would restore `main`'s behavior for the inferred path only and leave the trap for anyone constructing a `PhoneComparator` explicitly. The token rule's own motivation is sound and independently argued.

**`is_valid_number` stays.** Relaxing to parse-only would let `"0000000000"` canonicalize and report a placeholder pair as a *canonical phone match*. Under the fallback the same pair matches as a *string*: same score, honest claim.

**`compare("", "")` returns `1.0`** and is asserted in a named test rather than left implicit. `BaseComparator.compare` special-cases `None` but not `""`. End-to-end metrics are unaffected — the comparison layer resolves empty-on-both-sides as a true negative before scoring — and a carve-out would reintroduce the "two identical values score 0.0" branch this PR exists to remove.

## Retracting a documented position

The removed behavior was asserted by three passing tests, argued in a 12-line docstring passage, and defended in ~30 lines of the 0.7.0 CHANGELOG entry. All three are rewritten. The three tests are **inverted and renamed** to state the new contract — a test named for the behavior it asserts is the durable record that the reversal was deliberate rather than accidental.

The retraction is narrow: rejecting a *placeholder on both sides* was the goal, and the implementation achieved it by rejecting *every* unparseable pair, which also caught correctly extracted non-US numbers.

## Also fixed

`src/stickler/auto/README.md` line 86 read `email/url/zip/phone`→Exact, stale since #243 added `PhoneComparator` and split the postal rule out. Split into `email/url`→Exact, `zip/postal/postcode`→Exact (case-sensitive), `phone`→Phone@1.0. Added to the type-gate paragraph the limit this defect exposed: the gate tests the *declared type*, so `str` passes and it cannot catch a *value*-level parse failure — any token rule whose comparator can reject an individual value needs a same-value fallback of its own.

A comment in `tests/auto/test_risk_surface.py` that documented the old behavior as deliberate is corrected too.

## Verification

- Zero-config check prints `1.0` for all five reproduction values.
- `compare("N/A", "unknown") == 0.0`; `compare("206-555-0100", "N/A") == 0.0` in both orders; `compare("206-555-0100", "(206) 555-0100") == 1.0`; `compare("206-555-0100", "206-555-0101") == 0.0`; `PhoneComparator(region="GB").compare("+44 20 7183 8750", "02071838750") == 1.0`.
- `PhoneComparator(region="GB")` still round-trips through `to_stickler_config()` and `to_json_schema()`.
- `grep "including when both sides are identical"` and `grep "email/url/zip/phone"` both return nothing.
- `pytest tests/` — 1859 passed, 11 skipped. `ruff check` clean.

## Behavior change, visible to users

Fields routed to `PhoneComparator` that previously scored `0.0` on identical unparseable values now score `1.0`, so precision and recall move **up** for affected corpora. Nothing that previously scored `1.0` changes. 0.7.0 has not shipped, so no released behavior is affected.

Region plumbing on `evaluate()`/`eval_for()` is deferred to 0.8.0: it would widen the public API inside a release candidate and would not fix the reported cases on its own.