### PR TITLE
fix: reconcile LLMComparator availability across import paths (#259)

### DIFF
--- a/src/stickler/__init__.py
+++ b/src/stickler/__init__.py
@@ -69,10 +69,11 @@ def _dependency_available(name: str) -> bool:
 
 
 # `_HAS_LLM`/`LLM_AVAILABLE` mean "strands-agents is installed", which is what
-# gates __all__ and what tests/test_top_level_exports.py asserts. Note that the
-# MODULE stickler.comparators.llm imports fine without strands (it degrades to
-# STRANDS_AVAILABLE=False and raises at instantiation), so __getattr__ below
-# does not gate on this flag for LLMComparator; only __all__ does.
+# gates both __getattr__ below and __all__, and what
+# tests/test_top_level_exports.py asserts. The flag rather than a trial import
+# is the gate because the MODULE stickler.comparators.llm imports fine without
+# strands: it degrades to STRANDS_AVAILABLE=False and raises at instantiation,
+# so a successful import would prove nothing about availability.
 _HAS_LLM = _dependency_available("strands")
 _HAS_BERT = _dependency_available("evaluate")
 

--- a/src/stickler/comparators/__init__.py
+++ b/src/stickler/comparators/__init__.py
@@ -47,15 +47,16 @@ def _dependency_available(name: str) -> bool:
 
 
 # `_HAS_LLM`/`LLM_AVAILABLE` mean "strands-agents is installed", which is what
-# gates __all__ and what tests/test_top_level_exports.py asserts. Note that the
-# MODULE stickler.comparators.llm imports fine without strands (it degrades to
-# STRANDS_AVAILABLE=False and raises at instantiation), so __getattr__ below
-# does not gate on this flag for LLMComparator; only __all__ does.
+# gates both __getattr__ below and __all__, and what
+# tests/test_top_level_exports.py asserts. The flag rather than a trial import
+# is the gate because the MODULE stickler.comparators.llm imports fine without
+# strands: it degrades to STRANDS_AVAILABLE=False and raises at instantiation,
+# so a successful import would prove nothing about availability.
 LLM_AVAILABLE = _dependency_available("strands")
 BERT_AVAILABLE = _dependency_available("evaluate")
 
 _LAZY_COMPARATORS = {
-    "LLMComparator": ("stickler.comparators.llm", "llm", True),
+    "LLMComparator": ("stickler.comparators.llm", "llm", LLM_AVAILABLE),
     "BERTComparator": ("stickler.comparators.bert", "bert", BERT_AVAILABLE),
 }
 

--- a/tests/common/comparators/test_llm.py
+++ b/tests/common/comparators/test_llm.py
@@ -1,10 +1,13 @@
 """
 Tests for LLMComparator.
 
-Note: This test module mocks the strands-agents and botocore dependencies
-to allow tests to run without these optional packages installed. The mocking
-is done at module level using sys.modules before importing LLMComparator.
-This logic is located in the conftest.py file in this directory.
+Note: This test module runs without strands-agents or botocore installed. The
+conftest.py in this directory injects mocks into sys.modules via a fixture, so
+they are in place by the time a comparator is *instantiated* -- but not at
+import time, which is why LLMComparator is imported from its own module below
+rather than from the `stickler.comparators` namespace. That namespace only
+exposes the name when the `llm` extra is installed (#259); the module itself
+always imports, degrading to STRANDS_AVAILABLE=False.
 """
 
 import re
@@ -14,7 +17,8 @@ from unittest.mock import MagicMock, patch
 import jinja2
 import pytest
 
-from stickler.comparators import BaseComparator, LLMComparator
+from stickler.comparators import BaseComparator
+from stickler.comparators.llm import LLMComparator
 
 
 # Mock AWS exception classes to avoid botocore dependency in tests

--- a/tests/common/comparators/test_none_handling.py
+++ b/tests/common/comparators/test_none_handling.py
@@ -26,12 +26,19 @@ from stickler.comparators import (
     DateComparator,
     ExactComparator,
     LevenshteinComparator,
-    LLMComparator,
     NumericComparator,
     SemanticComparator,
     StructuredModelComparator,
 )
 from stickler.comparators.fuzzy import FuzzyComparator
+
+# Imported from its own module, not from `stickler.comparators`, because the
+# package namespace only exposes the name when the `llm` extra is installed
+# (#259). The module itself always imports, degrading to
+# STRANDS_AVAILABLE=False and raising at instantiation -- and instantiation
+# here goes through a mocked strands (see the fixture below), so the None
+# policy is testable without the extra.
+from stickler.comparators.llm import LLMComparator
 
 # Comparators needing more than a bare constructor get a factory. Everything
 # else is just the class, which is already a zero-argument callable.

--- a/tests/test_top_level_exports.py
+++ b/tests/test_top_level_exports.py
@@ -91,17 +91,22 @@ class TestAllConsistency:
         expectation from `stickler.comparators` instead, so adding a comparator
         to one namespace and not the other fails rather than passing quietly.
 
-        Scoped to eagerly imported comparators. `BERTComparator` and
-        `LLMComparator` come through the lazy `__getattr__` because they need
-        extras, and `TestOptionalGating` covers those.
+        Covers the lazily-imported comparators too. `BERTComparator` and
+        `LLMComparator` were exempted here, and the exemption was hiding #259:
+        `stickler.comparators` hardcoded `LLMComparator` as available while the
+        package root gated it on the strands probe, so without the extra the
+        subpackage resolved a name the root did not. Both `__dir__` hooks return
+        `globals() | __all__`, and `__getattr__` caches a resolved comparator
+        into `globals()`, so an unadvertised-but-resolvable name shows up here --
+        which is what makes the exemption's removal load-bearing rather than
+        cosmetic.
         """
         import stickler.comparators as comparators
 
         def comparator_names(namespace):
             return {n for n in dir(namespace) if n.endswith("Comparator")}
 
-        lazy = {"BERTComparator", "LLMComparator"}
-        missing = comparator_names(comparators) - comparator_names(stickler) - lazy
+        missing = comparator_names(comparators) - comparator_names(stickler)
 
         assert not missing, (
             f"in stickler.comparators but not at the top level: {sorted(missing)}. "
@@ -175,3 +180,74 @@ class TestOptionalGating:
 
         assert "LLMComparator" not in reloaded.__all__
         assert not hasattr(reloaded, "LLMComparator")
+
+    def test_both_import_paths_agree_when_strands_is_missing(self, monkeypatch):
+        """The two namespaces must give the same answer, not merely a safe one.
+
+        `stickler.comparators` hardcoded `LLMComparator` as available while the
+        package root gated it on the strands probe, so without the extra
+        `stickler.comparators.LLMComparator` resolved to a class that raised at
+        instantiation while `stickler.LLMComparator` raised AttributeError --
+        and neither `__all__` advertised it. Which import path worked was a
+        matter of luck (#259).
+
+        Absence is simulated with `sys.modules[name] = None`, the convention
+        `tests/common/comparators/conftest.py` establishes;
+        `_dependency_available()` treats an explicit None as blocked for exactly
+        this purpose.
+        """
+        monkeypatch.setitem(sys.modules, "strands", None)
+
+        for mod in [
+            k for k in sys.modules if k == "stickler" or k.startswith("stickler.")
+        ]:
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+
+        import stickler as root
+        import stickler.comparators as comparators
+
+        assert hasattr(root, "LLMComparator") == hasattr(
+            comparators, "LLMComparator"
+        ), "the two import paths disagree on whether LLMComparator exists"
+        assert not hasattr(comparators, "LLMComparator")
+
+        with pytest.raises(AttributeError):
+            comparators.LLMComparator
+        with pytest.raises(AttributeError):
+            root.LLMComparator
+
+        assert ("LLMComparator" in root.__all__) == (
+            "LLMComparator" in comparators.__all__
+        )
+        assert "LLMComparator" not in comparators.__all__
+
+    def test_both_import_paths_agree_when_strands_is_present(self):
+        """With the extra installed, both paths resolve to the same class."""
+        from stickler.comparators.llm import STRANDS_AVAILABLE
+
+        if not STRANDS_AVAILABLE:
+            pytest.skip("strands-agents is not installed")
+
+        import stickler.comparators as comparators
+
+        assert hasattr(stickler, "LLMComparator") == hasattr(
+            comparators, "LLMComparator"
+        )
+        assert stickler.LLMComparator is comparators.LLMComparator
+        assert ("LLMComparator" in stickler.__all__) == (
+            "LLMComparator" in comparators.__all__
+        )
+
+    def test_the_gate_is_the_flag_not_a_trial_import(self):
+        """Why availability is probed rather than tried.
+
+        `stickler.comparators.llm` imports fine without strands -- it degrades
+        to STRANDS_AVAILABLE=False and raises at instantiation -- so a
+        successful import proves nothing. This pins the premise both comments
+        rest on; if the module started failing to import, the gating rationale
+        would need rewriting.
+        """
+        module = importlib.import_module("stickler.comparators.llm")
+
+        assert hasattr(module, "LLMComparator")
+        assert hasattr(module, "STRANDS_AVAILABLE")


### PR DESCRIPTION
Closes #259. Third of six PRs clearing the 0.7.0 release-candidate review findings on #256.

## The divergence

Two parallel `_LAZY_COMPARATORS` tables disagreed:

```
src/stickler/__init__.py:84
    "LLMComparator": (".comparators.llm", "llm", _HAS_LLM)
src/stickler/comparators/__init__.py:58
    "LLMComparator": ("stickler.comparators.llm", "llm", True)   # hardcoded
```

Reproduced with `strands` absent, before this PR:

| expression | result |
|---|---|
| `hasattr(stickler, "LLMComparator")` | `False` |
| `hasattr(stickler.comparators, "LLMComparator")` | `True` |
| `"LLMComparator" in stickler.__all__` | `False` |
| `"LLMComparator" in stickler.comparators.__all__` | `False` |

So the subpackage resolved a name that was absent from its own `__all__`, and which import path worked was a matter of luck. Both files carried the *identical* comment justifying the lenient reading, so one comment was wrong either way.

## Direction: gate both (strict)

Three things in the code already took the strict reading and only the one hardcoded literal did not. `__all__` gates on the availability flag in **both** files, and the `__getattr__` docstring in `comparators/__init__.py` states its own intent as *"Raises AttributeError (not ImportError) for a missing extra, so `hasattr()` stays False exactly as the previous eager gating provided"* — which the hardcoded `True` defeated for `LLMComparator` specifically. Gating changes one literal; the lenient alternative would have changed three places.

## The comment

Both copies lose the final clause, *"so `__getattr__` below does not gate on this flag for LLMComparator; only `__all__` does"* — already false in `stickler/__init__.py`, and false in the subpackage after this change. What stays is the part a future reader needs: the `stickler.comparators.llm` **module** imports fine without strands, degrading to `STRANDS_AVAILABLE=False` and raising at instantiation, which is *why* a dependency probe rather than a trial import is the gate. A new test pins that premise.

## The test exemption was hiding the bug

`tests/test_top_level_exports.py` subtracted `lazy = {"BERTComparator", "LLMComparator"}` from its namespace-parity check. That exemption is **dropped entirely**, not narrowed. Both `__dir__` hooks return `globals() | __all__` and `__getattr__` caches a resolved comparator into `globals()`, so a resolvable-but-unadvertised name does surface in `dir()` — which is what makes removing it load-bearing rather than cosmetic.

New tests assert the two paths agree in both dependency states. Verified the parity test actually catches the defect: against the unfixed source it fails with *"the two import paths disagree on whether LLMComparator exists"*.

## Two test modules needed fixing

`tests/common/comparators/test_llm.py` and `test_none_handling.py` imported `LLMComparator` from the `stickler.comparators` namespace at module scope. That only ever worked because of the hardcoded `True`: the conftest injects its strands mock in a **fixture**, which runs after collection, so the mock is not in place at import time. `test_llm.py`'s module docstring claimed the mocking happened "at module level using sys.modules before importing LLMComparator", which was not what the conftest did.

Both now import from `stickler.comparators.llm` — the module that always imports — and instantiation still goes through the mock. Their comments record why.

## Verification

- With `strands` blocked, both paths raise `AttributeError` and neither `__all__` contains the name.
- `grep -rn "does not gate on this flag" src/` prints nothing.
- `pytest tests/test_top_level_exports.py` — 30 passed, 1 skipped (the strands-present case, correctly skipped here).
- `pytest tests/test_core_import_weight.py tests/test_lazy_import_allowlists.py` — strands and torch still off the import path.
- `pytest tests/` — 1846 passed, 12 skipped. `ruff check` clean.

## Behavior change

Without the `llm` extra, `stickler.comparators.LLMComparator` now raises `AttributeError` where it previously returned a class that raised at instantiation. The failure moves earlier and `hasattr()` becomes honest. With the extra installed, nothing changes.