### PR TITLE
fix: registry keeps a built-in pending when its import fails (#260)

### DIFF
--- a/src/stickler/structured_object_evaluator/models/comparator_registry.py
+++ b/src/stickler/structured_object_evaluator/models/comparator_registry.py
@@ -90,8 +90,12 @@ class ComparatorRegistry:
         A dependency that is installed but broken (a version-skewed transitive
         dep raising plain ImportError) is treated as unavailable rather than
         propagating, matching the previous try/except behavior.
+
+        A failed import leaves the name in ``_pending``, so a later call retries
+        and nothing the registry reports changes as a side effect of the
+        failure. The entry is consumed only once the class is in hand.
         """
-        spec = self._pending.pop(name, None)
+        spec = self._pending.get(name)
         if spec is None:
             return None
         module_path, _, _ = spec
@@ -104,8 +108,15 @@ class ComparatorRegistry:
             # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
             module = importlib.import_module(module_path)
         except ImportError:
+            # Leave the entry in `_pending`. A broken extra is unavailable now,
+            # but the name is still a built-in, so `is_registered()` and
+            # `list_available()` must not change as a side effect of a failed
+            # lookup, and `register()` -- which rejects a name only when it is
+            # in `_registry` or `_pending` -- must keep rejecting it rather than
+            # letting a caller silently shadow a built-in (#260).
             return None
         comparator_class = getattr(module, name)
+        self._pending.pop(name, None)
         self._registry[name] = comparator_class
         return comparator_class
 

--- a/tests/structured_object_evaluator/test_comparator_registry.py
+++ b/tests/structured_object_evaluator/test_comparator_registry.py
@@ -15,7 +15,13 @@ the canonical name without requiring the heavy extra in the default test env.
 
 from __future__ import annotations
 
+import importlib
+
+import pytest
+
+from stickler.comparators.base import BaseComparator
 from stickler.structured_object_evaluator.models.comparator_registry import (
+    ComparatorRegistry,
     get_comparator_class,
     get_global_registry,
 )
@@ -57,3 +63,162 @@ class TestBERTRegistryNaming:
         else:
             assert not registry.is_registered("BERTComparator")
             assert not registry.is_registered("BertComparator")
+
+
+class TestAFailedImportLeavesTheBuiltinRegistered:
+    """A failed lookup must not deregister a built-in.
+
+    ``_resolve`` used to pop the pending entry *before* attempting the import,
+    so an ``ImportError`` returned None with the entry already gone. A
+    broken-but-installed extra -- a version-skewed transitive dependency
+    raising plain ImportError, which is exactly the case the method docstring
+    says it handles -- was deregistered permanently by the first failed lookup.
+
+    Nothing about a failed import means the name stopped being a built-in, so
+    these pin that the registry's reported state does not depend on prior call
+    history.
+
+    See https://github.com/awslabs/stickler/issues/260
+    """
+
+    # A built-in with no optional extra, so the failure under test comes from
+    # the patched import rather than from a missing dependency.
+    NAME = "LevenshteinComparator"
+
+    @pytest.fixture
+    def registry_with_a_broken_builtin(self, monkeypatch):
+        """A fresh registry whose NAME built-in cannot be imported."""
+        registry = ComparatorRegistry()
+        module_path = ComparatorRegistry._BUILTINS[self.NAME][0]
+
+        def explode(name, *args, **kwargs):
+            if name == module_path:
+                raise ImportError(f"simulated broken extra: {name}")
+            return importlib.import_module(name)
+
+        monkeypatch.setattr(
+            "stickler.structured_object_evaluator.models."
+            "comparator_registry.importlib.import_module",
+            explode,
+        )
+
+        # Guard the guard: the patch must actually break this lookup, or every
+        # assertion below is vacuous.
+        with pytest.raises(KeyError):
+            registry.get(self.NAME)
+
+        return registry
+
+    def test_is_registered_is_unchanged_by_a_failed_get(self, monkeypatch):
+        registry = ComparatorRegistry()
+        module_path = ComparatorRegistry._BUILTINS[self.NAME][0]
+
+        before = registry.is_registered(self.NAME)
+        assert before is True
+
+        monkeypatch.setattr(
+            "stickler.structured_object_evaluator.models."
+            "comparator_registry.importlib.import_module",
+            lambda name, *a, **k: (_ for _ in ()).throw(ImportError(name)),
+        )
+        with pytest.raises(KeyError):
+            registry.get(self.NAME)
+
+        assert registry.is_registered(self.NAME) == before, (
+            f"{self.NAME} was deregistered by a failed lookup"
+        )
+        assert module_path  # the name really does have a module to import
+
+    def test_list_available_is_unchanged_by_a_failed_get(self, monkeypatch):
+        registry = ComparatorRegistry()
+        before = sorted(registry.list_available())
+
+        monkeypatch.setattr(
+            "stickler.structured_object_evaluator.models."
+            "comparator_registry.importlib.import_module",
+            lambda name, *a, **k: (_ for _ in ()).throw(ImportError(name)),
+        )
+        with pytest.raises(KeyError):
+            registry.get(self.NAME)
+
+        assert sorted(registry.list_available()) == before, (
+            "list_available() shrank as a side effect of a failed lookup"
+        )
+
+    def test_two_failed_gets_behave_identically(self, registry_with_a_broken_builtin):
+        """The second call must not take a different path from the first."""
+        registry = registry_with_a_broken_builtin
+
+        with pytest.raises(KeyError) as first:
+            registry.get(self.NAME)
+        with pytest.raises(KeyError) as second:
+            registry.get(self.NAME)
+
+        assert str(first.value) == str(second.value)
+
+    def test_a_broken_extra_raises_keyerror_not_importerror(
+        self, registry_with_a_broken_builtin
+    ):
+        """The unavailable-not-propagated contract, pinned alongside the fix.
+
+        Only the bookkeeping changed; a broken extra is still reported as an
+        absent comparator rather than surfacing the raw ImportError.
+        """
+        with pytest.raises(KeyError):
+            registry_with_a_broken_builtin.get(self.NAME)
+
+    def test_the_name_stays_reserved_against_registration(
+        self, registry_with_a_broken_builtin
+    ):
+        """The quietest consequence: a failed resolve freed the name.
+
+        ``register`` rejects a name only when it is in ``_registry`` or
+        ``_pending``, so popping the entry early let a caller silently shadow a
+        built-in.
+        """
+
+        class Custom(BaseComparator):
+            def _compare(self, a, b):
+                return 1.0
+
+        with pytest.raises(ValueError, match="already registered"):
+            registry_with_a_broken_builtin.register(self.NAME, Custom)
+
+
+class TestASuccessfulResolveStillCachesOnce:
+    """The fix must not break the path that was working."""
+
+    NAME = "ExactComparator"
+
+    def test_the_entry_moves_from_pending_to_registry(self):
+        registry = ComparatorRegistry()
+
+        assert self.NAME in registry._pending
+        assert self.NAME not in registry._registry
+
+        resolved = registry.get(self.NAME)
+
+        assert self.NAME not in registry._pending
+        assert registry._registry[self.NAME] is resolved
+
+    def test_a_second_get_returns_the_cached_class(self):
+        registry = ComparatorRegistry()
+
+        assert registry.get(self.NAME) is registry.get(self.NAME)
+
+    def test_the_name_is_listed_exactly_once_after_resolving(self):
+        """`list_available` concatenates `_registry` and `_pending` keys.
+
+        Reading without popping would list a resolved comparator twice.
+        """
+        registry = ComparatorRegistry()
+        registry.get(self.NAME)
+
+        assert registry.list_available().count(self.NAME) == 1
+
+    def test_is_registered_holds_before_and_after(self):
+        registry = ComparatorRegistry()
+
+        assert registry.is_registered(self.NAME)
+        registry.get(self.NAME)
+        assert registry.is_registered(self.NAME)


### PR DESCRIPTION
Closes #260. Fourth of six PRs clearing the 0.7.0 release-candidate review findings on #256.

## The defect

`ComparatorRegistry._resolve` popped the pending entry **before** attempting the import:

```python
spec = self._pending.pop(name, None)     # <-- entry gone here
if spec is None:
    return None
module_path, _, _ = spec
try:
    module = importlib.import_module(module_path)
except ImportError:
    return None                          # <-- ...and never comes back
```

A broken-but-installed extra — a version-skewed transitive dependency raising plain `ImportError`, which is exactly the case the method's own docstring says it handles — was deregistered permanently by the first failed lookup.

Four observable consequences:

| behavior | before | after |
|---|---|---|
| `is_registered(name)` before first `get()` | `True` | `True` |
| `is_registered(name)` after a failed `get()` | `False` | `True` |
| `list_available()` across a failed `get()` | shrinks | unchanged |
| `register(name, Custom)` after a failed resolve | silently succeeds | raises `ValueError` |

That last one is the quietest and the worst: `register()` rejects a name only when it is in `_registry` or `_pending`, so a failed resolve freed the built-in's name and let a caller silently shadow a built-in.

The registry is a module-level singleton, so one caller's failed lookup could change what an unrelated later caller saw in the same process. Nothing about a failed import means the name stopped being a built-in.

## The fix

`_resolve` reads the entry non-destructively and pops it only after the import returns and the class is in hand. The `except ImportError` branch carries a comment naming what the entry is protecting.

**`except ImportError: return None` is kept.** Treating a broken extra as unavailable rather than propagating is deliberate and documented, and a new test pins that `KeyError` — not `ImportError` — still reaches the caller. Only the bookkeeping changed.

## Tests

Three of the new tests **fail against the unpatched `_resolve`**, so they pin the defect rather than the implementation. The fixture guards itself: it asserts the patched import really does break the lookup, so the assertions cannot pass vacuously.

The successful path is covered too — the fix must not break what was working:

- the entry still moves out of `_pending` into `_registry`;
- a second `get()` returns the identical cached class;
- the name is listed **exactly once** afterwards. `list_available()` concatenates `_registry` and `_pending` keys, so reading without popping would have listed a resolved comparator twice. That is the failure mode this reordering could plausibly have introduced.

The test uses `LevenshteinComparator` — a built-in with no optional extra — so the failure under test comes from the patched import rather than from a genuinely missing dependency.

## Verification

- `pytest tests/structured_object_evaluator/test_comparator_registry.py` — 11 passed.
- `pytest tests/test_lazy_import_allowlists.py` — still green; `_resolve` is one of the three allowlisted-import sites that file guards, and the `nosemgrep` suppression's claim (an unregistered name misses `_pending` and returns `None` before reaching `import_module`) stays true with `get()`.
- `pytest tests/` — 1853 passed, 11 skipped. `ruff check` clean.

No API surface change. The only difference is that previously-lost state now survives, making `is_registered()`, `list_available()` and `register()` independent of call history.