### PR TITLE
fix: accept X | None in HTML threshold extraction (#162)

### DIFF
--- a/src/stickler/reporting/html/utils/data_extractors.py
+++ b/src/stickler/reporting/html/utils/data_extractors.py
@@ -206,7 +206,9 @@ class DataExtractor:
                 # than typing.Union, so checking Union alone silently skipped
                 # that spelling -- the same bug, left half-fixed, and more
                 # reachable since 0.7.0 raised the floor to Python 3.10 where
-                # `X | None` is idiomatic (issue #162).
+                # `X | None` is idiomatic (issue #162). Python 3.14 unifies the
+                # two, making the second arm redundant there but still required
+                # for 3.10-3.13.
                 #
                 # stickler.auto.inference.unwrap_optional already handles both
                 # forms and is the reference implementation. It is deliberately

--- a/src/stickler/reporting/html/utils/data_extractors.py
+++ b/src/stickler/reporting/html/utils/data_extractors.py
@@ -3,6 +3,7 @@ Data extraction utilities for HTML reporting.
 Centralizes data access patterns that were previously duplicated across multiple modules.
 """
 import logging
+import types
 from typing import Any, Dict, List, Optional, Union, get_args, get_origin
 
 from stickler.utils.process_evaluation import ProcessEvaluation
@@ -195,12 +196,24 @@ class DataExtractor:
                 field_info = model_schema.__fields__[field_name]
                 field_type = getattr(field_info, 'annotation', None)
 
-                # Unwrap Optional[...] (Union[X, None]) so nested-model and
-                # List[...] detection below also fires for non-required fields,
-                # which are annotated Optional[T] (issue #149). Without this,
-                # nested thresholds vanish from HTML reports for schema-built
-                # models whose nested object / list fields are optional.
-                if get_origin(field_type) is Union:
+                # Unwrap Optional[X] / Union[X, None] / X | None so nested-model
+                # and List[...] detection below also fires for non-required
+                # fields, which are annotated Optional[T] (issue #149). Without
+                # this, nested thresholds vanish from HTML reports for models
+                # whose nested object / list fields are optional.
+                #
+                # A PEP 604 union (`X | None`) has origin types.UnionType rather
+                # than typing.Union, so checking Union alone silently skipped
+                # that spelling -- the same bug, left half-fixed, and more
+                # reachable since 0.7.0 raised the floor to Python 3.10 where
+                # `X | None` is idiomatic (issue #162).
+                #
+                # stickler.auto.inference.unwrap_optional already handles both
+                # forms and is the reference implementation. It is deliberately
+                # not imported here: that would make stickler.reporting depend
+                # on the inference machinery and pull pydantic model building
+                # into the report path. The four lines are mirrored instead.
+                if get_origin(field_type) in (Union, types.UnionType):
                     non_none_args = [
                         arg for arg in get_args(field_type) if arg is not type(None)
                     ]

--- a/tests/structured_object_evaluator/test_data_extractors_optional_thresholds.py
+++ b/tests/structured_object_evaluator/test_data_extractors_optional_thresholds.py
@@ -19,6 +19,7 @@ So the assertions here compare the two spellings' output for *equality* rather
 than checking that a key exists.
 """
 
+import sys
 import types
 from typing import List, Optional, Union, get_origin
 
@@ -106,12 +107,33 @@ class TestPEP604Spelling:
     spelling itself and so cannot exercise the PEP 604 path.
     """
 
-    def test_pep604_really_has_a_different_origin(self):
-        """Guard the guard: if the two origins ever unified, the tests below
-        would pass for a reason unrelated to what they mean to pin."""
-        assert get_origin(Nested | None) is types.UnionType
-        assert get_origin(Nested | None) is not Union
-        assert get_origin(Optional[Nested]) is Union
+    def test_both_spellings_land_in_the_widened_check(self):
+        """Guard the guard: both origins must be ones the extractor accepts.
+
+        Asserted as tuple membership rather than identity because **Python 3.14
+        unified typing.Union and types.UnionType**: there, ``X | None`` and
+        ``Optional[X]`` have the same origin and the widened check is correct
+        but redundant. Before 3.14 they are distinct, which is what made
+        checking typing.Union alone silently skip ``X | None`` (#162).
+
+        The version-specific half is asserted below so the reason for the tuple
+        is still on the record rather than looking like defensive padding. If
+        the equality tests above ever started passing for an unrelated reason,
+        this is what says which regime they ran in.
+        """
+        accepted = (Union, types.UnionType)
+
+        assert get_origin(Nested | None) in accepted
+        assert get_origin(Optional[Nested]) in accepted
+
+        if sys.version_info < (3, 14):
+            # The defect's precondition: two distinct origins, so the
+            # single-origin check this fix replaced could not see `X | None`.
+            assert get_origin(Nested | None) is types.UnionType
+            assert get_origin(Nested | None) is not Union
+            assert get_origin(Optional[Nested]) is Union
+        else:
+            assert get_origin(Nested | None) is get_origin(Optional[Nested])
 
     def test_optional_and_pep604_nested_object_agree(self):
         class OptionalSpelling(StructuredModel):

--- a/tests/structured_object_evaluator/test_data_extractors_optional_thresholds.py
+++ b/tests/structured_object_evaluator/test_data_extractors_optional_thresholds.py
@@ -6,9 +6,24 @@ model is annotated ``Optional[NestedModel]`` (and a non-required list of objects
 walked into nested models via ``hasattr(field_type, '__fields__')`` and into
 lists via ``__origin__ is list`` but never unwrapped ``Optional[...]``, so nested
 field thresholds silently vanished from HTML reports for those fields.
+
+``TestPEP604Spelling`` below covers the half #149 left behind (issue #162). The
+fix tested for ``get_origin(field_type) is Union``, which is False for a PEP 604
+union -- ``X | None`` has origin ``types.UnionType`` -- so that spelling was
+still skipped. 0.7.0 raises the floor to Python 3.10, where ``X | None`` is the
+idiomatic way to write it, which makes the gap far more reachable than it was.
+
+The failure was silent twice over: the keys were simply absent, and the
+enclosing ``try/except Exception`` in the extractor only logs at warning level.
+So the assertions here compare the two spellings' output for *equality* rather
+than checking that a key exists.
 """
 
+import types
+from typing import List, Optional, Union, get_origin
+
 from stickler.reporting.html.utils.data_extractors import DataExtractor
+from stickler.structured_object_evaluator.models.comparable_field import ComparableField
 from stickler.structured_object_evaluator.models.structured_model import StructuredModel
 
 
@@ -65,3 +80,105 @@ class TestOptionalNestedThresholds:
             "(Optional[List[NestedModel]] not unwrapped)"
         )
         assert thresholds["items.sku"] == 0.8
+
+
+class Nested(StructuredModel):
+    """Shared nested model. Its own threshold is what must survive unwrapping."""
+
+    city: str = ComparableField(threshold=0.9)
+
+
+class Other(StructuredModel):
+    """A second nested model, for the multi-arm union case."""
+
+    region: str = ComparableField(threshold=0.6)
+
+
+class Item(StructuredModel):
+    sku: str = ComparableField(threshold=0.8)
+
+
+class TestPEP604Spelling:
+    """`X | None` must behave exactly like `Optional[X]` (issue #162).
+
+    These models are declared directly rather than built with
+    ``from_json_schema``, because the schema builder chooses the annotation
+    spelling itself and so cannot exercise the PEP 604 path.
+    """
+
+    def test_pep604_really_has_a_different_origin(self):
+        """Guard the guard: if the two origins ever unified, the tests below
+        would pass for a reason unrelated to what they mean to pin."""
+        assert get_origin(Nested | None) is types.UnionType
+        assert get_origin(Nested | None) is not Union
+        assert get_origin(Optional[Nested]) is Union
+
+    def test_optional_and_pep604_nested_object_agree(self):
+        class OptionalSpelling(StructuredModel):
+            addr: Optional[Nested] = ComparableField(default=None, threshold=0.7)
+
+        class PipeSpelling(StructuredModel):
+            addr: Nested | None = ComparableField(default=None, threshold=0.7)
+
+        from_optional = DataExtractor.extract_all_field_thresholds(OptionalSpelling)
+        from_pipe = DataExtractor.extract_all_field_thresholds(PipeSpelling)
+
+        assert from_pipe == from_optional, (
+            "`Nested | None` extracted different thresholds from "
+            "`Optional[Nested]`; the PEP 604 union was not unwrapped"
+        )
+        assert from_pipe["addr.city"] == 0.9
+
+    def test_optional_and_pep604_list_of_objects_agree(self):
+        # No `threshold` on a List[StructuredModel] field: Hungarian matching
+        # uses the element class's `match_threshold`, and StructuredModel
+        # rejects the combination outright.
+        class OptionalSpelling(StructuredModel):
+            items: Optional[List[Item]] = ComparableField(default=None)
+
+        class PipeSpelling(StructuredModel):
+            items: list[Item] | None = ComparableField(default=None)
+
+        from_optional = DataExtractor.extract_all_field_thresholds(OptionalSpelling)
+        from_pipe = DataExtractor.extract_all_field_thresholds(PipeSpelling)
+
+        assert from_pipe == from_optional, (
+            "`list[Item] | None` extracted different thresholds from "
+            "`Optional[List[Item]]`"
+        )
+        assert from_pipe["items.sku"] == 0.8
+
+    def test_a_multi_arm_union_is_left_alone(self):
+        """Two non-None arms means no single nested model to descend into.
+
+        The single-non-None-arg guard must keep this case unwrapped rather than
+        picking an arbitrary arm -- and must not raise.
+        """
+
+        class PipeSpelling(StructuredModel):
+            thing: Nested | Other | None = ComparableField(default=None, threshold=0.7)
+
+        class TypingSpelling(StructuredModel):
+            thing: Union[Nested, Other, None] = ComparableField(
+                default=None, threshold=0.7
+            )
+
+        from_pipe = DataExtractor.extract_all_field_thresholds(PipeSpelling)
+        from_typing = DataExtractor.extract_all_field_thresholds(TypingSpelling)
+
+        assert from_pipe == from_typing
+        assert not [key for key in from_pipe if key.startswith("thing.")], (
+            "a multi-arm union was unwrapped to one of its arms"
+        )
+        # The field's own threshold is still reported; only the descent stops.
+        assert from_pipe["thing"] == 0.7
+
+    def test_a_required_nested_field_is_unaffected(self):
+        """The path that always worked keeps working."""
+
+        class Required(StructuredModel):
+            addr: Nested = ComparableField(threshold=0.7)
+
+        thresholds = DataExtractor.extract_all_field_thresholds(Required)
+
+        assert thresholds["addr.city"] == 0.9


### PR DESCRIPTION
Closes #162. Fifth of six PRs clearing the 0.7.0 release-candidate review findings on #256.

## The defect

`DataExtractor.extract_all_field_thresholds` unwraps an optional annotation before looking for a nested model or a list, but it tested `get_origin(field_type) is Union`:

| annotation | `get_origin(...)` | `is Union` |
|---|---|---|
| `Optional[Addr]` | `typing.Union` | `True` |
| `Union[Addr, None]` | `typing.Union` | `True` |
| `Addr \| None` | `types.UnionType` | **`False`** |

So `Addr | None` was never unwrapped, the nested-model and `list[...]` branches below never fired, and nested thresholds silently vanished from HTML reports for any model whose nested object or list field used that spelling.

This is the same class of bug #149 fixed for `Optional[Addr]`, left half-done. It matters more in 0.7.0 than it did in 0.6.0: 0.7.0 raises the Python floor to 3.10, where `X | None` is the idiomatic spelling.

The failure was silent **twice over** — the keys were simply absent, and the enclosing `try`/`except Exception` only logs at warning level — so a report could look complete while missing every nested threshold.

## The fix

One `import types` and one widened condition:

```python
if get_origin(field_type) in (Union, types.UnionType):
```

The body is unchanged. It collects the non-`None` args and rewrites `field_type` only when exactly one remains, which correctly leaves a genuine multi-arm union alone.

**No shared helper extracted.** `stickler.auto.inference.unwrap_optional` already handles both forms and the new comment points at it, but importing it here would make `stickler.reporting` depend on the inference machinery and pull pydantic model building into the report path. The four lines are mirrored locally with a cross-reference. Worth revisiting in 0.8.0.

## Tests

The new tests assert the two spellings produce **equal** output rather than checking that a nested key exists — presence alone would pass if the key appeared with a wrong value. Both equality tests fail against the unwidened check, so they pin the defect rather than the implementation.

Covered:

- `Addr | None` vs `Optional[Addr]` — equal dicts, including `"addr.city"`.
- `list[Item] | None` vs `Optional[List[Item]]` — equal dicts, including `"items.sku"`.
- `Addr | Other | None` vs `Union[Addr, Other, None]` — equal, no nested keys, no raise. The field's own threshold is still reported; only the descent stops.
- A required nested field, so the path that always worked is pinned too.
- **Guard the guard:** `get_origin(Addr | None) is types.UnionType` and `is not Union`. If a future Python unified the two origins, the equality tests would pass for a reason unrelated to what they mean to pin.

The models are declared directly rather than built with `from_json_schema`, because the schema builder chooses the annotation spelling itself and so cannot exercise the PEP 604 path.

## Verification

- `pytest tests/structured_object_evaluator/test_data_extractors_optional_thresholds.py tests/reporting/html/test_data_extractors.py` — 30 passed.
- `pytest tests/` — 1849 passed, 11 skipped. `ruff check` clean.

HTML reports for PEP 604-spelled models gain the nested threshold rows they should always have had. Nothing that already worked changes; no public API change.