### PR TITLE
fix: install phonenumberslite from the lockfile, and correct the #162 changelog note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -391,12 +391,15 @@ Each release links to full notes on the
 
 - HTML reports no longer drop nested thresholds for a field annotated
   `Addr | None`. Threshold extraction unwrapped `Optional[X]` and
-  `Union[X, None]` but tested only for the `typing.Union` origin, and a PEP 604
-  union's origin is `types.UnionType`, so that spelling was never unwrapped and
-  the nested-model and list branches never fired. The same class of bug fixed for
-  `Optional[X]` in 0.6.0, left half-done -- and far more reachable now that 0.7.0
-  raises the floor to Python 3.10, where `X | None` is the idiomatic spelling. A
-  genuine multi-arm union is still left alone
+  `Union[X, None]` but tested only for the `typing.Union` origin, and on Python
+  3.10 through 3.13 a PEP 604 union's origin is `types.UnionType` instead, so
+  that spelling was never unwrapped and the nested-model and list branches never
+  fired. (Python 3.14 unifies the two, which is why the widened check has an arm
+  that cannot fail there.) The `Optional[X]` and `X | None` spellings are both
+  handled as of this release; the second was missed when the first was fixed, and
+  is the more reachable of the two now that 0.7.0 raises the floor to Python
+  3.10 where `X | None` is idiomatic. A genuine multi-arm union is still left
+  alone
   ([#162](https://github.com/awslabs/stickler/issues/162))
 
 - Zero-config evaluation no longer scores formatting-only differences in

--- a/tests/test_core_import_weight.py
+++ b/tests/test_core_import_weight.py
@@ -18,10 +18,15 @@ default install breaks for users.
 
 import json
 import os
+import re
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
+
+# The repository root, for reading pyproject.toml and uv.lock as text.
+REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # Packages that must not be imported as a side effect of `import stickler`,
 # mapped to the extra that owns them.
@@ -177,3 +182,95 @@ def test_broken_extra_does_not_break_import(tmp_path):
         f"the error should name the owning extra so the user knows what to "
         f"fix, got: {detail}"
     )
+
+
+class TestTheLockfileInstallsEveryCoreDependency:
+    """`uv sync --frozen` must produce an environment where stickler imports.
+
+    The lockfile records a core dependency in three places: its own
+    ``[[package]]`` entry, ``[package.metadata].requires-dist``, and the resolved
+    ``dependencies`` array of the ``stickler-eval`` package. Only the third
+    decides what ``uv sync`` installs.
+
+    ``phonenumberslite`` was present in the first two and absent from the third,
+    so a bare ``uv sync --frozen`` produced an environment where
+    ``import stickler`` raised ``ModuleNotFoundError: No module named
+    'phonenumbers'`` -- a hard failure rather than a degraded extra, because
+    ``comparators/phone.py`` imports it at module scope and
+    ``comparators/__init__.py`` imports phone eagerly.
+
+    Nothing caught it. ``uv lock --check`` validates ``requires-dist`` against
+    ``pyproject.toml`` and never reads the resolved array. CI stayed green
+    because ``run_pytest.yaml`` syncs with ``--extra llm --extra bert``, which
+    happen to pull the package in transitively, so the one job that imports
+    stickler was the one job not exercising the gap. The published wheel was
+    unaffected either way: its metadata comes from ``pyproject.toml``.
+
+    The cost landed on contributors, who follow CONTRIBUTING.md's plain
+    ``uv sync`` and get an unimportable package.
+
+    This parses rather than runs ``uv``, so it needs no network and no uv binary.
+    """
+
+    @staticmethod
+    def _core_dependency_names():
+        """The `[project].dependencies` names from pyproject.toml."""
+        pyproject = REPO_ROOT / "pyproject.toml"
+        text = pyproject.read_text()
+        block = re.search(r"^dependencies = \[(.*?)^\]", text, re.MULTILINE | re.DOTALL)
+        assert block, "could not find [project].dependencies in pyproject.toml"
+        names = re.findall(r'^\s*"([A-Za-z0-9._-]+)', block.group(1), re.MULTILINE)
+        assert names, "parsed no dependency names out of pyproject.toml"
+        return {name.lower().replace("_", "-") for name in names}
+
+    @staticmethod
+    def _locked_dependency_names():
+        """Names in the resolved `dependencies` array of the stickler-eval package."""
+        lock = REPO_ROOT / "uv.lock"
+        text = lock.read_text()
+        package = re.search(
+            r'^\[\[package\]\]\nname = "stickler-eval"\n(.*?)^\[package\.',
+            text,
+            re.MULTILINE | re.DOTALL,
+        )
+        assert package, "could not find the stickler-eval package block in uv.lock"
+        block = re.search(
+            r"^dependencies = \[(.*?)^\]", package.group(1), re.MULTILINE | re.DOTALL
+        )
+        assert block, "stickler-eval has no resolved dependencies array in uv.lock"
+        names = re.findall(r'\{ name = "([A-Za-z0-9._-]+)"', block.group(1))
+        return {name.lower().replace("_", "-") for name in names}
+
+    def test_every_core_dependency_is_in_the_resolved_lock_array(self):
+        declared = self._core_dependency_names()
+        locked = self._locked_dependency_names()
+
+        missing = declared - locked
+
+        assert not missing, (
+            f"declared in pyproject.toml [project].dependencies but absent from "
+            f"uv.lock's resolved `dependencies` array for stickler-eval: "
+            f"{sorted(missing)}. `uv sync --frozen` will not install these, so a "
+            f"default contributor environment cannot import stickler. Add "
+            f'`{{ name = "<pkg>" }}` to that array; `uv lock --check` does not '
+            f"catch this because it only validates requires-dist."
+        )
+
+    def test_the_lock_does_not_claim_dependencies_the_project_dropped(self):
+        """The inverse: a removed dependency must not linger as an install.
+
+        Same array, opposite direction. A stale entry would silently keep
+        installing a package the project no longer declares, which is how a
+        dependency stays alive after its last import is deleted.
+        """
+        declared = self._core_dependency_names()
+        locked = self._locked_dependency_names()
+
+        extra = locked - declared
+
+        assert not extra, (
+            f"in uv.lock's resolved `dependencies` array for stickler-eval but "
+            f"not declared in pyproject.toml [project].dependencies: "
+            f"{sorted(extra)}. Either restore the declaration or drop the lock "
+            f"entry."
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -4014,6 +4014,7 @@ dependencies = [
     { name = "munkres" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "phonenumberslite" },
     { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "rapidfuzz" },


### PR DESCRIPTION
Two release-readiness fixes found while verifying 0.7.0 against #256. Neither affects the published wheel; both affect people working in the repo.

@vawsgit tagging you since these sit on top of #268 and #269, and the second one is a correction to a CHANGELOG entry you wrote. No fault in either case, as explained below.

## 1. `uv sync --frozen` produced an unimportable package

`uv.lock` recorded `phonenumberslite` in two of the three places that matter and missed the third:

| location | present |
|---|---|
| its own `[[package]]` entry | yes |
| `[package.metadata].requires-dist` | yes |
| the resolved `dependencies` array of `stickler-eval` | **no** |

Only the third decides what `uv sync` installs. Before this PR:

```
$ uv sync --frozen
$ python -c "import stickler"
ModuleNotFoundError: No module named 'phonenumbers'
```

A hard failure rather than a degraded extra, because `comparators/phone.py` imports `phonenumbers` at module scope and `comparators/__init__.py` imports phone eagerly.

**Why nothing caught it.** Three independent reasons, which is the interesting part:

- `uv lock --check` validates `requires-dist` against `pyproject.toml` and never reads the resolved array. It passes both before and after this change.
- `run_pytest.yaml` syncs with `--extra llm --extra bert`, and those extras pull `phonenumberslite` in transitively. So the one job that imports stickler was the one job not exercising the gap.
- `security.yaml` does run a bare `uv sync --frozen`, and is green only because it never imports the package.

**The published wheel was never affected.** Wheel metadata comes from `pyproject.toml`, and I confirmed the built artifact carries `Requires-Dist: phonenumberslite<10.0.0,>=8.13.0`. `pip install stickler-eval` has always been correct. `workflow.yml` runs only `uv build` with no sync, so the publish path could not have been affected either.

The cost landed on contributors, who follow CONTRIBUTING.md's plain `uv sync` and get a package that cannot be imported.

**Root cause is worth naming.** This is the hand-patching policy in `AGENTS.md` producing its predictable failure mode: whoever added `phonenumberslite` updated the package entry and the metadata and missed the array. The policy exists for a real reason (running `uv lock` in this repo rewrites `exclude-newer` and strips platform markers), so the answer is a test rather than a policy change, which is what this adds.

## 2. The #162 CHANGELOG entry claimed a fix shipped in 0.6.0

The entry said:

> The same class of bug fixed for `Optional[X]` in 0.6.0, left half-done

That fix never shipped:

```
$ git tag --contains 9032eed                          # (empty)
$ git merge-base --is-ancestor 9032eed origin/main    -> false
$ git merge-base --is-ancestor 9032eed v0.6.0         -> false
$ git tag --contains 174ca9d   # sanity: the v0.6.0 release commit
v0.6.0
```

Both spellings land in 0.7.0. This is worth correcting rather than leaving because a reader would upgrade to 0.6.0 expecting nested thresholds for optional fields and not get them, and the GitHub Release body is derived from this section.

The entry also stated a PEP 604 union's origin is `types.UnionType` unconditionally, which is false on 3.14 where the two are unified. You had this right in the source comment on #268; this brings the CHANGELOG to the same precision, since 0.7.0 claims 3.10 through 3.14.

## The test

`tests/test_core_import_weight.py` was already the right home: its module docstring describes this exact failure mode from the other direction ("the suite installs every extra, so the import still succeeds here while a default install breaks for users").

The new class compares `[project].dependencies` against the resolved lock array in **both** directions, so a missing entry and a stale leftover both fail. It parses the two files as text rather than shelling out to uv, so it needs no network and no uv binary.

Verified load-bearing: deleting the `{ name = "phonenumberslite" }` line fails it with

```
declared in pyproject.toml [project].dependencies but absent from uv.lock's
resolved `dependencies` array for stickler-eval: ['phonenumberslite'].
```

## Verification

- Full suite: **1896 passed, 2 skipped** (1894 before, plus the two new tests), run locally with the `bert` extra installed, which CI does not have.
- `uv lock --check`: passes, 168 packages, unchanged from before.
- Bare `uv sync --frozen --no-group dev`: now installs `phonenumberslite==9.0.36`, `import stickler` succeeds, and `PhoneComparator` returns 1.0 for both a reformatted number and an identical unparseable one (so #258's fix is intact in that environment).
- `ruff check`: passes. The one remaining `ruff format` diff in the file is a pre-existing line I did not touch.

## Not addressed here

`AGENTS.md`'s `uv.lock` paragraph is itself partly inaccurate: it says `uv lock` "rewrites `exclude-newer` to `0001-01-01` and strips platform markers from the CUDA and nvidia entries... restore both", but `exclude-newer` has no behavioural effect once `exclude-newer-span` is set (uv says so in its own inline comment), so restoring it matters only for the semgrep rule, and the marker stripping is broader than the CUDA and nvidia entries. Left alone deliberately: correcting it means running `uv lock` to re-measure, which is not something to do inside a release. Worth a follow-up issue.
