### PR TITLE
Fix/233 score source parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,88 @@ Each release links to full notes on the
 
 ## [Unreleased]
 
+### Fixed
+
+- `overall_score` and the confusion matrix no longer disagree about a field that
+  is absent on both sides. The two read different scores for the same object
+  pair: `overall_score` takes the threshold-corrected score, while object
+  classification against `match_threshold` takes the raw pairwise similarity.
+  The raw path tested absence with a bare `is None`, so it scored `[]` against
+  `None` on a list field, `""` against `None` on a string field, and two empty
+  lists against each other all as `0.0` -- while `ComparisonDispatcher` scored
+  every one of those as a true negative worth `1.0`.
+
+  The result was a pair reported as `overall_score == 1.0` and `fd == 1` at once:
+  a perfect match that is also a false discovery. Two **identical** objects were
+  enough to trigger it. Any `List[Model]` whose element model declares an
+  optional list or string field reaches this whenever that field is left absent
+  on both sides, which for a document-extraction schema is the common case, not
+  an edge one -- and the contradiction is invisible unless you read both numbers
+  together, so it silently deflated precision on object-level metrics.
+
+  Both readers now define absence the same way the dispatcher does, per field
+  kind: `None` and `[]` for a list field, `None` and `""` for everything else.
+  This is the rule the docs already
+  [documented](https://awslabs.github.io/stickler/Advanced/classification-logic/)
+  ([#233](https://github.com/awslabs/stickler/issues/233))
+
+- A field annotated `list`, `list | None`, or `Optional[list]` is now recognized
+  as a list field. `_is_list_field` tested `get_origin(...) is list`, which
+  matches only a *parameterized* spelling, so the three unparameterized ones
+  answered `False` while `List`, `list[str] | None`, and `Optional[List[str]]`
+  answered `True`. `list | None` is the incongruous case: it is a PEP 604
+  optional list, and `list[str] | None` was already handled.
+
+  An unrecognized spelling skips list null handling and falls into the primitive
+  null check, where `[]` is not "effectively null". Such a field scored `1.0`
+  when empty on both sides but recorded **no classification evidence at all** --
+  no TN, no TP, no row. Because the score was right, the missing count was easy
+  to miss; it understated `tn` and every metric derived from it. Comparing a
+  six-field model against itself with every field `[]` reported `tn == 3` where
+  the docs call for `6`.
+
+  Recognition is now spelling-independent within a union: bare and parameterized
+  members answer alike. Only the null and empty cases move -- a populated list
+  reached `PrimitiveListComparator` before and still does, and no raw score
+  changes.
+
+  Two spellings are still not list fields, both deliberately. `Any` holding a
+  list is not one, because inferring list-ness from a runtime value rather than
+  an annotation is a larger change than this. Neither is
+  `Optional[Annotated[list, ...]]`: pydantic strips `Annotated` when it wraps the
+  whole annotation but preserves it as a union member, and unwrapping it should
+  be made consistent across the other annotation readers rather than here alone
+
+### Changed
+
+- Object-level TP/FD counts move for schemas with fields that are absent on both
+  sides. An absent-on-both field now contributes a full `1.0` to the raw object
+  similarity that `HungarianHelper` classifies against `match_threshold`, so a
+  pair that disagrees on every value a user actually supplied can clear the
+  threshold on the strength of its absent fields alone. An object with two
+  empty-on-both lists and one wrong string scores `2/3`; with five, `5/6`. Pairs
+  that previously classified as FD can now classify as TP, and **precision can
+  rise** as a function of how many absent optional fields a schema declares.
+
+  This extends existing semantics rather than introducing them. A field left
+  `None` already behaved exactly this way -- only the `[]` and `""` spellings
+  were scored differently, which is precisely the inconsistency
+  [#233](https://github.com/awslabs/stickler/issues/233) is about. Making them
+  agree necessarily means `[]` and `""` adopt what `None` already did.
+
+  Field-level counts do not move: an absent-on-both field is still a TN rather
+  than a TP, and a field the prediction gets wrong is still reported as an FD in
+  both the field breakdown and the aggregate. Only the *object-level*
+  classification of the enclosing pair changes. Anyone diffing evaluation
+  reports across this upgrade should expect object-level precision to shift for
+  affected schemas.
+
+  Absence is not leniency: `""` did not become a wildcard. An absent value
+  against a populated one still scores `0.0`, as the dispatcher already scored
+  it. A custom comparator that scored `""` against a populated value above `0.0`
+  is now short-circuited to `0.0` on the raw path, matching what `compare_with`
+  already reported for that pair.
+
 ## [0.7.0] - 2026-08-18
 
 ### Added

--- a/src/stickler/structured_object_evaluator/models/comparison_helper.py
+++ b/src/stickler/structured_object_evaluator/models/comparison_helper.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List
 from stickler.comparators.base import BaseComparator
 
 from .hungarian_helper import HungarianHelper
+from .null_helper import NullHelper
 from .threshold_helper import ThresholdHelper
 
 
@@ -166,7 +167,15 @@ class ComparisonHelper:
         # CRITICAL FIX: Use threshold-applied scores for consistency with individual comparison
         # This ensures list comparison matches the same scoring logic as individual comparison
         if not matched_pairs:
-            overall_score = 0.0
+            # Two empty lists agree perfectly: there is nothing to find and
+            # nothing was found. Scoring that 0.0 made an object whose only
+            # field is an empty list compare as a total mismatch against an
+            # identical object, which then classified as a false discovery even
+            # though `compare_with` reported a perfect match. The dispatcher
+            # already treats both-empty as a true negative with score 1.0; this
+            # keeps the raw path in agreement with it.
+            # See https://github.com/awslabs/stickler/issues/233
+            overall_score = 1.0 if not gt_list and not pred_list else 0.0
         else:
             # Apply threshold to each similarity score (same logic as individual comparison)
             threshold_applied_similarities = []
@@ -225,6 +234,18 @@ class ComparisonHelper:
 
         # Get field value from self
         self_value = getattr(structured_model_instance, field_name)
+
+        # For list fields, None and [] both mean "no items" and so agree with
+        # each other. The dispatcher already scores a both-null list field as a
+        # true negative worth 1.0; without the same rule here the generic None
+        # check below scores `[]` against `None` as 0.0, and the object lands
+        # under `match_threshold` while `compare_with` calls it a perfect match.
+        # See https://github.com/awslabs/stickler/issues/233
+        if structured_model_instance._is_list_field(field_name):
+            self_is_null = NullHelper.is_effectively_null_for_lists(self_value)
+            other_is_null = NullHelper.is_effectively_null_for_lists(other_value)
+            if self_is_null or other_is_null:
+                return 1.0 if self_is_null and other_is_null else 0.0
 
         # Handle None values
         if self_value is None or other_value is None:

--- a/src/stickler/structured_object_evaluator/models/comparison_helper.py
+++ b/src/stickler/structured_object_evaluator/models/comparison_helper.py
@@ -37,8 +37,12 @@ class ComparisonHelper:
             - fp: Total false positives (fd + fa)
             - overall_score: Similarity score for backward compatibility
         """
-        # Empty lists are handled early on immediately.
-   
+        # Empty lists reach here and fall through to `unordered_list_metrics`,
+        # which scores two of them 1.0. `ComparisonDispatcher` short-circuits an
+        # absent list field before this function is called, but only for fields
+        # `_is_list_field` recognizes -- a list held in an `Any`-annotated field
+        # arrives here empty.
+
         # Use HungarianHelper for Hungarian matching operations
         hungarian_helper = HungarianHelper()
         from .structured_model import StructuredModel
@@ -235,21 +239,29 @@ class ComparisonHelper:
         # Get field value from self
         self_value = getattr(structured_model_instance, field_name)
 
-        # For list fields, None and [] both mean "no items" and so agree with
-        # each other. The dispatcher already scores a both-null list field as a
-        # true negative worth 1.0; without the same rule here the generic None
-        # check below scores `[]` against `None` as 0.0, and the object lands
-        # under `match_threshold` while `compare_with` calls it a perfect match.
+        # Read absence the same way `ComparisonDispatcher` does. It scores a
+        # field absent on both sides as a true negative worth 1.0 and a field
+        # absent on exactly one side as FN/FA worth 0.0 (STEP 3 for list fields,
+        # STEP 4 for everything else). Without the same rule here the two score
+        # readers disagree: `compare_with` reports a perfect match while the raw
+        # similarity lands under `match_threshold`, so the same pair is a perfect
+        # match and a false discovery at once.
+        #
+        # What counts as absent is per-kind, exactly as the dispatcher defines
+        # it: for a list field `None` and `[]` both mean "no items"; for
+        # everything else `None` and `""` both mean "no value". Both predicates
+        # treat `None` as absent, which is why this subsumes the bare `is None`
+        # check that used to stand here.
         # See https://github.com/awslabs/stickler/issues/233
         if structured_model_instance._is_list_field(field_name):
-            self_is_null = NullHelper.is_effectively_null_for_lists(self_value)
-            other_is_null = NullHelper.is_effectively_null_for_lists(other_value)
-            if self_is_null or other_is_null:
-                return 1.0 if self_is_null and other_is_null else 0.0
+            is_absent = NullHelper.is_effectively_null_for_lists
+        else:
+            is_absent = NullHelper.is_effectively_null_for_primitives
 
-        # Handle None values
-        if self_value is None or other_value is None:
-            return 1.0 if self_value == other_value else 0.0
+        self_is_null = is_absent(self_value)
+        other_is_null = is_absent(other_value)
+        if self_is_null or other_is_null:
+            return 1.0 if self_is_null and other_is_null else 0.0
 
         # Handle lists with special processing
         if isinstance(self_value, list) and isinstance(other_value, list):

--- a/src/stickler/structured_object_evaluator/models/primitive_list_comparator.py
+++ b/src/stickler/structured_object_evaluator/models/primitive_list_comparator.py
@@ -90,7 +90,10 @@ class PrimitiveListComparator:
         weight = info.weight
         threshold = info.threshold
 
-        # All code paths already check if the lists are empty
+        # Empty lists are not filtered out before this point. `ComparisonDispatcher`
+        # short-circuits an absent list field, but only for fields
+        # `_is_list_field` recognizes -- a list held in an `Any`-annotated field
+        # arrives here empty and is scored by `_compare_unordered_lists`.
 
         # For primitive lists, use the comparison logic from _compare_unordered_lists
         # which properly handles the threshold-based matching

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -165,6 +165,53 @@ def _strip_extra_fields_property(schema_obj: Dict[str, Any]) -> None:
         schema_obj["required"] = [r for r in required if r != _EXTRA_FIELDS_KEY]
 
 
+def _annotation_is_list(annotation: Any) -> bool:
+    """Check whether a type annotation denotes a list, parameterized or not.
+
+    Every spelling of a list annotation has to answer the same way, because the
+    answer decides whether a field gets list null semantics (``None`` and ``[]``
+    both meaning "no items") or primitive ones. A spelling that reads as
+    non-list records no TN when both sides are empty, so it silently drops
+    classification evidence rather than failing loudly.
+
+    Two traps make that easy to get wrong, and both are handled here:
+
+    - ``get_origin`` returns ``list`` only for a *parameterized* spelling, so
+      bare ``list`` needs an identity test alongside it. Without one, ``list``
+      and ``list | None`` read as non-list while ``list[str]`` and
+      ``list[str] | None`` read as lists. ``typing.List`` needs no special case
+      -- ``get_origin`` already normalizes it to ``list``.
+    - A PEP 604 union (``list | None``) reports ``types.UnionType`` as its
+      origin, not ``typing.Union``, so its arms are reached through
+      :func:`optional_annotation.union_args` -- the package's single source for
+      destructuring a union in every spelling -- rather than a hand-rolled
+      origin check.
+
+    Union members are recursed with the same two rules rather than a bare ``is
+    list``, so a bare and a parameterized member inside one union answer alike.
+    Depth needs no special handling: ``typing`` flattens nested unions, so
+    ``Optional[list[str] | None]`` is stored as ``Optional[list[str]]``.
+
+    One spelling is deliberately *not* covered: ``Optional[Annotated[list,
+    ...]]``. Pydantic strips ``Annotated`` when it wraps the whole annotation
+    (so ``Annotated[list, "m"]`` and ``Annotated[Optional[List[str]], "m"]`` both
+    arrive here already unwrapped) but preserves it as a union member, and this
+    does not unwrap it. Doing so should be consistent with the other annotation
+    readers -- ``_is_structured_field_type`` and the HTML report's threshold
+    extraction -- rather than fixed here alone.
+    """
+    if annotation is list:
+        return True
+
+    if get_origin(annotation) is list:
+        return True
+
+    # Any union arm being a list is enough, in every spelling. `union_args`
+    # is the package's single source for a union's non-None arms and returns
+    # `()` for a non-union, so this also bottoms out the recursion.
+    return any(_annotation_is_list(arg) for arg in union_args(annotation))
+
+
 class StructuredModel(BaseModel):
     """Base class for models with structured comparison capabilities.
 
@@ -936,23 +983,7 @@ class StructuredModel(BaseModel):
             return False
 
         field_type = field_info.annotation
-
-        # Use get_origin rather than reading `__origin__` directly: a PEP 604
-        # union (`list[T] | None`) has no `__origin__` attribute at all, so the
-        # old `hasattr` guard skipped it entirely and such a field was not
-        # recognised as a list.
-        origin = get_origin(field_type)
-        if origin is list or origin is List:
-            return True
-
-        # Optional[List[...]] case, in every spelling. Any arm being a list is
-        # enough, so a wider union like `Optional[List[str]] | Any` still counts.
-        for arg in union_args(field_type):
-            arg_origin = get_origin(arg)
-            if arg_origin is list or arg_origin is List:
-                return True
-
-        return False
+        return _annotation_is_list(field_type)
 
     def _handle_list_field_dispatch(
         self, gt_val: Any, pred_val: Any, weight: float

--- a/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
+++ b/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
@@ -17,6 +17,9 @@ from stickler.comparators.levenshtein import LevenshteinComparator
 from stickler.structured_object_evaluator.models.comparable_field import (
     ComparableField,
 )
+from stickler.structured_object_evaluator.models.comparison_helper import (
+    ComparisonHelper,
+)
 from stickler.structured_object_evaluator.models.structured_model import (
     StructuredModel,
 )
@@ -32,6 +35,15 @@ class LineItemsInfo(StructuredModel):
 
 class Invoice(StructuredModel):
     LineItems: Optional[List[LineItemsInfo]] | Any = ComparableField(weight=1.0)
+
+
+class Pep604LineItemsInfo(StructuredModel):
+    LineItemDays: list[str] | None = ComparableField(weight=1.0)
+    match_threshold = 1.0
+
+
+class Pep604Invoice(StructuredModel):
+    LineItems: list[Pep604LineItemsInfo] = ComparableField(weight=1.0)
 
 
 # ---------------------------------------------------------------------------
@@ -258,6 +270,22 @@ def test_empty_simple_list_within_structured_list():
     assert obj_metrics["tp"] + obj_metrics["fd"] + obj_metrics["tn"] == 1
 
 
+def test_raw_empty_lists_score_as_perfect_match():
+    """The raw unordered-list path agrees that two empty lists match."""
+    result = ComparisonHelper.compare_unordered_lists(
+        [], [], ExactComparator(), threshold=1.0
+    )
+
+    assert result == {
+        "tp": 0,
+        "fd": 0,
+        "fa": 0,
+        "fn": 0,
+        "fp": 0,
+        "overall_score": 1.0,
+    }
+
+
 @pytest.mark.parametrize("n_items", [1, 2, 3])
 def test_empty_simple_lists_are_true_positives_at_any_length(n_items):
     """Identical empty-list objects are TPs at n=1 and n>1 alike.
@@ -311,6 +339,25 @@ def test_absent_simple_list_agrees_across_score_readers(gt_days, pred_days):
     assert result["overall_score"] == 1.0
     assert obj_metrics["fd"] == 0
     assert obj_metrics["tp"] == 1
+
+
+@pytest.mark.parametrize("gt_days,pred_days", [([], None), (None, [])])
+def test_pep604_optional_absent_list_agrees_across_score_readers(gt_days, pred_days):
+    """PEP 604 optional lists use the same absent-list semantics."""
+    gt = Pep604Invoice(LineItems=[Pep604LineItemsInfo(LineItemDays=gt_days)])
+    pred = Pep604Invoice(LineItems=[Pep604LineItemsInfo(LineItemDays=pred_days)])
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    cm = result["confusion_matrix"]
+    object_metrics = _overall(cm, "LineItems")
+    field_metrics = _overall(cm, "LineItems", "LineItemDays")
+
+    assert result["overall_score"] == 1.0
+    assert object_metrics["tp"] == 1
+    assert object_metrics["fd"] == 0
+    assert field_metrics["tn"] == 1
+    assert field_metrics["fn"] == 0
+    assert field_metrics["fa"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
+++ b/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
@@ -10,6 +10,8 @@ See: https://github.com/awslabs/stickler/issues/33
 
 from typing import Any, List, Optional
 
+import pytest
+
 from stickler.comparators.exact import ExactComparator
 from stickler.comparators.levenshtein import LevenshteinComparator
 from stickler.structured_object_evaluator.models.comparable_field import (
@@ -223,19 +225,17 @@ def test_simple_list_alongside_primitive_field():
 
 
 def test_empty_simple_list_within_structured_list():
-    """Empty simple lists on both sides — the pair is assigned, not unmatched.
+    """Empty simple lists on both sides — the pair is a TP, not a false discovery.
 
-    This asserts only the #224 property: an assigned pair is not reported as
-    FN + FA. It deliberately does *not* pin how the pair is classified.
+    Regression test for GitHub issue #233.
 
-    An object whose only field is an empty list gets list-path similarity 0.0
-    even though the two objects are identical, which is a separate pre-existing
-    bug. That leaves the result internally contradictory here -- the comparison
-    reports ``overall_score == 1.0`` (a perfect match) while the pair scores
-    below ``match_threshold`` and so classifies as FD. Pinning ``fd == 1``
-    would cement that contradiction into the suite and have to be undone when
-    the similarity bug is fixed, at which point this pair should become a TP or
-    a list-level TN.
+    The two objects are identical, so ``overall_score`` is 1.0. The confusion
+    matrix used to read a different score for the same pair: an object whose
+    only field was an empty list scored 0.0 on the list path, landing below
+    ``match_threshold`` and classifying as FD. The same pair was therefore a
+    perfect match and a false discovery at once.
+
+    Also retains the #224 property: an assigned pair is not reported as FN + FA.
     """
     gt = Invoice(LineItems=[LineItemsInfo(LineItemDays=[])])
     pred = Invoice(LineItems=[LineItemsInfo(LineItemDays=[])])
@@ -243,12 +243,74 @@ def test_empty_simple_list_within_structured_list():
     result = gt.compare_with(pred, include_confusion_matrix=True)
     obj_metrics = _overall(result["confusion_matrix"], "LineItems")
 
+    # Identical objects are a perfect match.
+    assert result["overall_score"] == 1.0
+
+    # The pair is a true positive, and specifically not a false discovery.
+    assert obj_metrics["tp"] == 1
+    assert obj_metrics["fd"] == 0
+
     # The #224 property: the pair is assigned, so neither side is orphaned.
     assert obj_metrics["fn"] == 0
     assert obj_metrics["fa"] == 0
 
-    # Whichever way the pair is classified, it is counted exactly once.
+    # The pair is counted exactly once.
     assert obj_metrics["tp"] + obj_metrics["fd"] + obj_metrics["tn"] == 1
+
+
+@pytest.mark.parametrize("n_items", [1, 2, 3])
+def test_empty_simple_lists_are_true_positives_at_any_length(n_items):
+    """Identical empty-list objects are TPs at n=1 and n>1 alike.
+
+    Regression test for GitHub issue #233, which recorded the contradiction at
+    both lengths: ``overall_score=1.0`` with ``fd=1`` at n=1 and ``fd=2`` at
+    n=2. Parameterized because the 1-vs-1 case reaches Hungarian matching
+    differently from the multi-item case.
+    """
+    items = [LineItemsInfo(LineItemDays=[]) for _ in range(n_items)]
+    gt = Invoice(LineItems=list(items))
+    pred = Invoice(LineItems=list(items))
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    obj_metrics = _overall(result["confusion_matrix"], "LineItems")
+
+    assert result["overall_score"] == 1.0
+    assert obj_metrics["tp"] == n_items
+    assert obj_metrics["fd"] == 0
+    assert obj_metrics["fn"] == 0
+    assert obj_metrics["fa"] == 0
+
+
+@pytest.mark.parametrize(
+    "gt_days,pred_days",
+    [
+        ([], []),
+        (None, None),
+        ([], None),
+        (None, []),
+    ],
+)
+def test_absent_simple_list_agrees_across_score_readers(gt_days, pred_days):
+    """``overall_score`` and the confusion matrix agree on an absent list field.
+
+    Regression test for GitHub issue #233.
+
+    For a list field, ``None`` and ``[]`` both mean "no items", so every
+    combination of the two is a perfect match. ``overall_score`` read that from
+    the threshold-corrected score while the confusion matrix read the raw
+    similarity, and the raw path scored ``[]`` against ``None`` as 0.0 — so the
+    pair reported 1.0 and FD together. Both readers must now agree.
+    """
+    gt = Invoice(LineItems=[LineItemsInfo(LineItemDays=gt_days)])
+    pred = Invoice(LineItems=[LineItemsInfo(LineItemDays=pred_days)])
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    obj_metrics = _overall(result["confusion_matrix"], "LineItems")
+
+    # A perfect score cannot coexist with a false discovery.
+    assert result["overall_score"] == 1.0
+    assert obj_metrics["fd"] == 0
+    assert obj_metrics["tp"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
+++ b/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
@@ -12,6 +12,7 @@ from typing import Any, List, Optional
 
 import pytest
 
+from stickler.comparators.base import BaseComparator
 from stickler.comparators.exact import ExactComparator
 from stickler.comparators.levenshtein import LevenshteinComparator
 from stickler.structured_object_evaluator.models.comparable_field import (
@@ -44,6 +45,67 @@ class Pep604LineItemsInfo(StructuredModel):
 
 class Pep604Invoice(StructuredModel):
     LineItems: list[Pep604LineItemsInfo] = ComparableField(weight=1.0)
+
+
+class EveryListSpelling(StructuredModel):
+    """Every spelling of a list annotation. All must be recognized alike.
+
+    ``get_origin`` returns ``list`` only for a *parameterized* spelling, so the
+    three unparameterized ones here used to read as non-list -- including
+    ``list | None``, a PEP 604 optional list. See ``_annotation_is_list``.
+    """
+
+    bare: list = ComparableField(weight=1.0)
+    bare_pep604_optional: list | None = ComparableField(weight=1.0)
+    bare_optional: Optional[list] = ComparableField(weight=1.0)
+    bare_typing: List = ComparableField(weight=1.0)
+    param_pep604_optional: list[str] | None = ComparableField(weight=1.0)
+    param_optional: Optional[List[str]] = ComparableField(weight=1.0)
+
+
+LIST_SPELLINGS = (
+    "bare",
+    "bare_pep604_optional",
+    "bare_optional",
+    "bare_typing",
+    "param_pep604_optional",
+    "param_optional",
+)
+
+
+class UntypedListHolder(StructuredModel):
+    """An ``Any``-annotated field, which is deliberately *not* a list field."""
+
+    vals: Any = ComparableField(weight=1.0)
+
+
+class NoteLeaf(StructuredModel):
+    """A non-list field, for the primitive half of #233's parity rule."""
+
+    note: Optional[str] = ComparableField(weight=1.0)
+    match_threshold = 1.0
+
+
+class NoteContainer(StructuredModel):
+    items: List[NoteLeaf] = ComparableField(weight=1.0)
+
+
+class PartiallyWrongItem(StructuredModel):
+    """Two absent-on-both list fields and one field the prediction gets wrong.
+
+    ``match_threshold`` is low enough that the two agreeing empty fields alone
+    carry the pair over it — see
+    ``test_absent_list_fields_lift_a_disagreeing_pair_to_a_true_positive``.
+    """
+
+    a: Optional[List[str]] = ComparableField(weight=1.0)
+    b: Optional[List[str]] = ComparableField(weight=1.0)
+    c: str = ComparableField(comparator=ExactComparator(), threshold=1.0, weight=1.0)
+    match_threshold = 0.5
+
+
+class PartiallyWrongContainer(StructuredModel):
+    items: List[PartiallyWrongItem] = ComparableField(weight=1.0)
 
 
 # ---------------------------------------------------------------------------
@@ -86,6 +148,19 @@ def _overall(cm, *field_path):
         node = node["fields"][f]
     return {k: v for k, v in node["overall"].items()
             if k in ("tp", "fa", "fd", "fp", "tn", "fn")}
+
+
+class _NeverCalledComparator(BaseComparator):
+    """A comparator that fails the test if it is ever invoked.
+
+    Lets a test assert that a code path does not consult its comparator, rather
+    than leaving an unused argument that reads as significant.
+    """
+
+    def _compare(self, str1, str2) -> float:
+        raise AssertionError(
+            f"comparator must not be invoked on this path, got {str1!r}, {str2!r}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -271,9 +346,23 @@ def test_empty_simple_list_within_structured_list():
 
 
 def test_raw_empty_lists_score_as_perfect_match():
-    """The raw unordered-list path agrees that two empty lists match."""
+    """The raw unordered-list path agrees that two empty lists match.
+
+    Two empty lists take the *StructuredModel* branch of
+    ``compare_unordered_lists``, vacuously: that branch is guarded by
+    ``all(isinstance(item, StructuredModel) for item in gt_list[:1])`` on both
+    sides, and ``[][:1]`` is empty, so both ``all()`` calls are trivially true
+    however the lists are annotated. That branch hardcodes its own
+    ``classification_threshold`` of ``0.01`` and never reads ``comparator``.
+
+    So the comparator and ``threshold`` arguments below are inert, and the test
+    says so rather than implying they matter: the comparator is one that raises
+    if it is ever called, which turns the claim into an assertion instead of a
+    comment. ``threshold`` cannot be shown inert the same way -- with no matched
+    pairs the threshold loop never runs, so no value of it changes the result.
+    """
     result = ComparisonHelper.compare_unordered_lists(
-        [], [], ExactComparator(), threshold=1.0
+        [], [], _NeverCalledComparator(), threshold=1.0
     )
 
     assert result == {
@@ -284,6 +373,40 @@ def test_raw_empty_lists_score_as_perfect_match():
         "fp": 0,
         "overall_score": 1.0,
     }
+
+
+@pytest.mark.parametrize(
+    "gt_list,pred_list,expected",
+    [
+        ([], ["x"], {"fa": 1, "fn": 0}),
+        (["x"], [], {"fa": 0, "fn": 1}),
+    ],
+    ids=["gt-empty", "pred-empty"],
+)
+def test_raw_one_sided_empty_list_is_not_a_match(gt_list, pred_list, expected):
+    """One empty side scores 0.0, and reaches ``unordered_list_metrics`` the
+    other way -- through the comparator branch.
+
+    This is the companion route to ``test_raw_empty_lists_score_as_perfect_match``
+    and the guard on the ``else 0.0`` half of the both-empty conditional. Because
+    only one side is empty, exactly one of the two ``all()`` guards is false, so
+    this takes the comparator branch and the ``threshold`` argument *is* honored
+    as ``classification_threshold`` -- both of which the both-empty case cannot
+    reach, since two empty lists always satisfy both guards vacuously.
+
+    Pinning it keeps the #233 fix from over-reaching: scoring two empty lists
+    1.0 must not leak into scoring an empty list against a populated one, which
+    is a genuine miss (FN) or a genuine spurious find (FA), not agreement.
+    """
+    result = ComparisonHelper.compare_unordered_lists(
+        gt_list, pred_list, ExactComparator(), threshold=1.0
+    )
+
+    assert result["overall_score"] == 0.0
+    assert result["tp"] == 0
+    assert result["fd"] == 0
+    assert result["fa"] == expected["fa"]
+    assert result["fn"] == expected["fn"]
 
 
 @pytest.mark.parametrize("n_items", [1, 2, 3])
@@ -358,6 +481,220 @@ def test_pep604_optional_absent_list_agrees_across_score_readers(gt_days, pred_d
     assert field_metrics["tn"] == 1
     assert field_metrics["fn"] == 0
     assert field_metrics["fa"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests — every spelling of a list annotation is recognized as a list field
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("field_name", LIST_SPELLINGS)
+def test_every_list_spelling_is_recognized_as_a_list_field(field_name):
+    """``_is_list_field`` is true for parameterized and bare spellings alike.
+
+    ``get_origin`` returns ``list`` only for a parameterized annotation, so
+    ``list``, ``list | None`` and ``Optional[list]`` used to answer ``False``
+    while ``List``, ``list[str] | None`` and ``Optional[List[str]]`` answered
+    ``True``. ``list | None`` answering differently from ``list[str] | None`` is
+    the odd one: both are PEP 604 optional lists.
+    """
+    instance = EveryListSpelling(**{name: [] for name in LIST_SPELLINGS})
+
+    assert instance._is_list_field(field_name) is True
+
+
+def test_every_list_spelling_records_a_true_negative_when_empty_on_both_sides():
+    """All six spellings produce the same classification evidence.
+
+    The spelling of an annotation must not change the metrics. A field that
+    reads as non-list skips the list null handling in
+    ``ComparisonDispatcher.dispatch_field_comparison`` STEP 3 and falls into the
+    primitive null check, where ``[]`` is not "effectively null" -- so it was
+    routed to ``PrimitiveListComparator``, scored ``1.0``, and recorded *no*
+    classification evidence at all: no TN, no TP, nothing. The score looked
+    right, so the missing row was easy to miss.
+
+    A TN is what the documented rule calls for: both sides agree there are no
+    items. See ``docs/docs/Advanced/classification-logic.md``.
+    """
+    values = {name: [] for name in LIST_SPELLINGS}
+    gt = EveryListSpelling(**values)
+    pred = EveryListSpelling(**values)
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    cm = result["confusion_matrix"]
+
+    assert result["overall_score"] == 1.0
+    for name in LIST_SPELLINGS:
+        assert _overall(cm, name) == {
+            "tp": 0,
+            "fa": 0,
+            "fd": 0,
+            "fp": 0,
+            "tn": 1,
+            "fn": 0,
+        }, f"{name} disagrees with the other spellings"
+
+    # One TN per field, and no spelling silently contributing nothing.
+    assert cm["aggregate"]["tn"] == len(LIST_SPELLINGS)
+
+
+def test_an_any_annotated_field_is_not_a_list_field():
+    """``Any`` holding a list is still not a list *field*, by design.
+
+    This pins the boundary of the spelling fix. ``Any`` is not a list
+    annotation, so it keeps primitive null semantics and routes an empty list to
+    ``PrimitiveListComparator`` -- the one remaining way two empty lists reach
+    ``compare_unordered_lists`` from a model comparison, and what keeps the
+    empty-list fall-through in that function live rather than dead code.
+
+    The pair still scores ``1.0``, and still records no classification evidence.
+    Recording a TN here would mean inferring list-ness from a runtime value
+    rather than an annotation, which is a larger decision than #233 -- so this
+    documents the current answer rather than asserting it is the desired one.
+    """
+    gt = UntypedListHolder(vals=[])
+    pred = UntypedListHolder(vals=[])
+
+    assert gt._is_list_field("vals") is False
+    assert gt.compare(pred) == 1.0
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    assert result["overall_score"] == 1.0
+    assert _overall(result["confusion_matrix"], "vals") == {
+        "tp": 0,
+        "fa": 0,
+        "fd": 0,
+        "fp": 0,
+        "tn": 0,
+        "fn": 0,
+    }
+
+
+@pytest.mark.parametrize(
+    "gt_note,pred_note",
+    [
+        ("", ""),
+        (None, None),
+        ("", None),
+        (None, ""),
+    ],
+)
+def test_absent_string_field_agrees_across_score_readers(gt_note, pred_note):
+    """The parity rule covers non-list fields too, not just lists.
+
+    Regression test for GitHub issue #233.
+
+    The list half of the parity fix left the primitive half open. The dispatcher
+    reads absence for a non-list field with
+    ``NullHelper.is_effectively_null_for_primitives``, which treats ``""`` and
+    ``None`` as the same thing, while the raw path tested bare ``is None``. So
+    the same contradiction reproduced for a string field that is ``""`` on one
+    side and ``None`` on the other: ``overall_score == 1.0`` reported alongside
+    ``fd == 1``. Both readers must agree here for the same reason they must
+    agree for lists.
+    """
+    gt = NoteContainer(items=[NoteLeaf(note=gt_note)])
+    pred = NoteContainer(items=[NoteLeaf(note=pred_note)])
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    cm = result["confusion_matrix"]
+    object_metrics = _overall(cm, "items")
+    field_metrics = _overall(cm, "items", "note")
+
+    # A perfect score cannot coexist with a false discovery.
+    assert result["overall_score"] == 1.0
+    assert object_metrics["tp"] == 1
+    assert object_metrics["fd"] == 0
+
+    # Both sides agree there is no value, which is a true negative.
+    assert field_metrics["tn"] == 1
+    assert field_metrics["fn"] == 0
+    assert field_metrics["fa"] == 0
+
+
+@pytest.mark.parametrize(
+    "gt_note,pred_note",
+    [
+        ("", "n"),
+        ("n", ""),
+        (None, "n"),
+        ("n", None),
+    ],
+)
+def test_absent_string_against_populated_is_not_leniently_matched(gt_note, pred_note):
+    """Absent-vs-populated is still a total mismatch, on both readers.
+
+    The #233 rule is equivalence between the two spellings of *absent*, not
+    leniency: ``""`` does not become a wildcard that matches any string. This
+    pins the other side of the branch, so widening the null rule cannot quietly
+    turn a missed value into a match.
+    """
+    leaf_score = NoteLeaf(note=gt_note).compare(NoteLeaf(note=pred_note))
+    gt = NoteContainer(items=[NoteLeaf(note=gt_note)])
+    pred = NoteContainer(items=[NoteLeaf(note=pred_note)])
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    object_metrics = _overall(result["confusion_matrix"], "items")
+
+    # Both readers agree the pair is wrong, so there is no contradiction here
+    # either -- it is just a false discovery rather than a true positive.
+    assert leaf_score == 0.0
+    assert result["overall_score"] == 0.0
+    assert object_metrics["tp"] == 0
+    assert object_metrics["fd"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests — object matching counts absent-on-both fields toward the threshold
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("absent", [[], None], ids=["empty-list", "none"])
+def test_absent_list_fields_lift_a_disagreeing_pair_to_a_true_positive(absent):
+    """Absent-on-both fields count toward ``match_threshold``. Deliberate.
+
+    This is the metric consequence of the #233 fix, pinned because it is not
+    self-evidently desirable. ``HungarianHelper`` classifies an object pair by
+    its raw similarity, and an absent-on-both field now contributes a full
+    ``1.0`` to that average. So a pair that disagrees on *every* value a user
+    actually supplied can still clear ``match_threshold`` on the strength of its
+    absent fields: here two of three fields are absent on both sides, the third
+    disagrees outright, and the pair scores ``2/3`` and classifies as TP. Before
+    the fix the ``[]`` spelling scored ``0.0`` and classified as FD.
+
+    Parameterized over both spellings of absent because that is the argument for
+    the flip: ``None`` already behaved this way, so the fix extends existing
+    semantics to ``[]`` rather than inventing a rule. The two ids must stay
+    equal — if they ever diverge, the parity #233 is about has reopened.
+
+    The inflation this permits is real and worth stating: precision rises with
+    the number of absent optional fields a schema declares. The field-level
+    counts are what keep the report honest — ``c`` is still reported as a false
+    discovery, and the aggregate still carries ``fd == 1``. Only the
+    *object-level* classification moves.
+    """
+    gt_item = PartiallyWrongItem(a=absent, b=absent, c="alpha")
+    pred_item = PartiallyWrongItem(a=absent, b=absent, c="zzzzz")
+
+    # Two of three fields agree (vacuously), the third does not.
+    assert gt_item.compare(pred_item) == pytest.approx(2 / 3)
+
+    result = PartiallyWrongContainer(items=[gt_item]).compare_with(
+        PartiallyWrongContainer(items=[pred_item]), include_confusion_matrix=True
+    )
+    cm = result["confusion_matrix"]
+
+    # 2/3 clears match_threshold=0.5, so the pair is an object-level TP.
+    assert _overall(cm, "items")["tp"] == 1
+    assert _overall(cm, "items")["fd"] == 0
+
+    # The disagreement is not swallowed: the field that is wrong is still wrong,
+    # the vacuously-agreeing fields are true negatives rather than true
+    # positives, and the aggregate still reports the false discovery.
+    assert _overall(cm, "items", "c")["fd"] == 1
+    assert _overall(cm, "items", "a")["tn"] == 1
+    assert _overall(cm, "items", "b")["tn"] == 1
+    assert cm["aggregate"]["fd"] == 1
+    assert cm["aggregate"]["tp"] == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Fixes #233

  *Description of changes:*

  Aligns raw list scoring with `compare_with()` semantics:

  - Scores two empty lists as a perfect match.
  - Treats `None` and `[]` as equivalent for list fields.
  - Supports both `Optional[List[T]]` and `list[T] | None`.
  - Adds regression coverage for single/multiple items and the raw helper path.

  This prevents identical objects from reporting `overall_score=1.0` while being classified as false discoveries.

  *Validation:*

  - 1,889 tests passed, 12 skipped
  - `ruff check src tests` passed


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
