### PR TITLE
fix: address PR #256 review findings 1 and 2 (list normalization, PEP 604 unions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,15 +205,21 @@ Each release links to full notes on the
   `to_json_schema()`.
 
   Note a side effect: dropping the internal `extra_fields` property means
-  `from_json_schema(M.model_json_schema())` now parses for a model whose fields
-  are all required, where it previously raised `ValueError`. It still does
-  **not** round-trip -- the rebuilt model carries default thresholds, weights
-  and comparators, because a shape-only schema does not describe them. A model
-  with any `Optional` field still raises, on the nullable `anyOf` gap that
-  [#198](https://github.com/awslabs/stickler/pull/198) addresses, so most real
-  models are unaffected either way. `model_json_schema()` remains documented as
-  not round-trip-capable; use `to_json_schema()` or `to_stickler_config()` to
-  preserve configuration. Tracked in
+  `from_json_schema(M.model_json_schema())` now parses where it previously
+  raised `ValueError`. It still does **not** round-trip -- the rebuilt model
+  carries default thresholds, weights and comparators, because a shape-only
+  schema does not describe them. `model_json_schema()` remains documented as not
+  round-trip-capable; use `to_json_schema()` or `to_stickler_config()` to
+  preserve configuration.
+
+  A model rebuilt this way enforces the schema's `required` list at construction
+  time, so it rejects a prediction that omits a required field -- unlike a
+  hand-written `ComparableField` model, where every field tolerates omission so
+  the engine can score a miss. That affects **any** model with a required field,
+  not just some: a model with no `Optional` field at all is precisely the case,
+  since `Optional` fields are the ones that were never required to begin with.
+  Model an evaluation target by hand, or via `to_json_schema()` /
+  `to_stickler_config()`, until this is resolved. Tracked in
   [#214](https://github.com/awslabs/stickler/issues/214)
   ([#188](https://github.com/awslabs/stickler/issues/188))
 
@@ -331,6 +337,74 @@ Each release links to full notes on the
 
 ### Fixed
 
+- A list-typed field's items now reach its comparator exactly as supplied.
+  `ComparisonHelper.compare_unordered_lists` built its `HungarianMatcher` with
+  `normalize_values` left at the default `True`, so every item was `str()`-coerced,
+  lowercased and whitespace-collapsed *before the comparator saw it* -- silently
+  overriding whatever comparator the field declared. Three distinct defects fall
+  out of that one line, and they have different histories:
+
+  - **`ExactComparator`'s strictness now applies to list fields.** This is the
+    other half of the `#199` fix below, and is new in 0.7.0: on 0.6.0 the
+    comparator folded case itself, so the matcher's normalization was redundant
+    and list and scalar fields agreed. Making the comparator strict without
+    removing the normalization split them. A `List[str]` scored
+    `"SHP-2024-001"` against `"shp-2024-001"` as `1.0` while an otherwise
+    identical `str` field scored it `0.0` -- so a confusion matrix depended on
+    whether a field happened to be a list. Same for `"A  B"` against `"A B"`.
+    Reachable with no configuration: the `id`, `code` and `zip` name tokens
+    route to `ExactComparator(case_sensitive=True)`, so `order_ids` and
+    `zip_codes` got none of the strictness their scalar siblings got.
+
+    Scores move **down** for list fields whose values differ only by case or
+    whitespace. The pre-0.7.0 leniency is available as
+    `ExactComparator(case_sensitive=False)` -- the same knob a scalar field
+    uses, since the opt-out is a property of the comparator, not of being a list.
+
+  - **`List[bbox]` fields could not score a match at all.** Pre-existing, and
+    shipped in 0.6.0 and earlier. `BBoxIoUComparator._normalize_bbox` rejects
+    anything that is not a `list`/`tuple`, so a box arriving as
+    `"[0, 0, 10, 10]"` was unparseable and IoU fell to `0.0` -- for **identical**
+    input, in both the flat `[x1, y1, x2, y2]` and two-point
+    `[[x1, y1], [x2, y2]]` forms. Such fields now score real IoU.
+
+  - **`List[dict]` under `LevenshteinComparator` scored `1.0` by comparing
+    `str(dict)`.** Also pre-existing. It now raises `TypeError`, whose message
+    names modelling the dict as a `StructuredModel` as the fix. Stringifying
+    makes key order significant and the comparison meaningless, so raising is
+    the correction.
+
+    This one is **not** parity with the scalar spelling, and is the one place
+    where a value scores differently for being in a list. The scalar spelling
+    already raises under `compare()` and `compare_field_raw()`; it returns `0.0`
+    only under `compare_recursive()`, where the dispatcher's type-mismatch case
+    intercepts a scalar dict before the comparator sees it and has no equivalent
+    for a dict item inside a list. Keeping the raise is deliberate: refusing a
+    shape stickler cannot compare beats a silently wrong score, and the scalar
+    `0.0` is the outlier. Two things to know: this is stricter than pre-0.7.0,
+    which returned `1.0`; and `BulkStructuredModelEvaluator` catches per-document
+    exceptions, so an affected document becomes an error entry plus an overall
+    `fn` rather than halting a run. Model the dict as a `StructuredModel` to
+    score it.
+
+  For the first two shapes the new value is what the field's own comparator
+  already returned for the same pair as a scalar, so the fix removes a
+  divergence rather than introducing a rule.
+  `HungarianMatcher(normalize_values=...)` is unchanged and still defaults to
+  `True` for direct callers -- including `HungarianHelper`, which matches
+  `List[StructuredModel]` and still substitutes `""` for `None` when scoring
+  candidate pairs.
+
+  One asymmetry is deliberate and remains: `NullHelper.is_effectively_null_for_primitives`
+  treats `""` as equivalent to `None` for a scalar primitive field, so a scalar
+  scores `None` against `""` as `1.0`. The list path applies the comparator's
+  `None` policy instead and scores `0.0`. The old normalization reproduced the
+  scalar answer only incidentally, by mapping `None` to `""`.
+
+  If you are diffing 0.7.0 metrics against a stored 0.6.0 baseline, expect
+  movement on list-of-bbox fields in addition to the list-of-identifier movement
+  `#199` implies ([#199](https://github.com/awslabs/stickler/issues/199))
+
 - `PhoneComparator` no longer scores two identical values `0.0`. When **neither**
   side is a usable number the comparison falls back to exact string equality, so
   a correctly extracted number that is not dialable under the configured region
@@ -389,18 +463,63 @@ Each release links to full notes on the
   `ImportError` at the caller; only the bookkeeping changed
   ([#260](https://github.com/awslabs/stickler/issues/260))
 
-- HTML reports no longer drop nested thresholds for a field annotated
-  `Addr | None`. Threshold extraction unwrapped `Optional[X]` and
-  `Union[X, None]` but tested only for the `typing.Union` origin, and on Python
-  3.10 through 3.13 a PEP 604 union's origin is `types.UnionType` instead, so
-  that spelling was never unwrapped and the nested-model and list branches never
-  fired. (Python 3.14 unifies the two, which is why the widened check has an arm
-  that cannot fail there.) The `Optional[X]` and `X | None` spellings are both
-  handled as of this release; the second was missed when the first was fixed, and
-  is the more reachable of the two now that 0.7.0 raises the floor to Python
-  3.10 where `X | None` is idiomatic. A genuine multi-arm union is still left
-  alone
+- A field's behavior no longer depends on which equivalent spelling of "optional"
+  was used to declare it. `Optional[X]`, `Union[X, None]` and `X | None` are the
+  same type, but ten places tested `get_origin(annotation) is Union`, which is
+  `True` only for the `typing` spellings: on Python 3.10 through 3.13 a PEP 604
+  union's origin is `types.UnionType`. (Python 3.14 unifies the two, which is why
+  the widened check has an arm that cannot fail there.) An `X | None` field
+  therefore took a different code path from an identical `Optional[X]` field, in
+  three separate ways:
+
+  - **HTML reports dropped nested thresholds.** Threshold extraction never
+    unwrapped the annotation, so the nested-model and list branches never fired.
+
+  - **`to_json_schema()` exported a nested model as `{"type": "string"}`.** The
+    model, its fields, its comparators and its thresholds were all replaced by a
+    bare string, with no error and no warning — so
+    `from_json_schema(M.to_json_schema())` rebuilt a *structurally different*
+    model. A nested list of models collapsed the same way, losing its item schema
+    and match threshold, and a nullable scalar exported as `"string"` rather than
+    `["string", "null"]`. Exporting a nested model as a scalar now raises instead
+    of succeeding quietly.
+
+  - **Hierarchical metric breakdowns were silently flattened.** This is the one
+    to check if you have `X | None` models: `is_structured_field_type` is the
+    gate #149 added, and when it says "not structured" a nested-object field is
+    routed to flat counts. For an optional nested object inside a list element,
+    the reported field lost its nested per-field rows, its derived metrics
+    (`cm_precision`, `cm_recall`, `cm_f1`, `cm_accuracy`) and its similarity
+    scores — while the top-level `tp`/`fd`/`fp` counts stayed correct, so the
+    confusion matrix looked right and the detail underneath it was missing.
+
+  The union check now lives in one place rather than being hand-copied. Note that
+  the ten sites were asking two different questions: two of them need *the* single
+  inner type in order to export it, while the other eight only ask "does any arm
+  of this union look like a list, or a model?" — the latter keep their permissive
+  behavior, so a wider annotation such as `Optional[List[str]] | Any` still
+  resolves as it did. A genuine multi-arm union is still never unwrapped to an
+  arbitrary arm.
+
+  Models written with `Optional[...]` are unaffected. Models written with
+  `X | None` will see corrected schema exports and *additional* nested rows in
+  hierarchical metrics, so expect movement when diffing against a stored baseline
   ([#162](https://github.com/awslabs/stickler/issues/162))
+
+- A field annotated `List[Optional[Model]]` (or `List[Model | None]`) can now be
+  exported. Both `to_json_schema()` and `to_stickler_config()` raised
+  `AttributeError: to_json_schema` on it: the predicate deciding whether the list
+  holds models unwraps the optional wrapper, but the export call it guards did
+  not, so it ran against the `Optional[...]` object itself. Pre-existing and
+  shipped for the `Optional` spelling; the `X | None` spelling reached it only
+  once `#162` made such a field resolve as a list of models at all, having
+  previously exported as an array of strings.
+
+  The element is now exported as the model, offered as nullable. Relatedly,
+  `List[Optional[T]]` for a primitive `T` had its item type exported as
+  `"string"` regardless of `T`, because `Optional[int]` is not a key in the
+  python-to-JSON type table; it now exports `["integer", "null"]` and
+  round-trips ([#256](https://github.com/awslabs/stickler/pull/256))
 
 - Zero-config evaluation no longer scores formatting-only differences in
   `email`, `url` and `phone` fields as complete mismatches. The name-token

--- a/src/stickler/algorithms/hungarian.py
+++ b/src/stickler/algorithms/hungarian.py
@@ -43,6 +43,28 @@ class HungarianMatcher:
             size_threshold: Maximum allowable matrix size (rows*cols) before warning
             normalize_values: Whether to normalize string values before comparison
                              (convert strings to lowercase, strip whitespace, etc.)
+
+                             Legacy, and deliberately declined on the
+                             list-of-values path.
+                             This predates comparators owning their own
+                             normalization; since 0.7.0 they do
+                             (``ExactComparator.case_sensitive``,
+                             ``LevenshteinComparator._normalize``,
+                             ``FuzzyComparator._normalize``), so normalizing
+                             here silently overrides the comparator a field
+                             declared. ``ComparisonHelper.compare_unordered_lists``
+                             therefore passes ``False``. The default stays
+                             ``True`` for direct callers who relied on it; do
+                             not "fix" that call site back.
+
+                             ``HungarianHelper``, which matches
+                             ``List[StructuredModel]`` via
+                             ``StructuredModelComparator``, still takes the
+                             default: it matches whole objects rather than
+                             values, so a field's declared comparator is not
+                             what gets overridden. It does still map ``None`` to
+                             ``""`` before scoring candidate pairs, which can
+                             change which pairs the algorithm assigns.
             match_threshold: Minimum similarity score to consider a match as TP
         """
         self.comparator = comparator or (lambda x, y: float(x == y))
@@ -52,6 +74,14 @@ class HungarianMatcher:
 
     def _normalize_value(self, value: Any) -> Any:
         """Normalize a value to improve string matching.
+
+        Only reached when ``normalize_values`` is true. Note what it does
+        beyond case folding: it ``str()``-coerces every primitive and maps
+        ``None`` to ``""``. Both are lossy for a comparator that inspects the
+        value -- ``BBoxIoUComparator`` cannot parse ``"[0, 0, 10, 10]"``, and
+        the ``""`` substitution bypasses ``BaseComparator``'s ``None`` policy.
+        See the ``normalize_values`` note in :meth:`__init__` for why the
+        evaluator path opts out.
 
         Args:
             value: Value to normalize

--- a/src/stickler/auto/README.md
+++ b/src/stickler/auto/README.md
@@ -19,7 +19,12 @@ The two pre-existing entry points lose information from real pydantic models:
 
 - `StructuredModel.from_json_schema(Model.model_json_schema())` supports
   nullable `Optional` schemas, but not general multi-type unions, and silently
-  degrades enums and `datetime` to bare strings.
+  degrades enums and `datetime` to bare strings. It also enforces the schema's
+  `required` list at construction, so it rejects a prediction that omits such a
+  field instead of scoring the miss
+  ([#214](https://github.com/awslabs/stickler/issues/214)) — and a shape-only
+  schema carries no comparison configuration, so the rebuilt model gets default
+  thresholds, weights and comparators.
 - Unannotated `StructuredModel` fields fall through
   `configuration_helper.py`'s type-blind default and get compared with
   `LevenshteinComparator`, which is wrong for `float`, `bool`, `date`.

--- a/src/stickler/auto/inference.py
+++ b/src/stickler/auto/inference.py
@@ -103,6 +103,14 @@ def unwrap_optional(annotation: Any) -> Tuple[Any, bool]:
     Returns ``(inner, was_optional)``. A multi-arm union that is not simply
     ``X | None`` is returned unchanged (the caller treats it as ambiguous and
     falls back to a string comparator).
+
+    One of three deliberate copies of this logic, kept separate to avoid
+    cross-package dependencies. The others are
+    ``stickler.reporting.html.utils.data_extractors`` and
+    ``stickler.structured_object_evaluator.models.optional_annotation`` (which
+    additionally exposes the permissive ``is_union`` / ``union_args`` pair, for
+    sites that search a union's arms rather than unwrapping it). Keep them in
+    sync; unifying all three is tracked for 0.8.0.
     """
     origin = get_origin(annotation)
     # PEP 604 unions (X | None) have origin types.UnionType, not typing.Union.

--- a/src/stickler/comparators/bbox.py
+++ b/src/stickler/comparators/bbox.py
@@ -39,6 +39,12 @@ class BBoxIoUComparator(BaseComparator):
         1.0
         >>> cmp.compare([[0, 0], [5, 5]], [[5, 5], [10, 10]])
         0.0
+
+    .. versionchanged:: 0.7.0
+        Usable on a list-of-boxes field. Previously every ``List[bbox]`` field
+        scored ``0.0``, even against identical input: the evaluator stringified
+        each item before comparison and ``"[0, 0, 10, 10]"`` is not a list, so
+        no box could be parsed.
     """
 
     def __init__(

--- a/src/stickler/reporting/html/utils/data_extractors.py
+++ b/src/stickler/reporting/html/utils/data_extractors.py
@@ -215,6 +215,11 @@ class DataExtractor:
                 # not imported here: that would make stickler.reporting depend
                 # on the inference machinery and pull pydantic model building
                 # into the report path. The four lines are mirrored instead.
+                #
+                # A third copy lives at
+                # stickler.structured_object_evaluator.models.optional_annotation,
+                # added once ten sites in that package were found with this same
+                # bug. Keep all three in sync; unifying them is a 0.8.0 item.
                 if get_origin(field_type) in (Union, types.UnionType):
                     non_none_args = [
                         arg for arg in get_args(field_type) if arg is not type(None)

--- a/src/stickler/structured_object_evaluator/models/comparison_helper.py
+++ b/src/stickler/structured_object_evaluator/models/comparison_helper.py
@@ -98,7 +98,21 @@ class ComparisonHelper:
             # `classification_threshold` instead. Do not read `tp`/`fp`/`fn`
             # from a matcher built this way -- every pair satisfies
             # `score >= 0.0`, so its `tp` counts pairs, not true positives.
-            hungarian = HungarianMatcher(comparator, match_threshold=0.0)
+            #
+            # `normalize_values=False` because comparators own their own
+            # normalization: `ExactComparator.case_sensitive`,
+            # `LevenshteinComparator._normalize`, `FuzzyComparator._normalize`.
+            # The matcher's normalization is a legacy pre-comparator behavior
+            # that lowercases, collapses whitespace and `str()`-coerces every
+            # item before the comparator sees it, which silently overrides the
+            # field's declared comparator -- it defeated #199 for every
+            # list-typed field, and made `List[bbox]` unscoreable because
+            # stringified coordinates cannot be parsed. Items must reach the
+            # comparator exactly as the caller supplied them, so that a list
+            # field and a scalar field score the same pair identically.
+            hungarian = HungarianMatcher(
+                comparator, match_threshold=0.0, normalize_values=False
+            )
             classification_threshold = threshold
 
             # Get detailed metrics from HungarianMatcher

--- a/src/stickler/structured_object_evaluator/models/configuration_helper.py
+++ b/src/stickler/structured_object_evaluator/models/configuration_helper.py
@@ -5,9 +5,11 @@ JSON processing, and schema generation for StructuredModel instances.
 """
 
 import inspect
-from typing import TYPE_CHECKING, Any, Dict, Union, get_args, get_origin
+from typing import TYPE_CHECKING, Any, Dict, get_args, get_origin
 
 from stickler.comparators.levenshtein import LevenshteinComparator
+
+from .optional_annotation import is_union, union_args
 
 if TYPE_CHECKING:
     from stickler.structured_object_evaluator.models.comparison_info import (
@@ -148,11 +150,10 @@ class ConfigurationHelper:
                     ):
                         return True
 
-            # Handle Optional[List[SomeType]] annotations (Union[List[SomeType], NoneType])
-            elif get_origin(annotation) is Union:
-                union_args = get_args(annotation)
-                # Look for List[SomeType] within the Union
-                for union_arg in union_args:
+            # Handle Optional[List[SomeType]] annotations, in every spelling.
+            elif is_union(annotation):
+                # Look for List[SomeType] in any arm.
+                for union_arg in union_args(annotation):
                     if get_origin(union_arg) is list:
                         list_args = get_args(union_arg)
                         if list_args:
@@ -166,6 +167,10 @@ class ConfigurationHelper:
                 # Non-required nested object fields are annotated this way (#149); without
                 # this, optional nested objects inside list items are routed down the
                 # non-hierarchical path and lose their nested metric breakdown.
+                #
+                # The spelling does not matter: `Inner | None` reaches here too.
+                # It did not before, so a PEP 604-spelled optional nested object
+                # silently lost exactly the breakdown #149 restored.
                 if ConfigurationHelper._is_optional_structured_model(annotation):
                     return True
 
@@ -402,20 +407,14 @@ class ConfigurationHelper:
         try:
             from .structured_model import StructuredModel
 
-            # Handle Union types (like Optional[StructuredModel])
-            if get_origin(annotation) is Union:
-                union_args = get_args(annotation)
-                # Check if it's a Union with NoneType (Optional pattern)
-                none_type = type(None)
-                if none_type in union_args:
-                    # Look for StructuredModel in the remaining args
-                    for arg in union_args:
-                        if (
-                            arg != none_type
-                            and inspect.isclass(arg)
-                            and issubclass(arg, StructuredModel)
-                        ):
-                            return True
+            # Handle Union types (like Optional[StructuredModel]), in every
+            # spelling including `StructuredModel | None`. The union must
+            # actually include None to be an "optional", but any arm may carry
+            # the model, so a wider union still resolves.
+            if is_union(annotation) and type(None) in get_args(annotation):
+                for arg in union_args(annotation):
+                    if inspect.isclass(arg) and issubclass(arg, StructuredModel):
+                        return True
             return False
         except (TypeError, AttributeError):
             return False
@@ -433,16 +432,9 @@ class ConfigurationHelper:
         try:
             from .structured_model import StructuredModel
 
-            if get_origin(annotation) is Union:
-                union_args = get_args(annotation)
-                none_type = type(None)
-                for arg in union_args:
-                    if (
-                        arg != none_type
-                        and inspect.isclass(arg)
-                        and issubclass(arg, StructuredModel)
-                    ):
-                        return arg
+            for arg in union_args(annotation):
+                if inspect.isclass(arg) and issubclass(arg, StructuredModel):
+                    return arg
             return None
         except (TypeError, AttributeError):
             return None
@@ -470,13 +462,10 @@ class ConfigurationHelper:
                 ):
                     return True
 
-            # Handle Optional[List[StructuredModel]] annotations (Union[List[StructuredModel], NoneType])
-            elif get_origin(annotation) is Union:
-                union_args = get_args(annotation)
-                none_type = type(None)
-                # Look for List[StructuredModel] within the Union
-                for arg in union_args:
-                    if arg != none_type and get_origin(arg) is list:
+            # Handle Optional[List[StructuredModel]], in every spelling.
+            elif is_union(annotation):
+                for arg in union_args(annotation):
+                    if get_origin(arg) is list:
                         list_args = get_args(arg)
                         if (
                             list_args
@@ -512,12 +501,10 @@ class ConfigurationHelper:
                 ):
                     return args[0]
 
-            # Handle Optional[List[StructuredModel]]
-            elif get_origin(annotation) is Union:
-                union_args = get_args(annotation)
-                none_type = type(None)
-                for arg in union_args:
-                    if arg != none_type and get_origin(arg) is list:
+            # Handle Optional[List[StructuredModel]], in every spelling.
+            elif is_union(annotation):
+                for arg in union_args(annotation):
+                    if get_origin(arg) is list:
                         list_args = get_args(arg)
                         if (
                             list_args

--- a/src/stickler/structured_object_evaluator/models/json_schema_field_converter.py
+++ b/src/stickler/structured_object_evaluator/models/json_schema_field_converter.py
@@ -4,12 +4,13 @@ This module provides utilities for converting JSON Schema properties to
 Pydantic Field instances with ComparableField functionality.
 """
 
-from typing import Any, Dict, List, Optional, Tuple, Type, Union, get_args, get_origin
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 from pydantic.fields import FieldInfo
 
 from .comparable_field import ComparableField
 from .comparator_registry import create_comparator
+from .optional_annotation import unwrap_optional
 
 # Type mapping from JSON Schema types to Python types
 JSON_TYPE_TO_PYTHON_TYPE = {
@@ -55,7 +56,7 @@ class JsonSchemaFieldConverter:
 
     def __init__(self, schema: Dict[str, Any], field_path: str = ""):
         """Initialize with a JSON Schema document.
-        
+
         Args:
             schema: JSON Schema document (already validated)
             field_path: Current field path for error messages (e.g., "address.street")
@@ -533,7 +534,7 @@ class JsonSchemaFieldConverter:
         # Get default value
         default = property_schema.get("default", ... if is_required else None)
         description = property_schema.get("description")
-        
+
         # Create ComparableField with dummy comparator (not used for StructuredModel)
         from stickler.comparators.levenshtein import LevenshteinComparator
         field = ComparableField(
@@ -646,11 +647,28 @@ class JsonSchemaFieldConverter:
         """
         # Unwrap Optional[T] in case the caller passes the wrapped type so the
         # nullability still survives the round-trip as the ["X", "null"] idiom.
-        if get_origin(field_type) is Union:
-            args = [a for a in get_args(field_type) if a is not type(None)]
-            if len(args) == 1 and type(None) in get_args(field_type):
-                field_type = args[0]
-                is_nullable = True
+        # Every spelling, including `X | None`.
+        unwrapped, was_optional = unwrap_optional(field_type)
+        if was_optional:
+            field_type = unwrapped
+            is_nullable = True
+
+        # A StructuredModel must never reach the scalar fallback below. It has
+        # its own schema -- properties, nested thresholds, comparators -- and
+        # `PYTHON_TYPE_TO_JSON_TYPE.get(..., "string")` would silently discard
+        # all of it, emitting a schema that rebuilds into a structurally
+        # different model. Raise rather than produce a wrong schema quietly.
+        #
+        # Deliberately scoped to StructuredModel, not to every dict miss:
+        # Decimal, UUID and enums legitimately export as "string".
+        from .structured_model import StructuredModel
+
+        if isinstance(field_type, type) and issubclass(field_type, StructuredModel):
+            raise ValueError(
+                f"Cannot export nested model field as a scalar: annotation "
+                f"{field_type!r} is a StructuredModel. Export it via its own "
+                f"to_json_schema() instead of field_to_property()."
+            )
 
         json_type = PYTHON_TYPE_TO_JSON_TYPE.get(field_type, "string")
         property_schema = {"type": [json_type, "null"] if is_nullable else json_type}

--- a/src/stickler/structured_object_evaluator/models/optional_annotation.py
+++ b/src/stickler/structured_object_evaluator/models/optional_annotation.py
@@ -1,0 +1,116 @@
+"""Recognising an optional annotation, in every spelling Python allows.
+
+``Optional[T]``, ``Union[T, None]`` and ``T | None`` are the same type, but they
+do not look the same to ``get_origin``:
+
+===========================  =====================  ==================
+annotation                   ``get_origin(...)``    ``__origin__``
+===========================  =====================  ==================
+``Optional[T]``              ``typing.Union``       present
+``Union[T, None]``           ``typing.Union``       present
+``T | None``                 ``types.UnionType``    **absent**
+===========================  =====================  ==================
+
+Testing ``get_origin(x) is Union`` therefore silently answers "no" for the PEP
+604 spelling, and testing ``hasattr(x, "__origin__")`` does too. Ten sites in
+this package each hand-rolled one of those checks and each got ``X | None``
+wrong; three consecutive reviews found only some of them. Ask through this
+module instead of rebuilding the check.
+
+``requires-python = ">=3.10"`` means ``T | None`` is valid across the whole
+supported range, and it is the spelling modern tooling emits.
+
+.. note::
+   Two other copies of this logic exist deliberately, and are not imported
+   from here: ``stickler.auto.inference.unwrap_optional`` and the check in
+   ``stickler.reporting.html.utils.data_extractors``. Both live in packages
+   that do not depend on the evaluator models — importing across would pull
+   pydantic model building into the report path (see #268). Keep them in sync
+   by hand; unifying all three is tracked for 0.8.0.
+
+.. note::
+   On Python 3.14 the two union representations are unified, so the
+   ``types.UnionType`` arm of :func:`is_optional_union` becomes redundant
+   rather than wrong. It is kept for 3.10-3.13.
+"""
+
+import types
+from typing import Any, Tuple, Union, get_args, get_origin
+
+__all__ = ["is_union", "union_args", "is_optional_union", "unwrap_optional"]
+
+# Both origins a union annotation can report. `types.UnionType` is what the
+# `|` operator produces; `typing.Union` is what the subscript form produces.
+_UNION_ORIGINS = (Union, types.UnionType)
+
+
+def is_union(annotation: Any) -> bool:
+    """Whether ``annotation`` is a union of any arity, in any spelling.
+
+    Broader than :func:`is_optional_union`: true for ``A | B``, ``A | B | None``
+    and ``Optional[T]`` alike. Use this when the question is "does any arm of
+    this union look like X", and :func:`is_optional_union` when the question is
+    "is there a single inner type to descend into".
+
+    Args:
+        annotation: Type annotation to inspect.
+
+    Returns:
+        True if the annotation is a union.
+    """
+    return get_origin(annotation) in _UNION_ORIGINS
+
+
+def union_args(annotation: Any) -> Tuple[Any, ...]:
+    """The non-``None`` arms of a union, in any spelling.
+
+    Returns an empty tuple when ``annotation`` is not a union, so a caller can
+    loop unconditionally.
+
+    Args:
+        annotation: Type annotation to inspect.
+
+    Returns:
+        The union's arms with ``NoneType`` removed, or ``()`` if not a union.
+    """
+    if not is_union(annotation):
+        return ()
+    return tuple(arg for arg in get_args(annotation) if arg is not type(None))
+
+
+def is_optional_union(annotation: Any) -> bool:
+    """Whether ``annotation`` is a union of exactly one type with ``None``.
+
+    True for ``Optional[T]``, ``Union[T, None]`` and ``T | None``. False for a
+    genuine multi-arm union such as ``A | B | None``, which has no single inner
+    type to descend into, and False for a union with no ``None`` arm.
+
+    Args:
+        annotation: Type annotation to inspect.
+
+    Returns:
+        True if the annotation is an optional wrapper around a single type.
+    """
+    if get_origin(annotation) not in _UNION_ORIGINS:
+        return False
+    args = get_args(annotation)
+    non_none = [arg for arg in args if arg is not type(None)]
+    return len(non_none) == 1 and type(None) in args
+
+
+def unwrap_optional(annotation: Any) -> Tuple[Any, bool]:
+    """Strip an optional wrapper, reporting whether one was present.
+
+    Args:
+        annotation: Type annotation to unwrap.
+
+    Returns:
+        ``(inner_type, True)`` when ``annotation`` is an optional wrapper
+        around a single type, otherwise ``(annotation, False)`` unchanged. A
+        multi-arm union is returned as-is rather than unwrapped to an arbitrary
+        arm.
+    """
+    if not is_optional_union(annotation):
+        return annotation, False
+    inner = next(arg for arg in get_args(annotation) if arg is not type(None))
+    return inner, True

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -29,6 +29,7 @@ from .configuration_helper import ConfigurationHelper
 from .evaluator_format_helper import EvaluatorFormatHelper
 from .hungarian_helper import HungarianHelper
 from .metrics_helper import MetricsHelper
+from .optional_annotation import union_args, unwrap_optional
 from .rich_value_helper import RichValueHelper
 from .threshold_helper import THRESHOLD_DOCS_URL
 from .threshold_helper import model_identity as _model_identity
@@ -437,10 +438,12 @@ class StructuredModel(BaseModel):
                 # Use consolidated method for element type check
                 return cls._is_structured_model_type(args[0])
 
-        # Handle Union types (like Optional[List[StructuredModel]])
-        elif origin is Union:
-            args = get_args(field_type)
-            for arg in args:
+        # Handle Union types (like Optional[List[StructuredModel]]), in every
+        # spelling -- `list[Model] | None` reaches here too. Searches every arm
+        # rather than requiring a single one, so a wider union such as
+        # `Optional[List[Model]] | Any` still resolves to a list of models.
+        else:
+            for arg in union_args(field_type):
                 if cls._is_list_of_structured_model_type(arg):
                     return True
 
@@ -933,18 +936,22 @@ class StructuredModel(BaseModel):
             return False
 
         field_type = field_info.annotation
-        # Handle Optional types and direct List types
-        if hasattr(field_type, "__origin__"):
-            origin = field_type.__origin__
-            if origin is list or origin is List:
+
+        # Use get_origin rather than reading `__origin__` directly: a PEP 604
+        # union (`list[T] | None`) has no `__origin__` attribute at all, so the
+        # old `hasattr` guard skipped it entirely and such a field was not
+        # recognised as a list.
+        origin = get_origin(field_type)
+        if origin is list or origin is List:
+            return True
+
+        # Optional[List[...]] case, in every spelling. Any arm being a list is
+        # enough, so a wider union like `Optional[List[str]] | Any` still counts.
+        for arg in union_args(field_type):
+            arg_origin = get_origin(arg)
+            if arg_origin is list or arg_origin is List:
                 return True
-            elif origin is Union:  # Optional[List[...]] case
-                args = field_type.__args__
-                for arg in args:
-                    if hasattr(arg, "__origin__") and (
-                        arg.__origin__ is list or arg.__origin__ is List
-                    ):
-                        return True
+
         return False
 
     def _handle_list_field_dispatch(
@@ -1570,13 +1577,23 @@ class StructuredModel(BaseModel):
                         f"Field '{field_name}' has unparameterized list type. "
                         f"Use List[str], List[int], etc."
                     )
-                element_type = args[0]
+                # Unwrap an optional element before dispatching on it.
+                # `_is_structured_model_type` unwraps internally, so without this
+                # `List[Optional[Model]]` passed the check and then called
+                # `to_json_schema()` on the `Optional[...]` wrapper, which has no
+                # such attribute -- an AttributeError instead of a schema. The
+                # primitive branch needs it too: `Optional[int]` is not a key in
+                # PYTHON_TYPE_TO_JSON_TYPE, so it fell through to "string".
+                element_type, element_is_nullable = cls._unwrap_optional(args[0])
 
                 if cls._is_structured_model_type(element_type):
                     # List of StructuredModels - recursively export element schema
+                    items_schema = element_type.to_json_schema()
+                    if element_is_nullable:
+                        items_schema = {"anyOf": [items_schema, {"type": "null"}]}
                     property_schema = {
                         "type": "array",
-                        "items": element_type.to_json_schema(),
+                        "items": items_schema,
                     }
                     metadata = converter._extract_field_metadata(field_info)
                     metadata.pop("comparator", None)
@@ -1589,7 +1606,11 @@ class StructuredModel(BaseModel):
                     )
                     property_schema = {
                         "type": "array",
-                        "items": {"type": json_element_type},
+                        "items": {
+                            "type": [json_element_type, "null"]
+                            if element_is_nullable
+                            else json_element_type
+                        },
                     }
                     # Extract and add stickler extensions from field metadata
                     metadata = converter._extract_field_metadata(field_info)
@@ -1618,18 +1639,20 @@ class StructuredModel(BaseModel):
     def _unwrap_optional(field_type: Type) -> tuple:
         """Unwrap Optional[T] to (T, True) or return (T, False) if not Optional.
 
+        Recognises every spelling, including ``T | None``. This is load-bearing
+        for ``to_json_schema()``: the nested-model branch, the list branch and
+        the nullability of a primitive property all key off it, so a spelling it
+        fails to recognise falls through to the scalar path and exports as
+        ``{"type": "string"}`` -- silently replacing a nested model, or a whole
+        array of models, with a string.
+
         Args:
             field_type: Type annotation to unwrap
 
         Returns:
             Tuple of (unwrapped_type, is_optional)
         """
-        if get_origin(field_type) is Union:
-            args = get_args(field_type)
-            non_none_args = [arg for arg in args if arg is not type(None)]
-            if len(non_none_args) == 1 and type(None) in args:
-                return non_none_args[0], True
-        return field_type, False
+        return unwrap_optional(field_type)
 
     @staticmethod
     def _is_structured_model_type(field_type: Type) -> bool:
@@ -1722,7 +1745,12 @@ class StructuredModel(BaseModel):
                         f"Field '{field_name}' has unparameterized list type. "
                         f"Use List[str], List[int], etc."
                     )
-                element_type = args[0]
+                # Unwrap an optional element for the same reason as
+                # to_json_schema()'s list branch: the predicate below unwraps, so
+                # `List[Optional[Model]]` reached `to_stickler_config()` on the
+                # wrapper. The primitive branch below also reads
+                # `element_type.__name__`, which a union does not have.
+                element_type, _ = cls._unwrap_optional(args[0])
 
                 if cls._is_structured_model_type(element_type):
                     nested_config = element_type.to_stickler_config()

--- a/src/stickler/structured_object_evaluator/models/type_resolver.py
+++ b/src/stickler/structured_object_evaluator/models/type_resolver.py
@@ -7,6 +7,8 @@ enabling configuration-based type specification in model_from_json().
 import re
 from typing import Any, Dict, List, Type, Union, get_args, get_origin
 
+from .optional_annotation import is_union, union_args
+
 
 class TypeResolver:
     """Resolver for converting string type names to Python types."""
@@ -32,7 +34,7 @@ class TypeResolver:
         self._type_registry["set"] = set
 
         # Typing module types
-        from typing import Any, Dict, List, Optional, Set, Tuple, Union
+        from typing import Any, Dict, List, Optional, Set, Tuple
 
         self._type_registry["List"] = List
         self._type_registry["Dict"] = Dict
@@ -177,17 +179,16 @@ class TypeResolver:
     def is_optional_type(self, type_obj: Type) -> bool:
         """Check if a type is Optional (Union with None).
 
+        Recognises every spelling: ``Optional[T]``, ``Union[T, None]`` and
+        ``T | None``.
+
         Args:
             type_obj: Type to check
 
         Returns:
             True if the type is Optional
         """
-        origin = get_origin(type_obj)
-        if origin is Union:
-            args = get_args(type_obj)
-            return type(None) in args
-        return False
+        return is_union(type_obj) and type(None) in get_args(type_obj)
 
     def get_optional_inner_type(self, type_obj: Type) -> Type:
         """Get the inner type from an Optional type.
@@ -204,10 +205,9 @@ class TypeResolver:
         if not self.is_optional_type(type_obj):
             raise ValueError(f"Type {type_obj} is not Optional")
 
-        args = get_args(type_obj)
-        for arg in args:
-            if arg is not type(None):
-                return arg
+        args = union_args(type_obj)
+        if args:
+            return args[0]
 
         raise ValueError(f"Could not find non-None type in {type_obj}")
 

--- a/tests/structured_object_evaluator/test_list_scalar_comparison_parity.py
+++ b/tests/structured_object_evaluator/test_list_scalar_comparison_parity.py
@@ -1,0 +1,342 @@
+"""A value scores the same whether or not it sits in a list.
+
+``ComparisonHelper.compare_unordered_lists`` builds its ``HungarianMatcher``
+with ``normalize_values`` left at the default ``True``, so ``_prepare_lists``
+coerced every item to ``str``, lowercased it and collapsed its whitespace
+*before the comparator ever saw it*. The field's declared comparator was
+handed values the caller never wrote.
+
+Three shapes were affected. Two of them now score the way the same comparator
+already scored the same pair as a scalar; the third deliberately does not:
+
+- ``ExactComparator`` on a case- or whitespace-only difference matched, which
+  silently undid #199 for every list-typed field. Now parity.
+- ``BBoxIoUComparator`` scored every list of boxes ``0.0``, even against
+  identical input, because ``_normalize_bbox`` rejects the stringified
+  coordinates. Now real IoU. There is no scalar spelling of a box field to
+  compare against -- a box is itself a list -- so those assertions call the
+  comparator directly instead.
+- ``List[dict]`` under ``LevenshteinComparator`` scored ``1.0`` by comparing
+  ``str(dict)``; it now raises the comparator's own ``TypeError``. This one is
+  **not** parity with the scalar spelling under ``compare_recursive``, and
+  ``test_dict_items_raise_like_the_scalar_compare_path`` documents the full
+  entry-point matrix.
+
+Most assertions here compare the list path to the scalar path rather than to a
+literal, because parity is the actual requirement: pinning two independent
+constants lets them drift apart while both stay green, which is how this
+survived #199 in the first place.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from stickler import ComparableField, StructuredModel
+from stickler.comparators import (
+    BBoxIoUComparator,
+    ExactComparator,
+    LevenshteinComparator,
+    NumericComparator,
+)
+from stickler.comparators.fuzzy import FuzzyComparator
+
+
+def _scores(comparator, threshold, gt_value, pred_value, item_type=str) -> Tuple[float, float]:
+    """Score one pair twice: once as a list field, once as a scalar field.
+
+    Returns ``(list_score, scalar_score)``. The two models are identical apart
+    from the list wrapper, and share a comparator instance and threshold, so any
+    difference is attributable to the list path alone.
+    """
+
+    class ListModel(StructuredModel):
+        v: List[item_type] = ComparableField(comparator=comparator, threshold=threshold)
+
+    class ScalarModel(StructuredModel):
+        v: item_type = ComparableField(comparator=comparator, threshold=threshold)
+
+    list_result = ListModel(v=[gt_value]).compare_recursive(ListModel(v=[pred_value]))
+    scalar_result = ScalarModel(v=gt_value).compare_recursive(ScalarModel(v=pred_value))
+    return (
+        list_result["fields"]["v"]["similarity_score"],
+        scalar_result["fields"]["v"]["similarity_score"],
+    )
+
+
+def _list_counts(comparator, threshold, gt_values, pred_values, item_type=str) -> Dict[str, Any]:
+    """Confusion-matrix counts for a list field."""
+
+    class ListModel(StructuredModel):
+        v: List[item_type] = ComparableField(comparator=comparator, threshold=threshold)
+
+    result = ListModel(v=gt_values).compare_recursive(ListModel(v=pred_values))
+    return result["fields"]["v"]["overall"]
+
+
+class TestExactComparatorReachesListFields:
+    """#199's strictness must apply to a list field, not only a scalar one."""
+
+    def test_case_only_difference_is_not_a_match(self):
+        """The exact pair #199 cites, which a List[str] used to match."""
+        list_score, scalar_score = _scores(
+            ExactComparator(), 1.0, "SHP-2024-001", "shp-2024-001"
+        )
+        assert list_score == scalar_score
+        assert list_score == 0.0
+
+    def test_case_only_difference_is_classified_as_a_non_match(self):
+        counts = _list_counts(ExactComparator(), 1.0, ["SHP-2024-001"], ["shp-2024-001"])
+        assert counts["tp"] == 0
+        assert counts["fd"] == 1
+
+    def test_whitespace_only_difference_is_not_a_match(self):
+        list_score, scalar_score = _scores(ExactComparator(), 1.0, "A  B", "A B")
+        assert list_score == scalar_score
+        assert list_score == 0.0
+
+    def test_an_equal_pair_still_matches(self):
+        """The fix must not simply score everything 0.0."""
+        list_score, scalar_score = _scores(ExactComparator(), 1.0, "SHP-1", "SHP-1")
+        assert list_score == scalar_score
+        assert list_score == 1.0
+
+    def test_case_insensitive_is_the_supported_opt_out(self):
+        """A caller wanting the old lenient behavior asks for it explicitly.
+
+        This is the same knob a scalar field uses, which is the point: the
+        opt-out is a comparator setting, not a property of being a list.
+        """
+        list_score, scalar_score = _scores(
+            ExactComparator(case_sensitive=False), 1.0, "SHP-2024-001", "shp-2024-001"
+        )
+        assert list_score == scalar_score
+        assert list_score == 1.0
+
+    def test_multi_item_lists_are_not_rescued_by_list_membership(self):
+        """Guards the general path, not just the 1x1 fast path.
+
+        ``HungarianMatcher.calculate_metrics`` short-circuits a single-item
+        list, so a two-item list exercises the matrix path instead.
+        """
+        counts = _list_counts(
+            ExactComparator(), 1.0, ["AB", "CD"], ["cd", "ab"]
+        )
+        assert counts["tp"] == 0
+        assert counts["fd"] == 2
+
+
+class TestComparatorsThatNormalizeThemselvesAreUnaffected:
+    """The no-regression half: self-normalizing comparators keep working."""
+
+    def test_levenshtein_case_only_difference(self):
+        list_score, scalar_score = _scores(
+            LevenshteinComparator(), 0.7, "Hello World", "hello world"
+        )
+        assert list_score == scalar_score
+        assert list_score == 1.0
+
+    def test_levenshtein_collapses_internal_whitespace(self):
+        list_score, scalar_score = _scores(LevenshteinComparator(), 0.7, "A  B", "A B")
+        assert list_score == scalar_score
+        assert list_score == 1.0
+
+    def test_fuzzy_case_only_difference(self):
+        list_score, scalar_score = _scores(
+            FuzzyComparator(), 0.7, "Hello World", "hello world"
+        )
+        assert list_score == scalar_score
+        assert list_score == 1.0
+
+    def test_fuzzy_internal_whitespace_is_the_comparators_business(self):
+        """No literal: ``FuzzyComparator._normalize`` deliberately does not
+        collapse internal whitespace, so the list path must land on whatever
+        the scalar path already returns rather than on 1.0.
+        """
+        list_score, scalar_score = _scores(FuzzyComparator(), 0.7, "A  B", "A B")
+        assert list_score == scalar_score
+        assert list_score < 1.0
+
+
+def _bbox_list_score(gt_boxes, pred_boxes, threshold, item_type) -> float:
+    """Score a list-of-bboxes field.
+
+    A bounding box *is* a list, so there is no scalar spelling of a bbox field
+    to compare against -- ``v: List[int]`` is a list field over coordinates,
+    not one box. These cases therefore assert against
+    ``BBoxIoUComparator().compare(...)`` called directly on whole boxes.
+    """
+
+    class ListModel(StructuredModel):
+        v: List[item_type] = ComparableField(
+            comparator=BBoxIoUComparator(), threshold=threshold
+        )
+
+    result = ListModel(v=gt_boxes).compare_recursive(ListModel(v=pred_boxes))
+    return result["fields"]["v"]["similarity_score"]
+
+
+class TestItemTypesReachTheComparatorIntact:
+    """Items must arrive as the caller supplied them, not as ``str(item)``."""
+
+    def test_identical_flat_bboxes_match(self):
+        """Every List[bbox] field scored 0.0 before this fix, including here.
+
+        The stringified ``"[0, 0, 10, 10]"`` is not a list, so
+        ``_normalize_bbox`` returned None and IoU fell to 0.0 -- so a
+        list-of-bboxes field could not score a match against identical input.
+        """
+        box = [0, 0, 10, 10]
+        assert _bbox_list_score([box], [box], 0.5, List[int]) == 1.0
+        assert BBoxIoUComparator().compare(box, box) == 1.0
+
+    def test_identical_two_point_bboxes_match(self):
+        box = [[0, 0], [10, 10]]
+        assert _bbox_list_score([box], [box], 0.5, List[List[int]]) == 1.0
+        assert BBoxIoUComparator().compare(box, box) == 1.0
+
+    def test_partially_overlapping_bboxes_score_real_iou(self):
+        gt, pred = [0, 0, 10, 10], [5, 5, 15, 15]
+        direct = BBoxIoUComparator().compare(gt, pred)
+        assert 0.0 < direct < 1.0
+        assert _bbox_list_score([gt], [pred], 0.01, List[int]) == direct
+
+    def test_numeric_items_supplied_as_numbers(self):
+        list_score, scalar_score = _scores(NumericComparator(), 1.0, 42, 42, item_type=int)
+        assert list_score == scalar_score
+        assert list_score == 1.0
+
+    def test_numeric_float_matches_across_spellings(self):
+        list_score, scalar_score = _scores(
+            NumericComparator(), 1.0, 1.50, 1.5, item_type=float
+        )
+        assert list_score == scalar_score
+        assert list_score == 1.0
+
+    def test_dict_items_raise_like_the_scalar_compare_path(self):
+        """``List[dict]`` raises. This is the one shape that is not parity.
+
+        A stringified dict compared ``1.0``: ``str(dict)`` makes key order
+        significant and the comparison meaningless, so the comparator's own
+        guard -- whose message names modelling the dict as a ``StructuredModel``
+        -- is right to fire. But calling that *parity with the scalar spelling*
+        would be wrong, because the scalar spelling does two different things
+        depending on the entry point:
+
+        =========================  ===========  ============
+        entry point                scalar dict  ``List[dict]``
+        =========================  ===========  ============
+        ``compare()``              TypeError    TypeError
+        ``compare_field_raw()``    TypeError    TypeError
+        ``compare_recursive()``    ``0.0``      TypeError
+        =========================  ===========  ============
+
+        So the raise agrees with ``compare()``, which already refuses a scalar
+        dict, and diverges from ``compare_recursive()``, where
+        ``ComparisonDispatcher``'s type-mismatch case (CASE 4) intercepts a
+        *scalar* dict before the comparator sees it but has no equivalent for a
+        dict *item* inside a list.
+
+        The divergence is deliberate, not parity: raising is the honest answer
+        for a shape stickler cannot compare, and CASE 4's silent ``0.0`` for the
+        scalar spelling is the odd one out. Two consequences a caller should
+        know: this is stricter than pre-0.7.0, which returned ``1.0``; and
+        ``BulkStructuredModelEvaluator`` catches per-document exceptions
+        (``bulk_structured_model_evaluator.py:246``), so an affected document
+        becomes an error entry plus an overall ``fn`` rather than halting a run.
+
+        All four cells are pinned here because the previous version of this test
+        asserted only the ``List[dict]`` raise and described it as parity, which
+        no assertion contradicted.
+        """
+
+        class ListModel(StructuredModel):
+            v: List[Dict[str, Any]] = ComparableField(
+                comparator=LevenshteinComparator(), threshold=0.7
+            )
+
+        class ScalarModel(StructuredModel):
+            v: Dict[str, Any] = ComparableField(
+                comparator=LevenshteinComparator(), threshold=0.7
+            )
+
+        with pytest.raises(TypeError, match="StructuredModel"):
+            ListModel(v=[{"a": 1}]).compare_recursive(ListModel(v=[{"a": 1}]))
+        with pytest.raises(TypeError, match="StructuredModel"):
+            ListModel(v=[{"a": 1}]).compare(ListModel(v=[{"a": 1}]))
+
+        # The scalar spelling: refuses under `compare`, scores under
+        # `compare_recursive`. Pinned so the asymmetry cannot drift unnoticed.
+        with pytest.raises(TypeError, match="StructuredModel"):
+            ScalarModel(v={"a": 1}).compare(ScalarModel(v={"a": 1}))
+
+        scalar_recursive = ScalarModel(v={"a": 1}).compare_recursive(
+            ScalarModel(v={"a": 1})
+        )
+        assert scalar_recursive["fields"]["v"]["similarity_score"] == 0.0
+        assert scalar_recursive["fields"]["v"]["overall"]["fd"] == 1
+
+
+class TestMissingValuePolicyOnTheListPath:
+    """``None`` items follow the shared policy, not a placeholder substitution."""
+
+    def test_both_items_missing_match(self):
+        list_score, _ = _scores(
+            ExactComparator(), 1.0, None, None, item_type=Optional[str]
+        )
+        assert list_score == 1.0
+
+    def test_one_item_missing_does_not_match(self):
+        list_score, _ = _scores(
+            ExactComparator(), 1.0, None, "x", item_type=Optional[str]
+        )
+        assert list_score == 0.0
+
+    def test_missing_against_empty_string_follows_the_comparator(self):
+        """The one case where list and scalar deliberately differ.
+
+        ``NullHelper.is_effectively_null_for_primitives`` treats ``""`` as
+        equivalent to ``None`` for a *scalar* primitive field, so the scalar
+        path scores this pair 1.0 by design. The list path has no such rule:
+        items go to the comparator, and ``BaseComparator``'s ``None`` policy
+        makes missing-against-present a non-match.
+
+        Before this change the list path reached 1.0 too, but only by accident
+        -- ``_normalize_value`` mapped ``None`` to ``""`` and the two then
+        compared equal as strings. Removing the normalization removes that
+        coincidence, which surfaces a real asymmetry: field-level null
+        equivalence is applied on the scalar path and not the list path. Pinned
+        here so it is a recorded decision rather than a silent difference.
+        """
+        list_score, scalar_score = _scores(
+            ExactComparator(), 1.0, None, "", item_type=Optional[str]
+        )
+        assert list_score == ExactComparator().compare(None, "") == 0.0
+        assert scalar_score == 1.0
+
+
+class TestNestedModelListsKeepTheirOwnPath:
+    """Model-element lists are scored by recursive comparison, as before."""
+
+    class _Inner(StructuredModel):
+        city: str = ComparableField(comparator=ExactComparator(), threshold=1.0)
+
+    def test_identical_nested_models_match(self):
+        class Doc(StructuredModel):
+            items: List["TestNestedModelListsKeepTheirOwnPath._Inner"] = ComparableField()
+
+        inner = TestNestedModelListsKeepTheirOwnPath._Inner
+        result = Doc(items=[inner(city="Seattle")]).compare_recursive(
+            Doc(items=[inner(city="Seattle")])
+        )
+        assert result["fields"]["items"]["similarity_score"] == 1.0
+
+    def test_differing_nested_models_do_not_match(self):
+        class Doc(StructuredModel):
+            items: List["TestNestedModelListsKeepTheirOwnPath._Inner"] = ComparableField()
+
+        inner = TestNestedModelListsKeepTheirOwnPath._Inner
+        result = Doc(items=[inner(city="Seattle")]).compare_recursive(
+            Doc(items=[inner(city="Portland")])
+        )
+        assert result["fields"]["items"]["similarity_score"] == 0.0

--- a/tests/structured_object_evaluator/test_optional_annotation.py
+++ b/tests/structured_object_evaluator/test_optional_annotation.py
@@ -1,0 +1,133 @@
+"""Unit tests for the shared optional-annotation helper.
+
+Every spelling of "may be None" must be recognised, and a genuine multi-arm
+union must not be mistaken for one.
+"""
+
+from typing import Any, Dict, List, Optional, Union
+
+from stickler.structured_object_evaluator.models.optional_annotation import (
+    is_optional_union,
+    is_union,
+    union_args,
+    unwrap_optional,
+)
+
+
+class _A:
+    pass
+
+
+class _B:
+    pass
+
+
+class TestIsOptionalUnion:
+    def test_all_three_spellings_of_an_optional_agree(self):
+        assert is_optional_union(Optional[str]) is True
+        assert is_optional_union(Union[str, None]) is True
+        assert is_optional_union(str | None) is True
+
+    def test_optional_of_a_class(self):
+        assert is_optional_union(Optional[_A]) is True
+        assert is_optional_union(_A | None) is True
+
+    def test_optional_of_a_generic(self):
+        assert is_optional_union(Optional[List[_A]]) is True
+        assert is_optional_union(list[_A] | None) is True
+        assert is_optional_union(Optional[Dict[str, int]]) is True
+        assert is_optional_union(dict[str, int] | None) is True
+
+    def test_multi_arm_union_with_none_is_not_an_optional(self):
+        """No single inner type to descend into, so it must be left alone."""
+        assert is_optional_union(Union[_A, _B, None]) is False
+        assert is_optional_union(_A | _B | None) is False
+
+    def test_union_without_none_is_not_an_optional(self):
+        assert is_optional_union(Union[_A, _B]) is False
+        assert is_optional_union(_A | _B) is False
+
+    def test_bare_types_are_not_optional(self):
+        assert is_optional_union(str) is False
+        assert is_optional_union(_A) is False
+        assert is_optional_union(List[str]) is False
+        assert is_optional_union(list[str]) is False
+
+    def test_none_itself_is_not_an_optional_wrapper(self):
+        assert is_optional_union(None) is False
+        assert is_optional_union(type(None)) is False
+
+    def test_nested_optional_collapses_to_a_single_optional(self):
+        """Python flattens ``Optional[Optional[T]]``; it stays an optional."""
+        assert is_optional_union(Optional[Optional[str]]) is True
+
+
+class TestIsUnionAndUnionArgs:
+    """The permissive pair, for sites that search a union's arms.
+
+    Eight of the ten converted sites ask "does *any* arm look like X", not "is
+    there a single inner type". Narrowing them to the latter broke issue #33's
+    models, which are annotated ``Optional[List[str]] | Any``.
+    """
+
+    def test_is_union_covers_any_arity_and_spelling(self):
+        assert is_union(Optional[str]) is True
+        assert is_union(Union[str, None]) is True
+        assert is_union(str | None) is True
+        assert is_union(Union[_A, _B]) is True
+        assert is_union(_A | _B | None) is True
+
+    def test_is_union_is_false_for_non_unions(self):
+        assert is_union(str) is False
+        assert is_union(List[str]) is False
+        assert is_union(None) is False
+
+    def test_union_args_drops_none_and_keeps_the_rest(self):
+        assert union_args(Optional[str]) == (str,)
+        assert union_args(str | None) == (str,)
+        assert set(union_args(Union[_A, _B, None])) == {_A, _B}
+        assert set(union_args(_A | _B | None)) == {_A, _B}
+
+    def test_union_args_is_empty_for_a_non_union(self):
+        """So callers can loop unconditionally."""
+        assert union_args(str) == ()
+        assert union_args(List[str]) == ()
+
+    def test_union_args_finds_a_list_arm_in_a_wide_union(self):
+        """The issue #33 shape: three arms, one of which is a list."""
+        annotation = Optional[List[str]] | Any
+        assert is_optional_union(annotation) is False  # not a single inner type
+        assert any(
+            getattr(arg, "__origin__", None) is list for arg in union_args(annotation)
+        )
+
+    def test_the_two_spellings_of_a_wide_union_agree(self):
+        """Same arms, differing only in how the *union* is written."""
+        assert set(union_args(Union[list[str], None, int])) == set(
+            union_args(list[str] | None | int)
+        )
+
+
+class TestUnwrapOptional:
+    def test_unwraps_every_spelling_to_the_same_inner_type(self):
+        assert unwrap_optional(Optional[str]) == (str, True)
+        assert unwrap_optional(Union[str, None]) == (str, True)
+        assert unwrap_optional(str | None) == (str, True)
+
+    def test_unwraps_a_generic_inner_type(self):
+        assert unwrap_optional(Optional[List[_A]]) == (List[_A], True)
+        assert unwrap_optional(list[_A] | None) == (list[_A], True)
+
+    def test_returns_a_bare_type_unchanged(self):
+        assert unwrap_optional(str) == (str, False)
+        assert unwrap_optional(List[str]) == (List[str], False)
+
+    def test_does_not_unwrap_a_multi_arm_union(self):
+        """Must not pick an arbitrary arm."""
+        assert unwrap_optional(Union[_A, _B, None]) == (Union[_A, _B, None], False)
+        multi = _A | _B | None
+        assert unwrap_optional(multi) == (multi, False)
+
+    def test_the_two_spellings_unwrap_identically(self):
+        assert unwrap_optional(Optional[_A]) == unwrap_optional(_A | None)
+        assert unwrap_optional(Optional[List[_A]])[1] == unwrap_optional(list[_A] | None)[1]

--- a/tests/structured_object_evaluator/test_pep604_hierarchical_parity.py
+++ b/tests/structured_object_evaluator/test_pep604_hierarchical_parity.py
@@ -1,0 +1,178 @@
+"""The spelling of an optional must not flatten a hierarchical metric breakdown.
+
+``ConfigurationHelper.is_structured_field_type`` is the #149 gate: when it
+returns False for a nested-object field, ``StructuredListComparator`` routes
+that field down the non-hierarchical path and, as the comment at
+``configuration_helper.py:165-168`` already warned, it "loses its nested metric
+breakdown".
+
+It returned True for ``Optional[Inner]`` and False for ``Inner | None``, so a
+PEP 604-spelled optional nested object silently lost the very breakdown #149
+restored -- while the top-level counts still agreed, which is why it hid.
+
+This is the more serious half of the PEP 604 gap: schema export produces
+visibly wrong output, but this produces a report that looks complete and is
+missing rows.
+"""
+
+from typing import List, Optional
+
+from stickler.comparators.exact import ExactComparator
+from stickler.structured_object_evaluator.models.comparable_field import ComparableField
+from stickler.structured_object_evaluator.models.configuration_helper import (
+    ConfigurationHelper,
+)
+from stickler.structured_object_evaluator.models.structured_list_comparator import (
+    StructuredListComparator,
+)
+from stickler.structured_object_evaluator.models.structured_model import StructuredModel
+
+
+class _Inner(StructuredModel):
+    city: str = ComparableField(comparator=ExactComparator())
+
+
+class TypingOuter(StructuredModel):
+    opt_obj: Optional[_Inner] = ComparableField(default=None, comparator=ExactComparator())
+    opt_list: Optional[List[_Inner]] = ComparableField(default=None)
+    opt_str: Optional[str] = ComparableField(default=None, comparator=ExactComparator())
+
+
+class Pep604Outer(StructuredModel):
+    opt_obj: _Inner | None = ComparableField(default=None, comparator=ExactComparator())
+    opt_list: list[_Inner] | None = ComparableField(default=None)
+    opt_str: str | None = ComparableField(default=None, comparator=ExactComparator())
+
+
+class TestIsStructuredFieldTypeSpellingParity:
+    """Mirrors test_configuration_helper_optional_structured.py in PEP 604."""
+
+    def test_optional_structured_model_is_structured_in_both_spellings(self):
+        assert (
+            ConfigurationHelper.is_structured_field_type(TypingOuter.model_fields["opt_obj"])
+            is True
+        )
+        assert (
+            ConfigurationHelper.is_structured_field_type(Pep604Outer.model_fields["opt_obj"])
+            is True
+        )
+
+    def test_optional_list_of_models_is_structured_in_both_spellings(self):
+        assert (
+            ConfigurationHelper.is_structured_field_type(TypingOuter.model_fields["opt_list"])
+            is True
+        )
+        assert (
+            ConfigurationHelper.is_structured_field_type(Pep604Outer.model_fields["opt_list"])
+            is True
+        )
+
+    def test_optional_primitive_is_not_structured_in_either_spelling(self):
+        assert (
+            ConfigurationHelper.is_structured_field_type(TypingOuter.model_fields["opt_str"])
+            is False
+        )
+        assert (
+            ConfigurationHelper.is_structured_field_type(Pep604Outer.model_fields["opt_str"])
+            is False
+        )
+
+
+# ---------------------------------------------------------------------------
+# The list-element models. Each item carries three matching sibling fields so
+# the pair scores 0.75 -- above the 0.7 match threshold -- because
+# StructuredListComparator only generates field_details for a good match
+# (structured_list_comparator.py:264-270).
+# ---------------------------------------------------------------------------
+
+
+class TypingItem(StructuredModel):
+    label: str = ComparableField(comparator=ExactComparator())
+    p1: str = ComparableField(comparator=ExactComparator())
+    p2: str = ComparableField(comparator=ExactComparator())
+    addr: Optional[_Inner] = ComparableField(default=None, comparator=ExactComparator())
+
+
+class Pep604Item(StructuredModel):
+    label: str = ComparableField(comparator=ExactComparator())
+    p1: str = ComparableField(comparator=ExactComparator())
+    p2: str = ComparableField(comparator=ExactComparator())
+    addr: _Inner | None = ComparableField(default=None, comparator=ExactComparator())
+
+
+class TypingDoc(StructuredModel):
+    items: List[TypingItem] = ComparableField()
+
+
+class Pep604Doc(StructuredModel):
+    items: List[Pep604Item] = ComparableField()
+
+
+def _addr_detail(doc_cls, item_cls):
+    """field_details['addr'] for a list whose item has an optional nested model."""
+    gt = [item_cls(label="a", p1="x", p2="y", addr=_Inner(city="Seattle"))]
+    pred = [item_cls(label="a", p1="x", p2="y", addr=_Inner(city="Portland"))]
+    comparator = StructuredListComparator(doc_cls(items=gt))
+    result = comparator.compare_struct_list_with_scores(gt, pred, "items")
+    return result["fields"]["addr"]
+
+
+class TestHierarchicalBreakdownSpellingParity:
+    def test_both_spellings_produce_equal_field_detail(self):
+        assert _addr_detail(TypingDoc, TypingItem) == _addr_detail(Pep604Doc, Pep604Item)
+
+    def test_pep604_keeps_the_nested_field_breakdown(self):
+        """``addr.fields.city`` was absent entirely for ``_Inner | None``."""
+        detail = _addr_detail(Pep604Doc, Pep604Item)
+        assert "fields" in detail
+        assert "city" in detail["fields"]
+
+    def test_pep604_keeps_the_derived_metrics(self):
+        detail = _addr_detail(Pep604Doc, Pep604Item)
+        assert "derived" in detail["overall"]
+        for key in ("cm_precision", "cm_recall", "cm_f1", "cm_accuracy"):
+            assert key in detail["overall"]["derived"]
+
+    def test_pep604_keeps_the_similarity_scores(self):
+        detail = _addr_detail(Pep604Doc, Pep604Item)
+        for key in (
+            "raw_similarity_score",
+            "similarity_score",
+            "threshold_applied_score",
+        ):
+            assert key in detail
+
+    def test_the_top_level_counts_agreed_all_along(self):
+        """Why this hid: the confusion matrix looked right either way."""
+        typing_counts = _addr_detail(TypingDoc, TypingItem)["overall"]
+        pep604_counts = _addr_detail(Pep604Doc, Pep604Item)["overall"]
+        for key in ("tp", "fd", "fp"):
+            assert typing_counts[key] == pep604_counts[key]
+
+
+class TestListDispatchSpellingParity:
+    """``_is_list_field`` read ``__origin__`` as an attribute, which a PEP 604
+    union does not have -- so the branch was unreachable rather than merely
+    narrow.
+    """
+
+    def test_optional_list_is_recognised_as_a_list_field(self):
+        typing_doc = TypingOuter(opt_list=[_Inner(city="Seattle")])
+        pep604_doc = Pep604Outer(opt_list=[_Inner(city="Seattle")])
+        assert typing_doc._is_list_field("opt_list") is True
+        assert pep604_doc._is_list_field("opt_list") is True
+
+    def test_optional_scalar_is_not_a_list_field(self):
+        typing_doc = TypingOuter(opt_str="x")
+        pep604_doc = Pep604Outer(opt_str="x")
+        assert typing_doc._is_list_field("opt_str") is False
+        assert pep604_doc._is_list_field("opt_str") is False
+
+    def test_optional_list_of_models_type_check_agrees(self):
+        assert (
+            StructuredModel._is_list_of_structured_model_type(Optional[List[_Inner]])
+            is True
+        )
+        assert (
+            StructuredModel._is_list_of_structured_model_type(list[_Inner] | None) is True
+        )

--- a/tests/structured_object_evaluator/test_pep604_schema_parity.py
+++ b/tests/structured_object_evaluator/test_pep604_schema_parity.py
@@ -1,0 +1,246 @@
+"""How an optional field is spelled must not change what the library does.
+
+``Optional[T]``, ``Union[T, None]`` and ``T | None`` are the same type. Ten
+sites tested ``get_origin(x) is Union``, which is False for the PEP 604
+spelling, so a ``T | None`` field took a different path from an identical
+``Optional[T]`` field.
+
+Export was the visible half: the nested model, its fields, and its whole
+comparison configuration were replaced by ``{"type": "string"}`` -- with no
+error and no warning -- so ``from_json_schema(M.to_json_schema())`` rebuilt a
+structurally different model. A nested *list* of models collapsed the same way.
+
+Assertions compare the spellings to each other rather than to literal schemas,
+except where the absolute value is the claim (a nested field being ``"object"``
+and not ``"string"``). Two independent literals can drift apart while both stay
+green, which is how this survived #268.
+"""
+
+from typing import List, Optional, Union
+
+import pytest
+
+from stickler import ComparableField, StructuredModel
+
+
+class Nested(StructuredModel):
+    a: str = ComparableField(threshold=0.9)
+
+
+class TypingOptional(StructuredModel):
+    n: Optional[Nested] = ComparableField()
+
+
+class TypingUnion(StructuredModel):
+    n: Union[Nested, None] = ComparableField()
+
+
+class Pep604(StructuredModel):
+    n: Nested | None = ComparableField()
+
+
+class TypingOptionalList(StructuredModel):
+    items: Optional[List[Nested]] = ComparableField()
+
+
+class Pep604List(StructuredModel):
+    items: list[Nested] | None = ComparableField()
+
+
+class TypingOptionalScalar(StructuredModel):
+    s: Optional[str] = ComparableField()
+
+
+class Pep604Scalar(StructuredModel):
+    s: str | None = ComparableField()
+
+
+class TestNestedModelExportParity:
+    def test_all_three_spellings_export_equal_schemas(self):
+        typing_optional = TypingOptional.to_json_schema()["properties"]["n"]
+        typing_union = TypingUnion.to_json_schema()["properties"]["n"]
+        pep604 = Pep604.to_json_schema()["properties"]["n"]
+        assert typing_optional == typing_union
+        assert typing_optional == pep604
+
+    def test_a_nested_model_is_not_exported_as_a_string(self):
+        """The defect: the model, its fields and its config became "string"."""
+        prop = Pep604.to_json_schema()["properties"]["n"]
+        assert prop["type"] == "object"
+        assert prop["type"] != "string"
+
+    def test_the_nested_models_own_configuration_survives(self):
+        prop = Pep604.to_json_schema()["properties"]["n"]
+        assert prop["x-aws-stickler-model-name"] == "Nested"
+        assert prop["properties"]["a"]["x-aws-stickler-threshold"] == 0.9
+
+
+class TestNestedListExportParity:
+    def test_optional_list_of_models_exports_equal_schemas(self):
+        assert (
+            TypingOptionalList.to_json_schema()["properties"]["items"]
+            == Pep604List.to_json_schema()["properties"]["items"]
+        )
+
+    def test_an_optional_list_of_models_is_not_exported_as_a_string(self):
+        """A whole array of models, its item schema and its match threshold."""
+        prop = Pep604List.to_json_schema()["properties"]["items"]
+        assert prop["type"] == "array"
+        assert prop["items"]["type"] == "object"
+        assert prop["items"]["x-aws-stickler-model-name"] == "Nested"
+
+
+class TestScalarNullabilityParity:
+    def test_optional_scalar_exports_equal_schemas(self):
+        assert (
+            TypingOptionalScalar.to_json_schema()["properties"]["s"]
+            == Pep604Scalar.to_json_schema()["properties"]["s"]
+        )
+
+    def test_nullability_survives_the_pep604_spelling(self):
+        """``is_nullable`` was derived from the same failing unwrap, so a
+        ``str | None`` field exported as ``"string"`` rather than
+        ``["string", "null"]``.
+        """
+        prop = Pep604Scalar.to_json_schema()["properties"]["s"]
+        assert prop["type"] == ["string", "null"]
+
+
+class TestRoundTripParity:
+    def test_pep604_nested_model_rebuilds_as_a_nested_model(self):
+        """It previously rebuilt as ``Optional[str]`` -- a different model."""
+        rebuilt = StructuredModel.from_json_schema(Pep604.to_json_schema())
+        annotation = rebuilt.model_fields["n"].annotation
+        assert annotation is not str
+        assert annotation != Optional[str]
+
+    def test_both_spellings_rebuild_to_the_same_field_shape(self):
+        from_typing = StructuredModel.from_json_schema(TypingOptional.to_json_schema())
+        from_pep604 = StructuredModel.from_json_schema(Pep604.to_json_schema())
+        assert set(from_typing.model_fields) == set(from_pep604.model_fields)
+        for name in from_typing.model_fields:
+            assert str(from_typing.model_fields[name].annotation) == str(
+                from_pep604.model_fields[name].annotation
+            ), name
+
+    def test_rebuilt_nested_model_keeps_its_nested_field(self):
+        rebuilt = StructuredModel.from_json_schema(Pep604.to_json_schema())
+        nested_annotation = rebuilt.model_fields["n"].annotation
+        # Unwrap the Optional to reach the nested model class.
+        from stickler.structured_object_evaluator.models.optional_annotation import (
+            unwrap_optional,
+        )
+
+        inner, was_optional = unwrap_optional(nested_annotation)
+        assert was_optional
+        assert issubclass(inner, StructuredModel)
+        assert "a" in inner.model_fields
+
+
+class TestANestedModelIsNeverExportedAsAScalar:
+    """The silent `"string"` fallback is replaced by a raise.
+
+    `PYTHON_TYPE_TO_JSON_TYPE.get(field_type, "string")` treated "I don't know
+    this type" as "it's a string". For a nested model that yields a schema which
+    rebuilds into a different model, so it fails loudly instead.
+
+    Unreachable through `to_json_schema()` now that `_unwrap_optional` handles
+    every spelling -- this is a guard against regression, exercised directly.
+    """
+
+    def test_passing_a_model_type_to_field_to_property_raises(self):
+        from stickler.structured_object_evaluator.models.json_schema_field_converter import (
+            JsonSchemaFieldConverter,
+        )
+
+        converter = JsonSchemaFieldConverter({})
+        field_info = Pep604.model_fields["n"]
+        with pytest.raises(ValueError, match="StructuredModel") as excinfo:
+            converter.field_to_property(Nested, field_info)
+        assert "Nested" in str(excinfo.value)
+        assert "to_json_schema" in str(excinfo.value)
+
+    def test_unmodelled_scalar_types_still_export_as_string(self):
+        """The raise must not widen to every dict miss.
+
+        `Decimal`, `UUID` and enums legitimately fall back to `"string"`.
+        """
+        from decimal import Decimal
+        from uuid import UUID
+
+        from stickler.structured_object_evaluator.models.json_schema_field_converter import (
+            JsonSchemaFieldConverter,
+        )
+
+        converter = JsonSchemaFieldConverter({})
+        field_info = Pep604Scalar.model_fields["s"]
+        for scalar_type in (Decimal, UUID):
+            prop = converter.field_to_property(scalar_type, field_info)
+            assert prop["type"] == "string"
+
+
+class TestMultiArmUnionsAreLeftAlone:
+    def test_a_two_model_union_is_not_unwrapped_to_an_arbitrary_arm(self):
+        """Both spellings must agree, and neither may pick an arm."""
+        from stickler.structured_object_evaluator.models.optional_annotation import (
+            unwrap_optional,
+        )
+
+        class Other(StructuredModel):
+            b: str = ComparableField()
+
+        typing_form = Union[Nested, Other, None]
+        pep604_form = Nested | Other | None
+        assert unwrap_optional(typing_form) == (typing_form, False)
+        assert unwrap_optional(pep604_form) == (pep604_form, False)
+
+
+class TestAnOptionalListElementIsUnwrappedBeforeExport:
+    """``List[Optional[Model]]`` crashed both export paths.
+
+    ``_is_structured_model_type`` unwraps its argument, so the predicate said
+    "yes" for an ``Optional[Model]`` element and the branch it guards then called
+    ``to_json_schema()`` on the ``Optional[...]`` wrapper -- ``AttributeError``,
+    not a schema. Pre-existing for the ``Optional`` spelling; the PEP 604
+    spelling reached it only once #162's union handling made it resolve as a list
+    of models at all, having previously exported as an array of strings.
+    """
+
+    def test_both_spellings_export_the_element_model(self):
+        class TypingForm(StructuredModel):
+            items: List[Optional[Nested]] = ComparableField()
+
+        class Pep604Form(StructuredModel):
+            items: List[Nested | None] = ComparableField()
+
+        typing_items = TypingForm.to_json_schema()["properties"]["items"]["items"]
+        pep604_items = Pep604Form.to_json_schema()["properties"]["items"]["items"]
+        assert typing_items == pep604_items
+        # The element is the model, offered as nullable -- not a bare string.
+        branches = typing_items["anyOf"]
+        assert {"type": "null"} in branches
+        model_branch = next(b for b in branches if b != {"type": "null"})
+        assert model_branch["type"] == "object"
+        assert "a" in model_branch["properties"]
+
+    def test_both_spellings_export_a_config(self):
+        class TypingForm(StructuredModel):
+            items: List[Optional[Nested]] = ComparableField()
+
+        class Pep604Form(StructuredModel):
+            items: List[Nested | None] = ComparableField()
+
+        typing_config = TypingForm.to_stickler_config()["fields"]["items"]
+        assert typing_config == Pep604Form.to_stickler_config()["fields"]["items"]
+        assert typing_config["type"] == "list_structured_model"
+
+    def test_an_optional_primitive_element_keeps_its_type(self):
+        """``Optional[int]`` is not a key in the type table, so it fell to
+        ``"string"`` -- an integer list exported as a list of strings."""
+
+        class OptInts(StructuredModel):
+            nums: List[Optional[int]] = ComparableField()
+
+        items = OptInts.to_json_schema()["properties"]["nums"]["items"]
+        assert items == {"type": ["integer", "null"]}
+        assert OptInts.to_stickler_config()["fields"]["nums"]["type"] == "List[int]"


### PR DESCRIPTION
Split out of #273 per @sromoam's review: this is findings 1 and 2 as they
stood there, with no new API surface. Finding 3 is held in a draft
(`fix/214-schema-rebuild-tolerance`) pending the #189 decision.

Targets `dev`, so it flows into #256 rather than bypassing it.

## 1 — a list field's items never reached its declared comparator (HIGH)

`ComparisonHelper.compare_unordered_lists` built its `HungarianMatcher` with
`normalize_values` left at the default `True`, so `_prepare_lists` lowercased,
whitespace-collapsed and `str()`-coerced every item *before the comparator saw
it*. The field's declared comparator was handed values the caller never wrote.

One line, three shipped defects — with different histories:

- **`ExactComparator`'s strictness never reached a list field**, which silently
  undid #199 for every list-typed field. New in 0.7.0: on 0.6.0 the comparator
  folded case itself, so the matcher's normalization was redundant and the two
  paths agreed. Reachable with no configuration — the `id`, `code` and `zip`
  name tokens route to `ExactComparator(case_sensitive=True)`, so `order_ids`
  got none of the strictness `order_id` got.
- **`List[bbox]` could not score a match at all** — pre-existing, shipped in
  0.6.0. `_normalize_bbox` rejects a non-list, so a box arriving as
  `"[0, 0, 10, 10]"` was unparseable and IoU fell to `0.0` **for identical
  input**, in both accepted formats.
- **`List[dict]` scored `1.0` by comparing `str(dict)`** — also pre-existing.
  Now raises, naming `StructuredModel` as the fix.

Tests assert the list path against the *scalar path* rather than against
literals: two independent constants is how this survived #199.

The `List[dict]` raise is the one deliberate divergence, and the matrix is
entry-point dependent: `compare()` and `compare_field_raw()` already raise for
a scalar dict, but `compare_recursive()` returns `0.0`, because the dispatcher's
type-mismatch case intercepts a scalar dict and has no equivalent for a dict
item inside a list. The raise is kept — refusing an uncomparable shape beats a
silently wrong score, and the scalar `0.0` is the outlier — and all four cells
are pinned by test. #276 supersedes it eventually by rejecting a dict-typed
`ComparableField` at class definition.

## 2 — PEP 604 unions took a different path from `Optional` (MEDIUM)

`X | None` has no `__origin__` attribute and its `get_origin()` is
`types.UnionType`, not `typing.Union`. The review named one site; there were
**ten**. One read `__origin__` as an attribute, a shape no amount of widening a
`get_origin` comparison would have found.

The gap was not export-only. It reached **hierarchical metrics**: for an
optional nested object inside a list element, the reported field lost its nested
per-field rows, its derived metrics and its similarity scores — while top-level
`tp`/`fd`/`fp` stayed correct, so the confusion matrix looked right and the
detail underneath it was missing. That is why it hid. `to_json_schema()`
separately exported such a nested model as `{"type": "string"}`, discarding the
model; that now raises.

Consolidated into one helper. The ten sites were asking **two different
questions**: two need *the* single inner type in order to export it, the other
eight only ask "does any arm look like a list, or a model?" The latter keep
permissive semantics, so #33's `Optional[List[str]] | Any` still resolves as
before — converting all ten to strict single-arm unwrapping dropped that
model's aggregate `tp` from 6 to 2, caught by a full-suite gate.

Also fixes `List[Optional[Model]]`, which crashed both export paths with
`AttributeError`: the list branch read `args[0]` without unwrapping while the
predicate guarding it unwraps internally. Pre-existing for the `Optional`
spelling; finding 2 made `X | None` reach it.

## Behavior changes to be aware of

Scores move for list fields. This is the correction, but it will show up when
diffing against a stored baseline:

| shape | before | after |
|---|---|---|
| `List[str]` under Exact, case/whitespace-only difference | `1.0` | `0.0` |
| `List[bbox]`, identical input | `0.0` | real IoU |
| `List[dict]` under Levenshtein | `1.0` | `TypeError` |
| `X \| None` models, hierarchical metrics | flattened | nested rows appear |
| `List[Optional[int]]` exported item type | `"string"` | `["integer","null"]` |

Pre-0.7.0 leniency for identifier lists is available as
`ExactComparator(case_sensitive=False)` — the same knob a scalar field uses.

One asymmetry is deliberate and documented: `NullHelper` treats `""` as
equivalent to `None` for a scalar primitive, so a scalar scores `None` against
`""` as `1.0` while the list path applies the comparator's `None` policy and
scores `0.0`.

## Verification

- **1946 passed, 12 skipped** (baseline 1879/12), without the `bert` extra.
  67 tests added, **no existing test modified**.
- New tests were confirmed to *fail* against pre-fix `src/` rather than merely
  passing after it.
- `ruff check src/ tests/` clean.
- The delta against #273's branch is exactly the finding-3 surface — the
  `tolerate_missing_fields` plumbing, the `mark_schema_required` marker and
  `test_json_schema_required_tolerance.py` — and nothing else.

The one doc change carried over from finding 3's territory: the 0.7.0 CHANGELOG
note on `from_json_schema(M.model_json_schema())` was false in both halves *and
inverted*, calling the all-required model benign when it is precisely the broken
one. Corrected here, pointing at #214, with no claim about a mitigation.

## Still open (LOW, not addressed)

- A multi-arm union carrying models (`A | B | None`) exports as
  `{"type": "string"}`, discarding both models. The new guard misses it because
  the annotation is not a class.
- A single box spelled `List[float]` still scores `0.0` against identical input
  — each coordinate is matched individually. The `versionchanged` note names the
  working spelling (`List[List[float]]`).
