### PR TITLE
feat: let a schema-rebuilt model score predictions that omit a required field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ Each release links to full notes on the
 
 ## [Unreleased]
 
+### Added
+
+- `StructuredModel.from_json_schema(schema, tolerate_missing_fields=True)` builds
+  a model that constructs from partial input, so a prediction omitting a field
+  the schema marks required is scored as a miss instead of raising
+  `ValidationError`.
+
+  This is what an *evaluation* model needs: the engine builds instances from
+  extraction output, and a hand-written `ComparableField` model already tolerates
+  omission for exactly that reason. A schema-built model did not, which made
+  `from_json_schema(Model.model_json_schema())` -- advertised in
+  `src/stickler/auto/README.md` -- unusable for scoring anything incomplete.
+
+  The default is `False`, preserving today's strict behavior, because a schema's
+  `required` list is a contract for callers who want it enforced. In particular
+  `required` together with a nullable type still means "must be present, may be
+  null", and the flag does not blur those two.
+
+  Requiredness is not traded away. `model_json_schema()` and `to_json_schema()`
+  name exactly the same required fields whether or not the flag is set, so the
+  Strands tool spec is unaffected. For a field that is required and *not*
+  nullable that follows from the annotation staying bare; a field that is
+  required *and* nullable must be annotated `Optional[X]` to accept null, which
+  is indistinguishable from an ordinary optional field by shape alone, so the
+  schema's own answer is recorded on the field and consulted when rendering. The
+  flag propagates into nested models and array items, so neither tolerance nor
+  the requiredness it preserves stops at the first level.
+
+  Whether `False` is the right default is open. An omitted field is a false
+  negative, which is what the library measures, so "a comparison model tolerates
+  omission" may be an invariant rather than an option -- in which case this
+  should be unconditional and not a flag at all. That turns on
+  [#189](https://github.com/awslabs/stickler/issues/189), which is about
+  `ComparableField` having no working notion of a required field in the first
+  place ([#214](https://github.com/awslabs/stickler/issues/214))
+
 ## [0.7.0] - 2026-08-18
 
 ### Added
@@ -219,7 +255,8 @@ Each release links to full notes on the
   not just some: a model with no `Optional` field at all is precisely the case,
   since `Optional` fields are the ones that were never required to begin with.
   Model an evaluation target by hand, or via `to_json_schema()` /
-  `to_stickler_config()`, until this is resolved. Tracked in
+  `to_stickler_config()`, on this release; `tolerate_missing_fields=True` (see
+  Unreleased) gets the hand-written model's behavior. Tracked in
   [#214](https://github.com/awslabs/stickler/issues/214)
   ([#188](https://github.com/awslabs/stickler/issues/188))
 

--- a/src/stickler/auto/README.md
+++ b/src/stickler/auto/README.md
@@ -20,10 +20,9 @@ The two pre-existing entry points lose information from real pydantic models:
 - `StructuredModel.from_json_schema(Model.model_json_schema())` supports
   nullable `Optional` schemas, but not general multi-type unions, and silently
   degrades enums and `datetime` to bare strings. It also enforces the schema's
-  `required` list at construction, so it rejects a prediction that omits such a
-  field instead of scoring the miss
-  ([#214](https://github.com/awslabs/stickler/issues/214)) — and a shape-only
-  schema carries no comparison configuration, so the rebuilt model gets default
+  `required` list at construction, so it rejects a prediction that omits a field
+  unless you pass `tolerate_missing_fields=True` — and a shape-only schema
+  carries no comparison configuration, so the rebuilt model gets default
   thresholds, weights and comparators.
 - Unannotated `StructuredModel` fields fall through
   `configuration_helper.py`'s type-blind default and get compared with

--- a/src/stickler/structured_object_evaluator/models/comparable_field.py
+++ b/src/stickler/structured_object_evaluator/models/comparable_field.py
@@ -187,6 +187,51 @@ def ComparableField(
     return field
 
 
+# Attribute set on a field's ``json_schema_extra`` callable to record that the
+# source JSON Schema listed the field in ``required``, even though the field
+# carries ``default=None`` so that construction tolerates its absence.
+#
+# Needed because that pairing is otherwise ambiguous. On a non-nullable
+# annotation, ``default=None`` alone identifies a required field -- that is
+# ComparableField's construction-tolerance sentinel, which
+# ``_AnnotationDrivenJsonSchema.field_is_required`` reads. On a *nullable*
+# annotation it does not: ``Optional[str]`` with ``default=None`` is exactly
+# what an optional field looks like, so a schema-required nullable field was
+# indistinguishable from an optional one and silently dropped out of the
+# rendered ``required`` list.
+#
+# Carried as a function attribute rather than a schema key because that is
+# already how ComparableField smuggles runtime data past ``FieldInfo``'s
+# ``__slots__`` (``_threshold``, ``_comparator_instance``). It therefore never
+# reaches rendered output and needs no stripping.
+SCHEMA_REQUIRED_ATTR = "_schema_required"
+
+
+def mark_schema_required(field: Any) -> None:
+    """Record that the source schema declared this field required.
+
+    No-op when the field carries no callable ``json_schema_extra``, which is
+    every field not built by ``ComparableField``.
+    """
+    extra = getattr(field, "json_schema_extra", None)
+    if callable(extra):
+        setattr(extra, SCHEMA_REQUIRED_ATTR, True)
+
+
+def is_schema_required(field_info: Any) -> bool:
+    """Whether the source schema declared this field required.
+
+    ``False`` for hand-written models, which never set the marker -- their
+    requiredness is already legible from the annotation.
+    """
+    return bool(
+        getattr(
+            getattr(field_info, "json_schema_extra", None),
+            SCHEMA_REQUIRED_ATTR,
+            False,
+        )
+    )
+
 
 def _restore_deprecated_aggregate(field: Any, value: Any) -> None:
     """Set a field's stored ``aggregate`` value without emitting a warning.

--- a/src/stickler/structured_object_evaluator/models/json_schema_field_converter.py
+++ b/src/stickler/structured_object_evaluator/models/json_schema_field_converter.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type
 
 from pydantic.fields import FieldInfo
 
-from .comparable_field import ComparableField
+from .comparable_field import ComparableField, mark_schema_required
 from .comparator_registry import create_comparator
 from .optional_annotation import unwrap_optional
 
@@ -54,17 +54,31 @@ class JsonSchemaFieldConverter:
     It extracts x-aws-stickler-* extensions and calls ComparableField() to create Pydantic Fields.
     """
 
-    def __init__(self, schema: Dict[str, Any], field_path: str = ""):
+    def __init__(
+        self,
+        schema: Dict[str, Any],
+        field_path: str = "",
+        tolerate_missing_fields: bool = False,
+    ):
         """Initialize with a JSON Schema document.
 
         Args:
             schema: JSON Schema document (already validated)
             field_path: Current field path for error messages (e.g., "address.street")
+            tolerate_missing_fields: When True, a required field with no stated
+                default is given ``default=None`` -- ComparableField's
+                construction-tolerance sentinel -- so the built model constructs
+                from a prediction that omits the field and the engine scores a
+                miss instead of raising ``ValidationError``. The annotation stays
+                non-nullable either way, so the field is still reported as
+                required in a rendered schema. Defaults to False, which enforces
+                the schema's ``required`` list at construction time.
         """
         self.schema = schema
         self.definitions = schema.get("definitions", {})
         self.defs = schema.get("$defs", {})  # JSON Schema draft 2019-09+
         self.field_path = field_path
+        self.tolerate_missing_fields = tolerate_missing_fields
 
     def convert_properties_to_fields(
         self, properties: Dict[str, Any], required: List[str]
@@ -137,8 +151,32 @@ class JsonSchemaFieldConverter:
         # Keeping this in one place means the nested-object / array handlers
         # never widen themselves; item-level nullability inside arrays
         # (List[Optional[T]]) is still applied by _handle_array_type.
-        default = property_schema.get("default", ... if is_required else None)
-        widen_to_optional = (not is_required) or (default is None) or is_nullable
+        #
+        # With ``tolerate_missing_fields``, a required field with no stated
+        # default gets ``default=None`` instead of ``...`` -- ComparableField's
+        # construction-tolerance sentinel, so a rebuilt model scores a
+        # prediction that omits the field rather than raising ValidationError.
+        # It must NOT widen the annotation: the sentinel only reads as
+        # "required" while the annotation stays non-nullable (see
+        # _AnnotationDrivenJsonSchema.field_is_required), so widening would drop
+        # the field out of the rendered schema's ``required`` list.
+        #
+        # Hence widening keys off whether the schema *stated* a default rather
+        # than off the resulting value: a None we were given means nullable, a
+        # None we supplied means tolerant, and the two are indistinguishable by
+        # value alone.
+        has_explicit_default = "default" in property_schema
+        if has_explicit_default:
+            default = property_schema["default"]
+        elif is_required:
+            default = None if self.tolerate_missing_fields else ...
+        else:
+            default = None
+        widen_to_optional = (
+            (not is_required)
+            or (has_explicit_default and default is None)
+            or is_nullable
+        )
 
         # Handle nested objects / arrays via their handlers; primitives inline.
         if json_type == "object":
@@ -182,6 +220,17 @@ class JsonSchemaFieldConverter:
 
         if widen_to_optional:
             field_type = Optional[field_type]
+
+        # Tolerating an omission is a construction-time concession, not a claim
+        # that the schema left the field optional. Record the schema's own
+        # answer so a further render still reports it required -- the sentinel
+        # cannot say so by itself once the annotation is nullable, because
+        # `Optional[X]` + `default=None` is also exactly what an optional field
+        # looks like. A field with a stated default is excluded: it is not
+        # relying on tolerance, and treating it as required would change the
+        # strict path's rendering too.
+        if is_required and self.tolerate_missing_fields and not has_explicit_default:
+            mark_schema_required(field)
 
         return field_type, field
 
@@ -521,7 +570,14 @@ class JsonSchemaFieldConverter:
             enriched_schema["$defs"] = self.defs
         
         try:
-            NestedModel = StructuredModel._from_json_schema_internal(enriched_schema, field_path=field_path)
+            # Propagate the flag so a nested model's own required fields behave
+            # the same way as the parent's -- tolerance must not stop at the
+            # first level.
+            NestedModel = StructuredModel._from_json_schema_internal(
+                enriched_schema,
+                field_path=field_path,
+                tolerate_missing_fields=self.tolerate_missing_fields,
+            )
         except ValueError:
             # Nested errors already have field path context
             raise
@@ -531,8 +587,13 @@ class JsonSchemaFieldConverter:
         weight = extensions.get("weight", 1.0)
         clip_under_threshold = extensions.get("clip_under_threshold", True)
         
-        # Get default value
-        default = property_schema.get("default", ... if is_required else None)
+        # Get default value. Same tolerance sentinel as the primitive path in
+        # convert_property_to_field, so a required nested object behaves like a
+        # required scalar.
+        default = property_schema.get(
+            "default",
+            ... if (is_required and not self.tolerate_missing_fields) else None,
+        )
         description = property_schema.get("description")
 
         # Create ComparableField with dummy comparator (not used for StructuredModel)
@@ -582,7 +643,11 @@ class JsonSchemaFieldConverter:
         if items_type == "object":
             from .structured_model import StructuredModel
             try:
-                ElementModel = StructuredModel._from_json_schema_internal(items_schema, field_path=f"{field_path}[]")
+                ElementModel = StructuredModel._from_json_schema_internal(
+                    items_schema,
+                    field_path=f"{field_path}[]",
+                    tolerate_missing_fields=self.tolerate_missing_fields,
+                )
             except ValueError:
                 # Nested errors already have field path context
                 raise
@@ -609,8 +674,13 @@ class JsonSchemaFieldConverter:
         weight = extensions.get("weight", 1.0)
         clip_under_threshold = extensions.get("clip_under_threshold", True)
         
-        # Get default
-        default = property_schema.get("default", ... if is_required else None)
+        # Get default. Same tolerance sentinel as the primitive path in
+        # convert_property_to_field, so a required array behaves like a required
+        # scalar.
+        default = property_schema.get(
+            "default",
+            ... if (is_required and not self.tolerate_missing_fields) else None,
+        )
         description = property_schema.get("description")
 
         # Create ComparableField

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -23,7 +23,11 @@ from pydantic.json_schema import GenerateJsonSchema
 from stickler.comparators.base import BaseComparator
 from stickler.utils.deprecation import warn_once
 
-from .comparable_field import ComparableField
+from .comparable_field import (
+    SCHEMA_REQUIRED_ATTR,
+    ComparableField,
+    is_schema_required,
+)
 from .comparison_helper import ComparisonHelper
 from .configuration_helper import ConfigurationHelper
 from .evaluator_format_helper import EvaluatorFormatHelper
@@ -85,6 +89,17 @@ class _AnnotationDrivenJsonSchema(GenerateJsonSchema):
         if wrapped.get("default") is not None:
             # An explicit, meaningful default: optional.
             return False
+        # A field rebuilt from a schema that listed it in `required`, with
+        # tolerance requested. Checked before the nullability test below because
+        # that test cannot see it: a required *nullable* field is annotated
+        # `Optional[X]`, so the sentinel alone is indistinguishable from an
+        # ordinary optional field.
+        if getattr(
+            (field.get("metadata") or {}).get("pydantic_js_extra"),
+            SCHEMA_REQUIRED_ATTR,
+            False,
+        ):
+            return True
         # default=None on a non-Optional annotation is ComparableField's
         # construction-tolerance sentinel, not a statement that the field is
         # optional.
@@ -638,7 +653,11 @@ class StructuredModel(BaseModel):
         return ModelFactory.create_model_from_json(config, base_class=cls)
 
     @classmethod
-    def from_json_schema(cls, schema: Dict[str, Any]) -> Type["StructuredModel"]:
+    def from_json_schema(
+        cls,
+        schema: Dict[str, Any],
+        tolerate_missing_fields: bool = False,
+    ) -> Type["StructuredModel"]:
         """Create a StructuredModel subclass from a JSON Schema document.
 
         This method accepts standard JSON Schema documents and creates fully functional
@@ -680,6 +699,21 @@ class StructuredModel(BaseModel):
 
         Args:
             schema: JSON Schema document as a dictionary
+            tolerate_missing_fields: Whether the built model may be constructed
+                from input that omits fields the schema marks required.
+
+                Defaults to False, which enforces the schema's ``required``
+                list: omitting such a field raises ``ValidationError``.
+
+                Pass True when the model is for *evaluation*. The comparison
+                engine builds instances from predictions, and a prediction that
+                omits a field is the ordinary case the engine exists to score --
+                a hand-written ``ComparableField`` model tolerates it, and with
+                this flag a schema-built model does too, scoring a miss rather
+                than raising. Requiredness is not lost: such a field keeps a
+                non-nullable annotation, so it is still reported as required in
+                ``model_json_schema()`` and exported with a non-nullable type by
+                ``to_json_schema()``.
 
         Returns:
             StructuredModel subclass created from the schema
@@ -732,7 +766,11 @@ class StructuredModel(BaseModel):
             >>> # name field has weight=2.0, price field clips scores below 0.95
         """
 
-        return cls._from_json_schema_internal(schema, field_path="")
+        return cls._from_json_schema_internal(
+            schema,
+            field_path="",
+            tolerate_missing_fields=tolerate_missing_fields,
+        )
 
     @classmethod
     def from_pydantic(
@@ -792,7 +830,10 @@ class StructuredModel(BaseModel):
 
     @classmethod
     def _from_json_schema_internal(
-        cls, schema: Dict[str, Any], field_path: str
+        cls,
+        schema: Dict[str, Any],
+        field_path: str,
+        tolerate_missing_fields: bool = False,
     ) -> Type["StructuredModel"]:
         """Internal method for creating StructuredModel from JSON Schema with field path tracking.
 
@@ -855,7 +896,11 @@ class StructuredModel(BaseModel):
         required = schema.get("required", [])
 
         # Create converter and convert properties to field definitions
-        converter = JsonSchemaFieldConverter(schema, field_path=field_path)
+        converter = JsonSchemaFieldConverter(
+            schema,
+            field_path=field_path,
+            tolerate_missing_fields=tolerate_missing_fields,
+        )
         field_definitions = converter.convert_properties_to_fields(properties, required)
 
         # Create the model using ModelFactory
@@ -1629,8 +1674,11 @@ class StructuredModel(BaseModel):
 
             schema["properties"][field_name] = property_schema
 
-            # Add to required if field is required (Pydantic uses is_required())
-            if field_info.is_required():
+            # Add to required if field is required. `is_required()` is False for
+            # anything carrying the construction-tolerance sentinel, so a model
+            # rebuilt with `tolerate_missing_fields=True` needs the schema's own
+            # answer as well or this export reports nothing required at all.
+            if field_info.is_required() or is_schema_required(field_info):
                 schema["required"].append(field_name)
 
         return schema

--- a/tests/structured_object_evaluator/test_json_schema_required_tolerance.py
+++ b/tests/structured_object_evaluator/test_json_schema_required_tolerance.py
@@ -1,0 +1,471 @@
+"""``from_json_schema(..., tolerate_missing_fields=True)``.
+
+``ComparableField`` gives every field ``default=None`` so that construction
+tolerates partial predictions -- the engine builds instances from prediction
+JSON that omits fields, and a prediction that omits a field is the ordinary case
+it exists to score. ``from_json_schema`` gave a required field ``default=...``
+(pydantic's "no default") instead, so a rebuilt model raised ``ValidationError``
+where the hand-written source model would have scored a miss.
+
+Rather than change that unconditionally, the tolerance is opt-in. Two audiences
+want different things from the same call: an evaluation model wants to accept
+whatever the extraction system produced, while a caller using a schema's
+``required`` list as a contract wants it enforced. The default stays strict --
+in particular ``required`` plus nullable still means "must be present, may be
+null", which
+``test_json_schema_field_converter.py::TestNullableTypeListForm`` and friends
+deliberately pin.
+
+With the flag on, a required field gets ``default=None`` while keeping a
+non-Optional annotation, which reproduces the source model's field shape
+exactly. Keeping the annotation bare is load-bearing:
+``_AnnotationDrivenJsonSchema.field_is_required`` reads exactly that sentinel
+(non-nullable annotation + ``default=None`` means required), so widening to
+``Optional[T]`` would report ``required: None`` and defeat the Strands tool
+spec. ``TestRequirednessSurvivesTheRebuild`` pins that invariant.
+
+Group 1 is characterisation: ``widen_to_optional`` is where #105, #127, #149 and
+#198 all converge, so those behaviors are pinned first and must not move.
+"""
+
+import json
+from typing import List, Optional
+
+import pytest
+from pydantic import ValidationError
+
+from stickler import ComparableField, StructuredModel
+from stickler.structured_object_evaluator.models.json_schema_field_converter import (
+    JsonSchemaFieldConverter,
+)
+
+
+def _fields(properties, required):
+    """Field definitions as JsonSchemaFieldConverter produces them."""
+    schema = {"type": "object", "properties": properties, "required": required}
+    return JsonSchemaFieldConverter(schema).convert_properties_to_fields(
+        properties, required
+    )
+
+
+def _annotation(properties, required, name):
+    return _fields(properties, required)[name][0]
+
+
+def _field_info(properties, required, name):
+    return _fields(properties, required)[name][1]
+
+
+# ---------------------------------------------------------------------------
+# Group 1 -- characterisation. These pass before and after the change.
+# ---------------------------------------------------------------------------
+
+
+class TestWidenToOptionalCharacterisation:
+    """The four cases converging on the widening decision. None may move."""
+
+    def test_not_required_field_is_widened_and_defaults_to_none(self):
+        """Issue #149."""
+        props = {"a": {"type": "string"}}
+        assert _annotation(props, [], "a") == Optional[str]
+        assert _field_info(props, [], "a").default is None
+
+    def test_required_field_with_explicit_null_default_is_widened(self):
+        """An explicit ``"default": null`` genuinely means nullable."""
+        props = {"a": {"type": "string", "default": None}}
+        assert _annotation(props, ["a"], "a") == Optional[str]
+        assert _field_info(props, ["a"], "a").default is None
+
+    def test_explicitly_nullable_type_list_is_widened(self):
+        """Issue #127: ``type: ["string", "null"]``."""
+        props = {"a": {"type": ["string", "null"]}}
+        assert _annotation(props, ["a"], "a") == Optional[str]
+
+    def test_two_branch_nullable_anyof_is_widened(self):
+        """Issues #105 / #198."""
+        props = {"a": {"anyOf": [{"type": "string"}, {"type": "null"}]}}
+        assert _annotation(props, ["a"], "a") == Optional[str]
+
+    def test_required_field_with_a_non_null_default_keeps_it(self):
+        """A stated default must survive, and must not widen the annotation."""
+        props = {"a": {"type": "string", "default": "fallback"}}
+        assert _annotation(props, ["a"], "a") is str
+        assert _field_info(props, ["a"], "a").default == "fallback"
+
+    def test_required_field_annotation_stays_bare(self):
+        """The constraint that forbids the widen-to-Optional shortcut."""
+        props = {"a": {"type": "string"}}
+        assert _annotation(props, ["a"], "a") is str
+
+
+# ---------------------------------------------------------------------------
+# Group 2 -- the defect.
+# ---------------------------------------------------------------------------
+
+
+class _Source(StructuredModel):
+    a: str = ComparableField()
+    b: Optional[str] = ComparableField()
+
+
+class _AllRequired(StructuredModel):
+    a: str = ComparableField()
+    c: int = ComparableField()
+
+
+class _Nested(StructuredModel):
+    city: str = ComparableField()
+
+
+class _WithNested(StructuredModel):
+    obj: _Nested = ComparableField()
+    items: List[str] = ComparableField()
+    scalar: str = ComparableField()
+
+
+class TestRebuiltModelToleratesPartialPredictions:
+    def test_a_required_field_may_be_omitted(self):
+        rebuilt = StructuredModel.from_json_schema(
+            _Source.model_json_schema(), tolerate_missing_fields=True
+        )
+        instance = rebuilt(b="y")
+        assert instance.a is None
+
+    def test_the_source_model_already_tolerated_it(self):
+        """Establishes that the rebuilt model was the odd one out."""
+        assert _Source(b="y").a is None
+
+    def test_a_model_with_no_optional_field_at_all(self):
+        """The shape the CHANGELOG called benign is the one that was broken.
+
+        No ``Optional`` field is involved, so the nullable ``anyOf`` gap #198
+        addresses has nothing to do with it.
+        """
+        rebuilt = StructuredModel.from_json_schema(
+            _AllRequired.model_json_schema(), tolerate_missing_fields=True
+        )
+        instance = rebuilt(a="x")
+        assert instance.c is None
+
+    def test_empty_input_constructs(self):
+        rebuilt = StructuredModel.from_json_schema(
+            _Source.model_json_schema(), tolerate_missing_fields=True
+        )
+        instance = rebuilt()
+        assert instance.a is None
+        assert instance.b is None
+
+    def test_the_rebuilt_model_is_not_stricter_than_the_hand_written_one(self):
+        rebuilt = StructuredModel.from_json_schema(
+            _Source.model_json_schema(), tolerate_missing_fields=True
+        )
+        for name in ("a", "b"):
+            source_field = _Source.model_fields[name]
+            rebuilt_field = rebuilt.model_fields[name]
+            assert rebuilt_field.is_required() == source_field.is_required(), name
+            assert rebuilt_field.default == source_field.default, name
+
+
+class TestRequirednessSurvivesTheRebuild:
+    """Tolerance is a construction concession, not a claim of optionality."""
+
+    def test_a_required_field_is_still_reported_required(self):
+        rebuilt = StructuredModel.from_json_schema(
+            _Source.model_json_schema(), tolerate_missing_fields=True
+        )
+        assert "a" in rebuilt.model_json_schema()["required"]
+
+    def test_an_optional_field_is_still_not_reported_required(self):
+        rebuilt = StructuredModel.from_json_schema(
+            _Source.model_json_schema(), tolerate_missing_fields=True
+        )
+        assert "b" not in (rebuilt.model_json_schema().get("required") or [])
+
+    def test_a_required_field_is_not_nullable_in_the_config_export(self):
+        rebuilt = StructuredModel.from_json_schema(
+            _Source.model_json_schema(), tolerate_missing_fields=True
+        )
+        assert rebuilt.to_json_schema()["properties"]["a"]["type"] == "string"
+
+    def test_requiredness_matches_the_source_model(self):
+        rebuilt = StructuredModel.from_json_schema(
+            _Source.model_json_schema(), tolerate_missing_fields=True
+        )
+        assert rebuilt.model_json_schema()["required"] == (
+            _Source.model_json_schema()["required"]
+        )
+
+
+_NULLABLE_AND_REQUIRED = {
+    "type": "object",
+    "properties": {
+        "nullable_required": {"type": ["string", "null"]},
+        "plain_required": {"type": "string"},
+        "not_required": {"type": "string"},
+        "defaulted_required": {"type": "string", "default": "d"},
+    },
+    "required": ["nullable_required", "plain_required", "defaulted_required"],
+}
+
+
+class TestRequirednessSurvivesForANullableRequiredField:
+    """The shape the construction-tolerance sentinel cannot express on its own.
+
+    On a non-nullable annotation, ``default=None`` *is* the marker for "required
+    but constructible" -- that is what ``field_is_required`` reads. On a nullable
+    annotation it says nothing, because ``Optional[str]`` with ``default=None``
+    is also exactly what an ordinary optional field looks like. So a field the
+    schema declared **required and nullable** was rendered as not required,
+    silently contradicting the invariant the class above pins for the
+    non-nullable case, and re-breaking the tool-spec use case
+    ``_AnnotationDrivenJsonSchema`` exists for.
+    """
+
+    def test_a_required_nullable_field_is_still_reported_required(self):
+        tolerant = StructuredModel.from_json_schema(
+            _NULLABLE_AND_REQUIRED, tolerate_missing_fields=True
+        )
+        assert "nullable_required" in tolerant.model_json_schema()["required"]
+
+    def test_tolerance_does_not_change_the_rendered_required_list_at_all(self):
+        """The strongest form: tolerance is invisible to a schema consumer."""
+        strict = StructuredModel.from_json_schema(_NULLABLE_AND_REQUIRED)
+        tolerant = StructuredModel.from_json_schema(
+            _NULLABLE_AND_REQUIRED, tolerate_missing_fields=True
+        )
+        assert (
+            tolerant.model_json_schema()["required"]
+            == strict.model_json_schema()["required"]
+        )
+
+    def test_the_config_export_reports_required_too(self):
+        """``to_json_schema`` derives ``required`` from ``is_required()``.
+
+        That is ``False`` for anything carrying the tolerance sentinel, so
+        without consulting the schema's own answer this export named nothing
+        required for a tolerantly built model -- and one export/import cycle
+        would then widen every annotation to ``Optional``.
+        """
+        strict = StructuredModel.from_json_schema(_NULLABLE_AND_REQUIRED)
+        tolerant = StructuredModel.from_json_schema(
+            _NULLABLE_AND_REQUIRED, tolerate_missing_fields=True
+        )
+        assert tolerant.to_json_schema()["required"] == (
+            strict.to_json_schema()["required"]
+        )
+        assert "nullable_required" in tolerant.to_json_schema()["required"]
+
+    def test_a_stated_default_still_means_not_required(self):
+        """Excluded deliberately: such a field is not relying on tolerance.
+
+        Marking it would change the strict path's rendering too, which is out of
+        scope. Asserted against the strict render so the two cannot diverge.
+        """
+        for model in (
+            StructuredModel.from_json_schema(_NULLABLE_AND_REQUIRED),
+            StructuredModel.from_json_schema(
+                _NULLABLE_AND_REQUIRED, tolerate_missing_fields=True
+            ),
+        ):
+            required = model.model_json_schema()["required"]
+            assert "defaulted_required" not in required
+            assert "not_required" not in required
+
+    def test_the_nullable_field_still_accepts_null_and_omission(self):
+        """Requiredness is restored to the *render*, not to construction."""
+        tolerant = StructuredModel.from_json_schema(
+            _NULLABLE_AND_REQUIRED, tolerate_missing_fields=True
+        )
+        assert tolerant.from_json({"plain_required": "x"}).nullable_required is None
+        assert (
+            tolerant.from_json(
+                {"nullable_required": None, "plain_required": "x"}
+            ).nullable_required
+            is None
+        )
+
+    def test_a_nested_required_nullable_field_is_reported_required(self):
+        """The marker rides on the field, so ``$defs`` entries get it for free."""
+        nested = {
+            "type": "object",
+            "properties": {
+                "child": {
+                    "type": "object",
+                    "properties": {"cid": {"type": ["string", "null"]}},
+                    "required": ["cid"],
+                }
+            },
+            "required": ["child"],
+        }
+        rendered = StructuredModel.from_json_schema(
+            nested, tolerate_missing_fields=True
+        ).model_json_schema()
+        child_defs = [
+            entry
+            for entry in rendered.get("$defs", {}).values()
+            if "cid" in entry.get("properties", {})
+        ]
+        assert child_defs, "expected the nested model to render into $defs"
+        assert all("cid" in entry["required"] for entry in child_defs)
+
+    def test_the_marker_does_not_leak_into_rendered_output(self):
+        """It is a function attribute, so no schema key needs stripping."""
+        tolerant = StructuredModel.from_json_schema(
+            _NULLABLE_AND_REQUIRED, tolerate_missing_fields=True
+        )
+        for rendered in (tolerant.model_json_schema(), tolerant.to_json_schema()):
+            assert "_schema_required" not in json.dumps(rendered)
+
+
+class TestToleranceIsUniformAcrossFieldShapes:
+    def test_a_required_nested_object_may_be_omitted(self):
+        rebuilt = StructuredModel.from_json_schema(
+            _WithNested.model_json_schema(), tolerate_missing_fields=True
+        )
+        instance = rebuilt(scalar="x")
+        assert instance.obj is None
+
+    def test_a_required_array_may_be_omitted(self):
+        rebuilt = StructuredModel.from_json_schema(
+            _WithNested.model_json_schema(), tolerate_missing_fields=True
+        )
+        instance = rebuilt(scalar="x")
+        assert instance.items is None
+
+    def test_a_required_field_inside_a_nested_object_may_be_omitted(self):
+        rebuilt = StructuredModel.from_json_schema(
+            _WithNested.model_json_schema(), tolerate_missing_fields=True
+        )
+        instance = rebuilt(obj={})
+        assert instance.obj is not None
+
+    def test_every_field_omitted_across_all_shapes(self):
+        rebuilt = StructuredModel.from_json_schema(
+            _WithNested.model_json_schema(), tolerate_missing_fields=True
+        )
+        instance = rebuilt()
+        assert instance.obj is None
+        assert instance.items is None
+        assert instance.scalar is None
+
+
+class TestExplicitDefaultsStillWin:
+    def test_a_non_null_default_on_a_required_field_is_used(self):
+        props = {"a": {"type": "string", "default": "fallback"}}
+        schema = {"type": "object", "properties": props, "required": ["a"]}
+        rebuilt = StructuredModel.from_json_schema(schema)
+        assert rebuilt().a == "fallback"
+
+    def test_an_explicit_null_default_makes_the_field_nullable(self):
+        props = {"a": {"type": "string", "default": None}}
+        schema = {"type": "object", "properties": props, "required": ["a"]}
+        rebuilt = StructuredModel.from_json_schema(schema)
+        assert rebuilt(a=None).a is None
+
+
+class TestTheSupportedRoundTripIsUnchanged:
+    """``to_json_schema()`` marks nothing required, so it already tolerated
+    omission. Its field shapes must not move.
+    """
+
+    def test_config_preserving_round_trip_still_constructs(self):
+        rebuilt = StructuredModel.from_json_schema(_AllRequired.to_json_schema())
+        assert rebuilt(a="x").c is None
+
+    def test_config_preserving_round_trip_field_shapes(self):
+        rebuilt = StructuredModel.from_json_schema(_AllRequired.to_json_schema())
+        for name in ("a", "c"):
+            assert rebuilt.model_fields[name].is_required() is False
+            assert rebuilt.model_fields[name].default is None
+
+
+class TestValidationErrorIsNoLongerRaised:
+    def test_the_exact_reproduction_from_the_review(self):
+        rebuilt = StructuredModel.from_json_schema(
+            _Source.model_json_schema(), tolerate_missing_fields=True
+        )
+        try:
+            rebuilt(b="y")
+        except ValidationError as exc:  # pragma: no cover - the defect
+            pytest.fail(f"rebuilt model rejected a partial prediction: {exc}")
+
+
+class TestTheDefaultRemainsStrict:
+    """Opting out is the default, so nothing existing changes shape."""
+
+    def test_omitting_a_required_field_still_raises_by_default(self):
+        rebuilt = StructuredModel.from_json_schema(_Source.model_json_schema())
+        with pytest.raises(ValidationError):
+            rebuilt(b="y")
+
+    def test_required_and_nullable_still_means_present_but_may_be_null(self):
+        """The distinction the flag must not erase when it is off."""
+        schema = {
+            "type": "object",
+            "properties": {"description": {"type": ["string", "null"]}},
+            "required": ["description"],
+        }
+        strict = StructuredModel.from_json_schema(schema)
+        assert strict(description=None).description is None
+        with pytest.raises(ValidationError):
+            strict()
+
+    def test_the_same_schema_tolerates_omission_when_asked(self):
+        schema = {
+            "type": "object",
+            "properties": {"description": {"type": ["string", "null"]}},
+            "required": ["description"],
+        }
+        tolerant = StructuredModel.from_json_schema(
+            schema, tolerate_missing_fields=True
+        )
+        assert tolerant().description is None
+
+    def test_default_field_shapes_are_unchanged(self):
+        rebuilt = StructuredModel.from_json_schema(_Source.model_json_schema())
+        assert rebuilt.model_fields["a"].is_required() is True
+        assert rebuilt.model_fields["b"].is_required() is False
+
+    def test_round_trip_idempotence_is_preserved_by_default(self):
+        """``to_json_schema()`` derives ``required`` from ``is_required()``, so
+        flipping it unconditionally would have degraded this round trip.
+        """
+
+        class Product(StructuredModel):
+            name: str = ComparableField(default=...)
+            in_stock: bool = ComparableField(default=...)
+
+        first = StructuredModel.from_json_schema(Product.to_json_schema())
+        second = StructuredModel.from_json_schema(first.to_json_schema())
+        assert first.to_json_schema() == second.to_json_schema()
+
+    def test_nested_and_array_shapes_are_strict_by_default(self):
+        rebuilt = StructuredModel.from_json_schema(_WithNested.model_json_schema())
+        with pytest.raises(ValidationError):
+            rebuilt(scalar="x")
+
+
+class TestToleranceReachesNestedModels:
+    """The flag must propagate through nested objects and array items."""
+
+    def test_a_nested_models_own_required_field_may_be_omitted(self):
+        rebuilt = StructuredModel.from_json_schema(
+            _WithNested.model_json_schema(), tolerate_missing_fields=True
+        )
+        instance = rebuilt(obj={})
+        assert instance.obj is not None
+        assert instance.obj.city is None
+
+    def test_an_array_items_required_field_may_be_omitted(self):
+        class Item(StructuredModel):
+            code: str = ComparableField()
+            label: str = ComparableField()
+
+        class Doc(StructuredModel):
+            items: List[Item] = ComparableField()
+
+        rebuilt = StructuredModel.from_json_schema(
+            Doc.model_json_schema(), tolerate_missing_fields=True
+        )
+        instance = rebuilt(items=[{"code": "A"}])
+        assert instance.items[0].label is None


### PR DESCRIPTION
Finding 3 of #273, split out per @sromoam's review and **held for the #189
decision** — see "The open question" below. Draft on purpose; nothing here is
asking to merge today.

Stacked on #278 (findings 1 and 2), which GitHub will retarget to `dev` once
that lands. The diff against #278 is this change alone.

## The defect

`from_json_schema` mapped a schema's `required` list to `default=...`, so a
rebuilt model raised `ValidationError` where the hand-written source model
scored a miss:

```
tolerate_missing_fields=False  (default) -> ValidationError: shipment_id Field required
tolerate_missing_fields=True             -> scored, shipment_id=0.0
```

The comparison engine builds instances from predictions, and a prediction that
omits a field is the ordinary case it exists to score. So the entry point
`src/stickler/auto/README.md` advertises for rebuilding a real pydantic model was
unusable for scoring anything incomplete.

## What this adds

`tolerate_missing_fields=True` gives such a field `ComparableField`'s
construction-tolerance sentinel (`default=None`) instead of `...`. It propagates
into nested models and array items, so tolerance does not stop at the first
level.

Requiredness is preserved rather than traded away, and that turned out to need
the schema's own answer recorded on the field:

- A field that is required *and* nullable must be annotated `Optional[X]` to
  accept null, at which point it is indistinguishable by shape from an optional
  one — so it dropped out of the rendered `required` list.
- `to_json_schema()` was worse: it derives `required` from `is_required()`, so it
  named **nothing** required for any tolerantly built model, and one
  export/import cycle widened every annotation.

## The open question — why this is a draft

@sromoam's position, which I think is right on the merits:

> An omitted field is an FN, which is what the library measures, so I don't think
> the strict setting has a legitimate use in a comparison model — which makes
> `False` the wrong default rather than a compatibility win.

Three arguments against landing it as-is, all of which stand:

1. It adds a public boolean immediately before a release that declares API
   stability, while #202 is open about flag proliferation.
2. It routes around #189 rather than resolving it. #189 is that `ComparableField`
   sets `default=None` unconditionally, so stickler has no working notion of a
   required field at all. If that lands properly this flag may be redundant
   surface we are committed to.
3. If tolerance is an invariant of a comparison model rather than an option, the
   right shape is unconditional behavior and no parameter.

Kept as a flag defaulting to `False` in this draft only because making it
unconditional **failed 7 tests, not the 4 predicted** — 4 of them encoding a
deliberate nullable-vs-optional distinction, and one exposing that
`to_json_schema()` round-trip idempotence depends on `is_required()`. Those 7 are
the real cost of flipping the default, and they are worth reading before deciding;
they are not a reason to prefer the flag.

Resolution paths, in preference order:
1. #189 lands and makes this unnecessary — close this.
2. #189 decides tolerance is an invariant — drop the parameter, make it
   unconditional, and pay down those 7 tests.
3. #189 stalls and the flag ships as the interim — flip the default to `True`
   first, per the review.

## Verification

- **1985 passed, 12 skipped** without the `bert` extra (39 tests added on top of
  #278's 1946). `ruff check src/ tests/` clean.
- `TestTheDefaultRemainsStrict` pins that no existing caller changes behavior.
- CHANGELOG entry sits under `[Unreleased]`, not 0.7.0, since this is not
  expected to ship with that release.
