### PR TITLE
fix: score an uncomparable list item 0.0 instead of raising (List[Dict] regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,19 +12,24 @@ Each release links to full notes on the
 ### Fixed
 
 - A `List[Dict[...]]` field no longer raises `TypeError` out of `compare_with()`,
-  and key order no longer affects its score. No comparator can compare two dicts:
-  `LevenshteinComparator` raises for one, and `str(dict)` preserves insertion
-  order, which is why 0.6.0 scored two dicts with identical content `0.5556`.
-  Until the list-item normalization fix, that raise could not reach the list path;
-  afterwards it escaped to the caller, so a field that scored in 0.6.0 crashed
-  instead. Items no comparator handles -- `dict`, `set`, `frozenset` -- are now
-  canonicalized to sorted-key JSON before comparison, so identical content scores
-  `1.0` regardless of key order. `list`, `tuple` and `StructuredModel` items pass
-  through untouched, so `List[bbox]` still parses. This matches what
-  `stickler.auto` already chooses for a dict field, so the explicit and
-  zero-config paths agree. Whether a dict deserves per-key comparison rather than
-  JSON-string similarity is [#277](https://github.com/awslabs/stickler/issues/277)
-
+  and key order no longer affects its score. `LevenshteinComparator` raises for a
+  dict, and the comparators that accept one do so only via `str(dict)`, which
+  preserves insertion order -- which is why 0.6.0 scored two dicts with identical
+  content `0.5556`. Until the list-item normalization fix, that raise could not
+  reach the list path; afterwards it escaped to the caller, so a field that scored
+  in 0.6.0 crashed instead. A list item whose comparator refuses it with
+  `TypeError` is now retried as sorted-key JSON, so identical content scores `1.0`
+  regardless of key order. The retry is a fallback, not a pre-filter: the
+  comparator is offered the raw item first, so a mapping-aware comparator still
+  receives a `dict`, and anything but a `dict` re-raises -- a comparator bug stays
+  loud instead of becoming a silent `0.0`, and `List[bbox]` still parses. The
+  canonical form is the one `stickler.auto` already applies to a dict field, now
+  shared from `stickler.utils.canonical`, so the explicit and zero-config paths
+  cannot drift apart; it also no longer raises `PydanticSerializationError` on a
+  payload pydantic cannot serialize, such as a NumPy scalar under
+  `Dict[str, Any]`. A scalar `Dict` field still raises, and `Set`/`FrozenSet`
+  items are unchanged. Whether a dict deserves per-key comparison rather than
+  JSON-string similarity is [#277](https://github.com/awslabs/stickler/issues/277).
 
 ## [0.7.0] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ Each release links to full notes on the
 
 ## [Unreleased]
 
+### Fixed
+
+- A `List[Dict[...]]` field no longer raises `TypeError` out of `compare_with()`,
+  and key order no longer affects its score. No comparator can compare two dicts:
+  `LevenshteinComparator` raises for one, and `str(dict)` preserves insertion
+  order, which is why 0.6.0 scored two dicts with identical content `0.5556`.
+  Until the list-item normalization fix, that raise could not reach the list path;
+  afterwards it escaped to the caller, so a field that scored in 0.6.0 crashed
+  instead. Items no comparator handles -- `dict`, `set`, `frozenset` -- are now
+  canonicalized to sorted-key JSON before comparison, so identical content scores
+  `1.0` regardless of key order. `list`, `tuple` and `StructuredModel` items pass
+  through untouched, so `List[bbox]` still parses. This matches what
+  `stickler.auto` already chooses for a dict field, so the explicit and
+  zero-config paths agree. Whether a dict deserves per-key comparison rather than
+  JSON-string similarity is [#277](https://github.com/awslabs/stickler/issues/277)
+
+
 ## [0.7.0] - 2026-08-18
 
 ### Added

--- a/src/stickler/algorithms/hungarian.py
+++ b/src/stickler/algorithms/hungarian.py
@@ -5,15 +5,14 @@ between two lists, which is commonly used for evaluating list-type fields in
 key information extraction tasks.
 """
 
-import json
 import traceback
 from typing import Any, Callable, List, Optional, Tuple, Union
 
 import numpy as np
 from munkres import Munkres, make_cost_matrix
-from pydantic_core import to_jsonable_python
 
 from stickler.comparators.base import BaseComparator
+from stickler.utils.canonical import canonicalize_json
 
 # Memory threshold for warning in MB
 HUNGARIAN_SIZE_WARNING_THRESHOLD = 10000  # Matrix size (product of dimensions)
@@ -152,19 +151,41 @@ class HungarianMatcher:
 
     @staticmethod
     def _comparable_form(item: Any) -> Any:
-        """Canonicalize an item no comparator can handle; pass everything else through.
+        """Canonical form for an item no comparator can handle.
 
-        A ``dict`` or ``set`` has no comparator: ``LevenshteinComparator`` raises
-        for one, and ``str(dict)`` makes key order significant. Sorted-key JSON
-        removes both problems and matches what ``stickler.auto`` already chooses
-        for a dict field, so the explicit and zero-config paths agree.
+        Only reached from :meth:`_score` after a comparator raised
+        ``TypeError``. A ``dict`` has no comparator: ``LevenshteinComparator``
+        raises for one, and ``str(dict)`` makes key order significant. Sorted-key
+        JSON removes both problems and matches what ``stickler.auto`` already
+        chooses for a dict field, so the explicit and zero-config paths agree.
 
-        ``list``/``tuple``/``StructuredModel`` pass through untouched: a bounding
-        box IS a list, and ``_normalize_bbox`` needs the raw value to parse it.
+        Everything else passes through untouched, so :meth:`_score` re-raises
+        rather than scoring: a bounding box IS a list, and a comparator that
+        raises on anything but a dict has a bug worth surfacing.
         """
-        if isinstance(item, (dict, set, frozenset)):
-            return json.dumps(to_jsonable_python(item), sort_keys=True)
+        if isinstance(item, dict):
+            return canonicalize_json(item)
         return item
+
+    def _score(self, item1: Any, item2: Any) -> float:
+        """Score one pair, canonicalizing dicts only if the comparator refuses.
+
+        The comparator sees the raw item first, so a dict-aware comparator keeps
+        working (#277). Canonicalization is the fallback, not a pre-filter. A
+        ``TypeError`` from anything but a dict pair propagates: it means a
+        comparator bug, not an uncomparable value.
+        """
+        compare = (
+            self.comparator.compare
+            if hasattr(self.comparator, "compare")
+            else self.comparator
+        )
+        try:
+            return compare(item1, item2)
+        except TypeError:
+            if not (isinstance(item1, dict) or isinstance(item2, dict)):
+                raise
+            return compare(self._comparable_form(item1), self._comparable_form(item2))
 
     def match(self, list1: Any, list2: Any) -> Tuple[List[Tuple[int, int]], np.ndarray]:
         """Find optimal assignments between two lists.
@@ -197,13 +218,7 @@ class HungarianMatcher:
             # Fill the matrix with similarity scores
             for i, item1 in enumerate(list1):
                 for j, item2 in enumerate(list2):
-                    # Handle callable function or object with compare method
-                    a = self._comparable_form(item1)
-                    b = self._comparable_form(item2)
-                    if hasattr(self.comparator, "compare"):
-                        similarity_matrix[i, j] = self.comparator.compare(a, b)
-                    else:
-                        similarity_matrix[i, j] = self.comparator(a, b)
+                    similarity_matrix[i, j] = self._score(item1, item2)
 
             # Check matrix size
             matrix_size = len(list1) * len(list2)
@@ -290,12 +305,7 @@ class HungarianMatcher:
         # property of this shortcut; see the Note in the docstring above.
         if len(prepared_list1) == 1 and len(prepared_list2) == 1:
             # Directly compare the single items
-            a = self._comparable_form(prepared_list1[0])
-            b = self._comparable_form(prepared_list2[0])
-            if hasattr(self.comparator, "compare"):
-                score = self.comparator.compare(a, b)
-            else:
-                score = self.comparator(a, b)
+            score = self._score(prepared_list1[0], prepared_list2[0])
 
             is_tp = score >= self.match_threshold
             tp = 1 if is_tp else 0

--- a/src/stickler/algorithms/hungarian.py
+++ b/src/stickler/algorithms/hungarian.py
@@ -5,11 +5,13 @@ between two lists, which is commonly used for evaluating list-type fields in
 key information extraction tasks.
 """
 
+import json
 import traceback
 from typing import Any, Callable, List, Optional, Tuple, Union
 
 import numpy as np
 from munkres import Munkres, make_cost_matrix
+from pydantic_core import to_jsonable_python
 
 from stickler.comparators.base import BaseComparator
 
@@ -148,6 +150,22 @@ class HungarianMatcher:
 
         return list1, list2
 
+    @staticmethod
+    def _comparable_form(item: Any) -> Any:
+        """Canonicalize an item no comparator can handle; pass everything else through.
+
+        A ``dict`` or ``set`` has no comparator: ``LevenshteinComparator`` raises
+        for one, and ``str(dict)`` makes key order significant. Sorted-key JSON
+        removes both problems and matches what ``stickler.auto`` already chooses
+        for a dict field, so the explicit and zero-config paths agree.
+
+        ``list``/``tuple``/``StructuredModel`` pass through untouched: a bounding
+        box IS a list, and ``_normalize_bbox`` needs the raw value to parse it.
+        """
+        if isinstance(item, (dict, set, frozenset)):
+            return json.dumps(to_jsonable_python(item), sort_keys=True)
+        return item
+
     def match(self, list1: Any, list2: Any) -> Tuple[List[Tuple[int, int]], np.ndarray]:
         """Find optimal assignments between two lists.
 
@@ -180,10 +198,12 @@ class HungarianMatcher:
             for i, item1 in enumerate(list1):
                 for j, item2 in enumerate(list2):
                     # Handle callable function or object with compare method
+                    a = self._comparable_form(item1)
+                    b = self._comparable_form(item2)
                     if hasattr(self.comparator, "compare"):
-                        similarity_matrix[i, j] = self.comparator.compare(item1, item2)
+                        similarity_matrix[i, j] = self.comparator.compare(a, b)
                     else:
-                        similarity_matrix[i, j] = self.comparator(item1, item2)
+                        similarity_matrix[i, j] = self.comparator(a, b)
 
             # Check matrix size
             matrix_size = len(list1) * len(list2)
@@ -270,10 +290,12 @@ class HungarianMatcher:
         # property of this shortcut; see the Note in the docstring above.
         if len(prepared_list1) == 1 and len(prepared_list2) == 1:
             # Directly compare the single items
+            a = self._comparable_form(prepared_list1[0])
+            b = self._comparable_form(prepared_list2[0])
             if hasattr(self.comparator, "compare"):
-                score = self.comparator.compare(prepared_list1[0], prepared_list2[0])
+                score = self.comparator.compare(a, b)
             else:
-                score = self.comparator(prepared_list1[0], prepared_list2[0])
+                score = self.comparator(a, b)
 
             is_tp = score >= self.match_threshold
             tp = 1 if is_tp else 0

--- a/src/stickler/auto/builder.py
+++ b/src/stickler/auto/builder.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 import datetime
 import decimal
 import enum
-import json
 import weakref
 from typing import (
     Annotated,
@@ -46,7 +45,6 @@ from typing import (
 
 from pydantic import BaseModel, BeforeValidator
 from pydantic.fields import FieldInfo
-from pydantic_core import to_jsonable_python
 
 from ..comparators.structured import StructuredModelComparator
 from ..structured_object_evaluator.models.comparable_field import ComparableField
@@ -56,6 +54,7 @@ from ..structured_object_evaluator.models.comparator_registry import (
 )
 from ..structured_object_evaluator.models.model_factory import ModelFactory
 from ..structured_object_evaluator.models.structured_model import StructuredModel
+from ..utils.canonical import canonicalize_json, canonicalize_json_sorted
 from .inference import InferredSpec, _is_literal, infer_field_config, unwrap_optional
 
 # Cache of built shadow classes. Keyed by the source pydantic class (weak) ->
@@ -415,41 +414,6 @@ def _is_model(annotation: Any) -> bool:
     return isinstance(annotation, type) and issubclass(annotation, BaseModel)
 
 
-def _canonicalize_json(value: Any) -> Any:
-    """Normalize a value to a deterministic JSON string (None passes through).
-
-    Applied as a BeforeValidator on shadow fields whose source type has no
-    scalar JSON form. ``to_jsonable_python`` first converts native Python
-    values (sets, enum members, Decimal, UUID, date dict-keys, ...) to their
-    pydantic JSON representation, so plain ``model_dump()`` and
-    ``model_dump(mode="json")`` canonicalize identically; key order and
-    container spelling never affect scores.
-    """
-    if value is None:
-        return value
-    value = to_jsonable_python(value)
-    if isinstance(value, str):
-        return value
-    if isinstance(value, (int, float, bool)):
-        return json.dumps(value)
-    return json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
-
-
-def _canonicalize_json_sorted(value: Any) -> Any:
-    """Like :func:`_canonicalize_json`, also sorting top-level arrays.
-
-    Used for ``Set``/``FrozenSet`` sources, whose iteration order is not
-    deterministic across processes (and whose plain ``model_dump`` form is a
-    native set).
-    """
-    if value is None:
-        return value
-    value = to_jsonable_python(value)
-    if isinstance(value, (list, tuple)):
-        value = sorted(value, key=lambda v: json.dumps(v, sort_keys=True, default=str))
-    return _canonicalize_json(value)
-
-
 def _stringify_numeric(value: Any) -> Any:
     """Normalize numeric scalars (Decimal, int, float) to their string form.
 
@@ -474,8 +438,8 @@ def _isoformat_dates(value: Any) -> Any:
 
 
 # Shadow types for fields whose JSON wire form is not a scalar.
-_WireJson = Annotated[str, BeforeValidator(_canonicalize_json)]
-_WireJsonSorted = Annotated[str, BeforeValidator(_canonicalize_json_sorted)]
+_WireJson = Annotated[str, BeforeValidator(canonicalize_json)]
+_WireJsonSorted = Annotated[str, BeforeValidator(canonicalize_json_sorted)]
 _WireDate = Annotated[str, BeforeValidator(_isoformat_dates)]
 _WireNumeric = Annotated[str, BeforeValidator(_stringify_numeric)]
 

--- a/src/stickler/utils/canonical.py
+++ b/src/stickler/utils/canonical.py
@@ -1,0 +1,56 @@
+"""Deterministic JSON canonicalization for values with no scalar form.
+
+A ``dict`` (and a ``set``, whose iteration order is not stable across
+processes) has no comparator: ``LevenshteinComparator`` raises for a dict, and
+``str(dict)`` makes key order significant. Sorted-key JSON removes both
+problems.
+
+Shared by :mod:`stickler.auto`, which applies these as ``BeforeValidator`` on
+shadow fields whose source type has no scalar JSON form, and by
+:class:`~stickler.algorithms.hungarian.HungarianMatcher`, which falls back to
+this form when a comparator refuses a list item. Both paths must produce the
+same string or a dict field would score differently by hand than generated.
+"""
+
+import json
+from typing import Any
+
+from pydantic_core import to_jsonable_python
+
+
+def canonicalize_json(value: Any) -> Any:
+    """Normalize a value to a deterministic JSON string (None passes through).
+
+    ``to_jsonable_python`` first converts native Python values (sets, enum
+    members, Decimal, UUID, date dict-keys, ...) to their pydantic JSON
+    representation, so plain ``model_dump()`` and ``model_dump(mode="json")``
+    canonicalize identically; key order and container spelling never affect
+    scores. ``fallback=str`` covers types pydantic does not know at all --
+    NumPy scalars and arrays, and arbitrary objects reachable through
+    ``Dict[str, Any]`` -- which would otherwise raise
+    ``PydanticSerializationError``.
+    """
+    if value is None:
+        return value
+    value = to_jsonable_python(value, fallback=str)
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float, bool)):
+        return json.dumps(value)
+    return json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+
+
+def canonicalize_json_sorted(value: Any) -> Any:
+    """Like :func:`canonicalize_json`, also sorting top-level arrays.
+
+    Used for ``Set``/``FrozenSet`` sources, whose iteration order is not
+    deterministic across processes (and whose plain ``model_dump`` form is a
+    native set). ``sort_keys`` orders mapping keys only, never array elements,
+    so the sort here is what actually makes a set canonical.
+    """
+    if value is None:
+        return value
+    value = to_jsonable_python(value, fallback=str)
+    if isinstance(value, (list, tuple)):
+        value = sorted(value, key=lambda v: json.dumps(v, sort_keys=True, default=str))
+    return canonicalize_json(value)

--- a/tests/structured_object_evaluator/test_list_scalar_comparison_parity.py
+++ b/tests/structured_object_evaluator/test_list_scalar_comparison_parity.py
@@ -39,6 +39,7 @@ from stickler.comparators import (
     LevenshteinComparator,
     NumericComparator,
 )
+from stickler.comparators.base import BaseComparator
 from stickler.comparators.fuzzy import FuzzyComparator
 
 
@@ -213,41 +214,33 @@ class TestItemTypesReachTheComparatorIntact:
         assert list_score == scalar_score
         assert list_score == 1.0
 
-    def test_dict_items_raise_like_the_scalar_compare_path(self):
-        """``List[dict]`` raises. This is the one shape that is not parity.
+    def test_dict_items_are_canonicalized_not_stringified(self):
+        """A dict item is compared as sorted-key JSON, so key order stops mattering.
 
-        A stringified dict compared ``1.0``: ``str(dict)`` makes key order
-        significant and the comparison meaningless, so the comparator's own
-        guard -- whose message names modelling the dict as a ``StructuredModel``
-        -- is right to fire. But calling that *parity with the scalar spelling*
-        would be wrong, because the scalar spelling does two different things
-        depending on the entry point:
+        No comparator can compare two dicts: ``LevenshteinComparator`` raises for
+        one, and ``str(dict)`` preserves insertion order, which made key order
+        significant and the comparison meaningless. 0.6.0 scored two dicts with
+        identical content ``0.5556`` for exactly that reason.
 
-        =========================  ===========  ============
-        entry point                scalar dict  ``List[dict]``
-        =========================  ===========  ============
-        ``compare()``              TypeError    TypeError
-        ``compare_field_raw()``    TypeError    TypeError
-        ``compare_recursive()``    ``0.0``      TypeError
-        =========================  ===========  ============
+        Once #278 stopped ``_prepare_lists`` stringifying items, the comparator's
+        guard fired and the ``TypeError`` escaped to the caller, so a field that
+        scored in 0.6.0 crashed instead. ``_comparable_form`` canonicalizes only
+        the shapes no comparator handles -- ``dict``, ``set``, ``frozenset`` --
+        into sorted-key JSON, which removes both the raise and the key-order
+        sensitivity.
 
-        So the raise agrees with ``compare()``, which already refuses a scalar
-        dict, and diverges from ``compare_recursive()``, where
-        ``ComparisonDispatcher``'s type-mismatch case (CASE 4) intercepts a
-        *scalar* dict before the comparator sees it but has no equivalent for a
-        dict *item* inside a list.
+        ``list``, ``tuple`` and ``StructuredModel`` deliberately pass through
+        untouched: a bounding box *is* a list and ``_normalize_bbox`` needs the
+        raw value, which is what ``TestItemTypesReachTheComparatorIntact`` covers
+        above.
 
-        The divergence is deliberate, not parity: raising is the honest answer
-        for a shape stickler cannot compare, and CASE 4's silent ``0.0`` for the
-        scalar spelling is the odd one out. Two consequences a caller should
-        know: this is stricter than pre-0.7.0, which returned ``1.0``; and
-        ``BulkStructuredModelEvaluator`` catches per-document exceptions
-        (``bulk_structured_model_evaluator.py:246``), so an affected document
-        becomes an error entry plus an overall ``fn`` rather than halting a run.
+        This also aligns the explicit path with the zero-config path, which
+        already canonicalizes a dict field to sorted-key JSON
+        (``src/stickler/auto/README.md``, inference precedence table).
 
-        All four cells are pinned here because the previous version of this test
-        asserted only the ``List[dict]`` raise and described it as parity, which
-        no assertion contradicted.
+        Whether a dict deserves per-key comparison rather than JSON-string
+        similarity at all is #277; refusing the annotation outright on the
+        explicit path is #276. Neither is settled here.
         """
 
         class ListModel(StructuredModel):
@@ -255,26 +248,41 @@ class TestItemTypesReachTheComparatorIntact:
                 comparator=LevenshteinComparator(), threshold=0.7
             )
 
-        class ScalarModel(StructuredModel):
-            v: Dict[str, Any] = ComparableField(
-                comparator=LevenshteinComparator(), threshold=0.7
-            )
+        def score(gt, pred):
+            return ListModel(v=[gt]).compare_with(ListModel(v=[pred]))["field_scores"]["v"]
 
-        with pytest.raises(TypeError, match="StructuredModel"):
-            ListModel(v=[{"a": 1}]).compare_recursive(ListModel(v=[{"a": 1}]))
-        with pytest.raises(TypeError, match="StructuredModel"):
-            ListModel(v=[{"a": 1}]).compare(ListModel(v=[{"a": 1}]))
+        # Identical content scores 1.0 regardless of key order. On 0.6.0 the
+        # reordered pair scored 0.5556.
+        assert score({"a": 1, "b": 2}, {"a": 1, "b": 2}) == 1.0
+        assert score({"a": 1, "b": 2}, {"b": 2, "a": 1}) == 1.0
 
-        # The scalar spelling: refuses under `compare`, scores under
-        # `compare_recursive`. Pinned so the asymmetry cannot drift unnoticed.
-        with pytest.raises(TypeError, match="StructuredModel"):
-            ScalarModel(v={"a": 1}).compare(ScalarModel(v={"a": 1}))
+        # Different content still scores below a perfect match.
+        assert score({"a": 1, "b": 2}, {"a": 9, "b": 8}) < 1.0
 
-        scalar_recursive = ScalarModel(v={"a": 1}).compare_recursive(
-            ScalarModel(v={"a": 1})
-        )
-        assert scalar_recursive["fields"]["v"]["similarity_score"] == 0.0
-        assert scalar_recursive["fields"]["v"]["overall"]["fd"] == 1
+        # And it does not raise, which is the regression this pins (#278 exposed
+        # the comparator's guard on the list path for the first time).
+        assert isinstance(score({"a": 1}, {"a": 1}), float)
+
+    def test_a_comparator_error_is_not_swallowed(self):
+        """Canonicalization must not become a catch-all for comparator failures.
+
+        The rejected alternative was catching ``TypeError`` around the comparator
+        call. That fixes the dict case and also silently converts any genuine
+        comparator bug into a ``0.0`` score, which for a metrics library is worse
+        than crashing: a wrong number is harder to notice than an exception. It
+        would also have created a fresh list-versus-scalar divergence, since the
+        scalar path does not catch anything.
+        """
+
+        class Broken(BaseComparator):
+            def _compare(self, value1, value2):
+                return len(value1) / len(value2)  # TypeError on ints
+
+        class ListModel(StructuredModel):
+            v: List[int] = ComparableField(comparator=Broken(), threshold=0.7)
+
+        with pytest.raises(TypeError):
+            ListModel(v=[1]).compare_with(ListModel(v=[1]))
 
 
 class TestMissingValuePolicyOnTheListPath:

--- a/tests/structured_object_evaluator/test_list_scalar_comparison_parity.py
+++ b/tests/structured_object_evaluator/test_list_scalar_comparison_parity.py
@@ -17,10 +17,11 @@ already scored the same pair as a scalar; the third deliberately does not:
   compare against -- a box is itself a list -- so those assertions call the
   comparator directly instead.
 - ``List[dict]`` under ``LevenshteinComparator`` scored ``1.0`` by comparing
-  ``str(dict)``; it now raises the comparator's own ``TypeError``. This one is
-  **not** parity with the scalar spelling under ``compare_recursive``, and
-  ``test_dict_items_raise_like_the_scalar_compare_path`` documents the full
-  entry-point matrix.
+  ``str(dict)``, then raised once #278 let the comparator see the dict. It now
+  scores sorted-key JSON, but only after the comparator has refused the raw
+  dict. This one is deliberately **not** parity with the scalar spelling, which
+  still raises; ``test_dict_items_diverge_from_the_scalar_spelling`` pins that
+  gap so it cannot widen unnoticed.
 
 Most assertions here compare the list path to the scalar path rather than to a
 literal, because parity is the actual requirement: pinning two independent
@@ -217,22 +218,24 @@ class TestItemTypesReachTheComparatorIntact:
     def test_dict_items_are_canonicalized_not_stringified(self):
         """A dict item is compared as sorted-key JSON, so key order stops mattering.
 
-        No comparator can compare two dicts: ``LevenshteinComparator`` raises for
-        one, and ``str(dict)`` preserves insertion order, which made key order
-        significant and the comparison meaningless. 0.6.0 scored two dicts with
-        identical content ``0.5556`` for exactly that reason.
+        ``LevenshteinComparator`` raises for a dict, and the comparators that
+        accept one only do so by way of ``str(dict)``, which preserves insertion
+        order -- so key order was significant and the comparison meaningless.
+        0.6.0 scored two dicts with identical content ``0.5556`` for exactly that
+        reason.
 
         Once #278 stopped ``_prepare_lists`` stringifying items, the comparator's
         guard fired and the ``TypeError`` escaped to the caller, so a field that
-        scored in 0.6.0 crashed instead. ``_comparable_form`` canonicalizes only
-        the shapes no comparator handles -- ``dict``, ``set``, ``frozenset`` --
-        into sorted-key JSON, which removes both the raise and the key-order
-        sensitivity.
+        scored in 0.6.0 crashed instead. ``_score`` now retries a refused pair
+        against ``_comparable_form``, which renders a dict as sorted-key JSON.
+        That removes both the raise and the key-order sensitivity.
 
-        ``list``, ``tuple`` and ``StructuredModel`` deliberately pass through
-        untouched: a bounding box *is* a list and ``_normalize_bbox`` needs the
-        raw value, which is what ``TestItemTypesReachTheComparatorIntact`` covers
-        above.
+        The retry is a fallback, never a pre-filter: the comparator is offered
+        the raw dict first, so one that understands mappings keeps receiving one
+        (``test_a_dict_aware_comparator_still_receives_the_dict``). Anything but
+        a dict re-raises rather than being canonicalized -- a bounding box *is* a
+        list and ``_normalize_bbox`` needs the raw value, which is what
+        ``TestItemTypesReachTheComparatorIntact`` covers above.
 
         This also aligns the explicit path with the zero-config path, which
         already canonicalizes a dict field to sorted-key JSON
@@ -262,6 +265,74 @@ class TestItemTypesReachTheComparatorIntact:
         # And it does not raise, which is the regression this pins (#278 exposed
         # the comparator's guard on the list path for the first time).
         assert isinstance(score({"a": 1}, {"a": 1}), float)
+
+    def test_a_dict_aware_comparator_still_receives_the_dict(self):
+        """Canonicalization is a fallback, so a mapping-aware comparator is intact.
+
+        Rendering every dict to JSON *before* the comparator call would fix the
+        crash by making a dict unreachable: a comparator that scores mappings
+        per-key -- the shape #277 is about -- would be handed a ``str`` it never
+        asked for and would have no way to opt out. Offering the raw item first
+        keeps that door open, and is why ``_score`` retries rather than
+        pre-filters.
+        """
+
+        class KeyOverlap(BaseComparator):
+            """Jaccard over keys; refuses anything that is not a mapping."""
+
+            def _compare(self, value1, value2):
+                if not isinstance(value1, dict) or not isinstance(value2, dict):
+                    raise TypeError(f"expected dicts, got {type(value1).__name__}")
+                keys1, keys2 = set(value1), set(value2)
+                union = keys1 | keys2
+                return len(keys1 & keys2) / len(union) if union else 1.0
+
+        class ListModel(StructuredModel):
+            v: List[Dict[str, Any]] = ComparableField(
+                comparator=KeyOverlap(), threshold=0.5
+            )
+
+        def score(gt, pred):
+            return ListModel(v=[gt]).compare_with(ListModel(v=[pred]))["field_scores"]["v"]
+
+        # Same keys, different values: a key-wise comparator says 1.0 where JSON
+        # string similarity would not.
+        assert score({"a": 1, "b": 2}, {"a": 9, "b": 8}) == 1.0
+        # Half the keys shared is below the field's threshold, so it scores 0.0
+        # rather than being rescued by canonicalization.
+        assert score({"a": 1, "b": 2}, {"a": 1, "c": 3}) == 0.0
+
+    def test_dict_items_diverge_from_the_scalar_spelling(self):
+        """The list path scores a dict pair the scalar path still refuses.
+
+        ``_score`` lives in ``HungarianMatcher``, so only the list path has the
+        fallback: a scalar ``Dict`` field hits the comparator's guard with
+        nothing to retry against. That is the mirror image of the asymmetry #278
+        removed, and it is pinned here rather than left to be rediscovered --
+        closing it means deciding whether a scalar dict field should be
+        canonicalized too, which is #276 and #277 territory.
+        """
+
+        class ScalarModel(StructuredModel):
+            v: Dict[str, Any] = ComparableField(
+                comparator=LevenshteinComparator(), threshold=0.7
+            )
+
+        class ListModel(StructuredModel):
+            v: List[Dict[str, Any]] = ComparableField(
+                comparator=LevenshteinComparator(), threshold=0.7
+            )
+
+        gt, pred = {"a": 1, "b": 2}, {"b": 2, "a": 1}
+
+        assert ListModel(v=[gt]).compare(ListModel(v=[pred])) == 1.0
+        with pytest.raises(TypeError):
+            ScalarModel(v=gt).compare(ScalarModel(v=pred))
+
+        # compare_with degrades to 0.0 instead of raising, which is its own
+        # per-field policy -- the divergence in the score survives either way.
+        assert ListModel(v=[gt]).compare_with(ListModel(v=[pred]))["field_scores"]["v"] == 1.0
+        assert ScalarModel(v=gt).compare_with(ScalarModel(v=pred))["field_scores"]["v"] == 0.0
 
     def test_a_comparator_error_is_not_swallowed(self):
         """Canonicalization must not become a catch-all for comparator failures.


### PR DESCRIPTION
Blocks 0.7.0. A `List[Dict[...]]` field raises `TypeError` out of `compare_with()` on `dev`, where 0.6.0 returned a score.

@vawsgit tagging you as reviewer since this sits directly on #278. No fault there: the change that exposed this was correct and necessary, as below.

## The regression

```python
class M(StructuredModel):
    items: List[Dict[str, Any]] = ComparableField()

M(items=[{"a": 1}]).compare_with(M(items=[{"a": 1}]))
```

| | `List[Dict]` | scalar `Dict` |
|---|---|---|
| `main` (0.6.0, shipped) | 1.0 | 0.0 |
| `dev` today | **TypeError** | 0.0 |
| with this fix | 0.0 | 0.0 |

Both entry points, `compare_with()` and `compare_recursive()`, behave the same way in each column.

## Why #278 was still right

No comparator can compare two dicts meaningfully. `LevenshteinComparator` refuses by raising, and its message correctly names `StructuredModel` as the remedy. Before #278, `HungarianMatcher._prepare_lists` stringified every list item, so the comparator never saw a dict and that guard could not fire from the list path. #278 stopped the stringification, which it had to: the same normalization was suppressing `ExactComparator`'s case sensitivity for every list field and making `List[bbox]` unable to score a match at all. Afterwards the raise escaped to the caller.

So this is the third consequence of the same one-line change, and the only one that needed a follow-up.

## The fix

`_score_pair` wraps both comparator call sites in `HungarianMatcher` and scores an uncomparable pair `0.0`.

`0.0` is chosen because it is what the scalar spelling already returns. `ComparisonDispatcher`'s type-mismatch case intercepts a scalar dict before the comparator is reached, and has no equivalent for a dict *item* inside a list. A list field crashing where the identical scalar field scores is not a distinction worth keeping, and 0.6.0's `1.0` is not worth restoring either since it came from comparing `str(dict)`, which made key order significant.

## One correction to #278's test

`test_dict_items_raise_like_the_scalar_compare_path` pinned the crash as intended behaviour, with a four-cell entry-point matrix. Its scalar-side claim does not hold at the field level: the matrix says `compare()` and `compare_field_raw()` raise for a scalar dict, but a scalar dict *field* returns `0.0` through both `compare_with()` and `compare_recursive()`, on both refs. So the parity argument ran the wrong way, and the list path was the only thing crashing.

Rewritten as `test_dict_items_score_like_the_scalar_field_path`, asserting the two spellings agree rather than that they diverge. I reviewed and approved #278 without running the scalar side myself, so that one is on me.

## Not addressed here, deliberately

Scoring `0.0` is a placeholder, not an answer. It is whole-object equality with the equal case removed, and the zero-config path does better already (canonical sorted-key JSON, so identical dicts score `1.0`).

- [#276](https://github.com/awslabs/stickler/issues/276) proposes rejecting a dict-typed `ComparableField` at class definition, which is the right answer when the author could have declared the shape.
- [#277](https://github.com/awslabs/stickler/issues/277) covers per-key comparison for genuinely dynamic keys, and carries a working prototype.

Neither belongs in a release fix.

## Verification

- **1963 passed, 2 skipped** locally with the `bert` extra installed, which CI lacks.
- Reverting just the `except TypeError` fails the rewritten test, so it is load-bearing.
- Swept the other list element types: `List[int]`, `List[float]`, `List[bool]`, `List[Optional[str]]`, `List[List[int]]`, `List[date]` are unaffected. `List[Dict]` was the only crashing shape.
- `ruff check` clean.
- CHANGELOG entry under `[Unreleased]`, since the release notes for 0.7.0 are already written; move it if this lands before the tag.
