### PR TITLE
chore: update deprecation strings from 0.8.0 to 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,6 +301,8 @@ Each release links to full notes on the
   required. The shim is removed in 0.8.0, after which such a comparator
   raises `TypeError` at construction
   ([#215](https://github.com/awslabs/stickler/issues/215)).
+  <br>*Correction: the 0.8.0 milestone was renamed to 1.0 after this entry shipped.
+  The shim is removed in 1.0.*
 
   Note that the pre-fix `(None, "") -> 1.0` result cannot be inherited: the
   coercion was removed from Levenshtein's algorithm rather than guarded, so
@@ -319,6 +321,8 @@ Each release links to full notes on the
   Callers passing `aggregate=False` had no signal the parameter was going away
   and would have met a bare `TypeError` on removal. Remove the argument; there
   is no replacement to adopt. Scheduled for removal in 0.8.0.
+  <br>*Correction: the 0.8.0 milestone was renamed to 1.0 after this entry shipped.
+  The parameter is removed in 1.0.*
 
   Reading a config does **not** count as explicit use: `to_stickler_config()`
   writes the `aggregate` key for every field, so `model_from_json()` restores
@@ -427,7 +431,7 @@ Each release links to full notes on the
 
   Scores move **up** for affected corpora; nothing that scored `1.0` before
   changes. A region or per-field comparator override on the zero-config entry
-  points is deferred to 0.8.0: it would widen the public API inside a release
+  points is deferred to 1.0: it would widen the public API inside a release
   candidate, and it would not have fixed these cases on its own -- `"ext 4021"`
   is invalid under every region, and no single region works for a mixed corpus
   ([#258](https://github.com/awslabs/stickler/issues/258))

--- a/docs/docs/Guides/Comparators/README.md
+++ b/docs/docs/Guides/Comparators/README.md
@@ -353,7 +353,7 @@ The policy lives in `BaseComparator.compare` and nowhere else. You don't write a
 !!! warning "Implement `_compare`, not `compare`"
     Overriding `compare` directly bypasses the `None` policy and reintroduces exactly the divergence this design prevents. Implement `_compare`.
 
-    A comparator written against the older interface — implementing `compare` — still constructs and behaves exactly as written, and emits a `DeprecationWarning` naming the rename. It does **not** receive the `None` policy, since its `compare` shadows the template method. That shim is removed in 0.8.0 ([#215](https://github.com/awslabs/stickler/issues/215)), after which such a comparator raises `TypeError` at construction.
+    A comparator written against the older interface — implementing `compare` — still constructs and behaves exactly as written, and emits a `DeprecationWarning` naming the rename. It does **not** receive the `None` policy, since its `compare` shadows the template method. That shim is removed in 1.0 ([#215](https://github.com/awslabs/stickler/issues/215)), after which such a comparator raises `TypeError` at construction.
 
 ### Example: Custom RegexComparator
 

--- a/docs/docs/Guides/Evaluation/README.md
+++ b/docs/docs/Guides/Evaluation/README.md
@@ -49,7 +49,7 @@ When defining a `StructuredModel` subclass in Python, each field is declared wit
 | `threshold` | `float` (0.0--1.0) | `0.5` | Minimum similarity score required for a field to be classified as a match. |
 | `weight` | `float` (> 0.0) | `1.0` | Relative importance of this field when computing aggregate scores. |
 | `clip_under_threshold` | `bool` | `True` | When `True`, scores below `threshold` are zeroed out before contributing to the weighted average. |
-| `aggregate` | `bool` | `False` | **Deprecated, removed in 0.8.0.** Has no effect: every node already carries an `aggregate` block in the `compare_with()` output summing the primitive field metrics below it. Passing it at all emits a `DeprecationWarning`; remove the argument, there is no replacement to adopt ([#226](https://github.com/awslabs/stickler/issues/226)). |
+| `aggregate` | `bool` | `False` | **Deprecated, removed in 1.0.** Has no effect: every node already carries an `aggregate` block in the `compare_with()` output summing the primitive field metrics below it. Passing it at all emits a `DeprecationWarning`; remove the argument, there is no replacement to adopt ([#226](https://github.com/awslabs/stickler/issues/226)). |
 
 ### How Each Parameter Affects Scoring
 

--- a/src/stickler/auto/inference.py
+++ b/src/stickler/auto/inference.py
@@ -110,7 +110,7 @@ def unwrap_optional(annotation: Any) -> Tuple[Any, bool]:
     ``stickler.structured_object_evaluator.models.optional_annotation`` (which
     additionally exposes the permissive ``is_union`` / ``union_args`` pair, for
     sites that search a union's arms rather than unwrapping it). Keep them in
-    sync; unifying all three is tracked for 0.8.0.
+    sync; unifying all three is tracked for 1.0.
     """
     origin = get_origin(annotation)
     # PEP 604 unions (X | None) have origin types.UnionType, not typing.Union.

--- a/src/stickler/comparators/base.py
+++ b/src/stickler/comparators/base.py
@@ -38,7 +38,7 @@ class BaseComparator(ABC):
         this template, which dispatches straight back to the function that
         made it.
 
-        Temporary. Removed in 0.8.0 (see issue #215), after which an
+        Temporary. Removed in 1.0 (see issue #215), after which an
         un-migrated comparator becomes abstract again.
         """
         super().__init_subclass__(**kwargs)
@@ -79,7 +79,7 @@ class BaseComparator(ABC):
             f"extension point and bypasses the shared None policy. Rename "
             f"compare() to _compare() and delete any None handling it "
             f"contains, since _compare() never receives None. Support for "
-            f"implementing compare() directly will be removed in 0.8.0.",
+            f"implementing compare() directly will be removed in 1.0.",
             stacklevel=4,
         )
 

--- a/src/stickler/reporting/html/utils/data_extractors.py
+++ b/src/stickler/reporting/html/utils/data_extractors.py
@@ -219,7 +219,7 @@ class DataExtractor:
                 # A third copy lives at
                 # stickler.structured_object_evaluator.models.optional_annotation,
                 # added once ten sites in that package were found with this same
-                # bug. Keep all three in sync; unifying them is a 0.8.0 item.
+                # bug. Keep all three in sync; unifying them is a 1.0 item.
                 if get_origin(field_type) in (Union, types.UnionType):
                     non_none_args = [
                         arg for arg in get_args(field_type) if arg is not type(None)

--- a/src/stickler/structured_object_evaluator/models/comparable_field.py
+++ b/src/stickler/structured_object_evaluator/models/comparable_field.py
@@ -60,7 +60,7 @@ def ComparableField(
         threshold: Minimum similarity score to consider a match (default: 0.5)
         weight: Weight of this field in overall score calculation (default: 1.0)
         default: Default value for the field (default: None)
-        aggregate: DEPRECATED, has no effect, and will be removed in 0.8.0.
+        aggregate: DEPRECATED, has no effect, and will be removed in 1.0.
                   Passing it at all (either value) emits a DeprecationWarning.
                   Aggregation is applied at the comparison layer: every node in
                   compare_with() output already carries an 'aggregate' block
@@ -97,7 +97,7 @@ def ComparableField(
     if aggregate is not _UNSET:
         warnings.warn(
             "The 'aggregate' parameter in ComparableField is deprecated, has no "
-            "effect, and will be removed in 0.8.0. All nodes automatically "
+            "effect, and will be removed in 1.0. All nodes automatically "
             "include an 'aggregate' field in the compare_with() output that "
             "sums primitive field metrics below that node. Remove the argument; "
             "no replacement is needed. See "
@@ -197,7 +197,7 @@ def _restore_deprecated_aggregate(field: Any, value: Any) -> None:
     export -> import -> export is unchanged, including for ``aggregate=True``
     -- while the warning stays reserved for code a user can actually edit.
 
-    Internal, and removed with the parameter in 0.8.0
+    Internal, and removed with the parameter in 1.0
     (https://github.com/awslabs/stickler/issues/226).
     """
     if not isinstance(value, bool):

--- a/src/stickler/structured_object_evaluator/models/optional_annotation.py
+++ b/src/stickler/structured_object_evaluator/models/optional_annotation.py
@@ -26,7 +26,7 @@ supported range, and it is the spelling modern tooling emits.
    ``stickler.reporting.html.utils.data_extractors``. Both live in packages
    that do not depend on the evaluator models — importing across would pull
    pydantic model building into the report path (see #268). Keep them in sync
-   by hand; unifying all three is tracked for 0.8.0.
+   by hand; unifying all three is tracked for 1.0.
 
 .. note::
    On Python 3.14 the two union representations are unified, so the

--- a/tests/common/comparators/test_none_handling.py
+++ b/tests/common/comparators/test_none_handling.py
@@ -232,7 +232,7 @@ class TestPreRenameSubclassMigration:
     rename is needed.
 
     That is why the shim is temporary: it buys an upgrade path, not
-    correctness. Removed in 0.8.0 (issue #215), after which these shapes go
+    correctness. Removed in 1.0 (issue #215), after which these shapes go
     back to raising ``TypeError`` at construction.
     """
 

--- a/tests/structured_object_evaluator/test_model_export.py
+++ b/tests/structured_object_evaluator/test_model_export.py
@@ -209,7 +209,7 @@ def test_export_preserves_metadata():
 
     Still exercises the deprecated ``aggregate`` parameter on purpose: it is
     part of the serialized export format, so the round trip has to keep working
-    until the field is removed in 0.8.0 (issue #226). The warning is expected
+    until the field is removed in 1.0 (issue #226). The warning is expected
     here and suppressed rather than silenced globally.
     """
 

--- a/tests/structured_object_evaluator/test_universal_aggregate_field_comprehensive.py
+++ b/tests/structured_object_evaluator/test_universal_aggregate_field_comprehensive.py
@@ -163,7 +163,7 @@ class TestUniversalAggregateField:
 
         aggregate=False used to be silent, so those callers had no signal the
         parameter is going away and would have met a bare TypeError on the
-        0.8.0 removal (issue #226). The value has no effect either way.
+        1.0 removal (issue #226). The value has no effect either way.
         """
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
@@ -175,7 +175,7 @@ class TestUniversalAggregateField:
             message = str(w[0].message)
             assert "aggregate" in message
             assert "deprecated" in message
-            assert "0.8.0" in message, "the warning should name the removal version"
+            assert "1.0" in message, "the warning should name the removal version"
 
     def test_no_warning_when_aggregate_is_omitted(self):
         """The common case stays quiet."""


### PR DESCRIPTION
## Summary

The 0.8.0 milestone was renamed to 1.0. This PR updates all deprecation version references throughout the codebase.

## Changes

### Source code (runtime deprecation messages)
- `base.py`: `compare()` → `_compare()` shim removal version
- `comparable_field.py`: `aggregate` parameter removal version (docstring, warning message, internal docstring)

### Documentation
- `Guides/Comparators/README.md`: `compare()` shim removal note
- `Guides/Evaluation/README.md`: `aggregate` parameter table

### Internal tracking comments
- `inference.py`, `optional_annotation.py`, `data_extractors.py`: Optional-unwrap consolidation task milestone

### Tests
- `test_none_handling.py`, `test_model_export.py`, `test_universal_aggregate_field_comprehensive.py`: Version assertions

### CHANGELOG.md
- Added **correction notes** to the two shipped 0.7.0 entries that referenced 0.8.0. The original text is preserved per the Keep a Changelog principle; corrections are appended explaining the milestone rename.
- Updated the PhoneComparator deferral note to reference 1.0

## Verification

All 0.8.0 references in source, docs, and tests have been updated. The only remaining "0.8.0" strings are in CHANGELOG.md's shipped entries (which preserve history) plus the correction notes.

Closes: Part of milestone preparation for 1.0