### PR TITLE
refactor: replace sklearn metrics with NumPy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Each release links to full notes on the
 
 ## [Unreleased]
 
+### Changed
+
+- Confidence AUROC and document-splitting statistics now use NumPy
+  implementations with randomized scikit-learn and SciPy equivalence tests.
+  `scikit-learn` is no longer a core dependency, and the `docsplit` extra now
+  adds only pandas; SciPy remains isolated to the `semantic` extra
+  ([#216](https://github.com/awslabs/stickler/issues/216)).
+
 ## [0.7.0] - 2026-08-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ That installs the comparison engine and confidence calibration, which is everyth
 | `[semantic]` | boto3, scipy | `SemanticComparator` (Bedrock embeddings) |
 | `[llm]` | strands-agents, jinja2 | `LLMComparator` (LLM-as-judge comparison) |
 | `[bert]` | evaluate, torch, bert-score | `BERTComparator` (BERTScore similarity) |
-| `[docsplit]` | pandas, scipy, scikit-learn | Document packet splitting metrics |
+| `[docsplit]` | pandas | Document packet splitting metrics |
 | `[reporting]` | pandas | Confusion-matrix tables in HTML reports |
 | `[all]` | all of the above except the ML stack | Convenience |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,8 @@ dev = [
     # Used by the memory-measurement assertions in the stress and deep-nesting
     # tests. Not imported anywhere in src/.
     "psutil>=5.9.6,<7.0.0",
-    # The suite exercises every optional module, so it needs every extra's
-    # dependencies even though they are not required at runtime.
+    # The suite exercises every optional module; scipy and scikit-learn also
+    # serve as development metric oracles for tests/test_statistics.py.
     "jinja2>=3.1.6,<3.2.0",
     "pandas>=2.1.1,<3.0.0",
     "scipy>=1.12.0,<2.0.0",
@@ -156,8 +156,8 @@ test = [
     "psutil>=5.9.6,<7.0.0",
     # Used by examples/notebooks/Review_Efficiency_Exploration.ipynb.
     "matplotlib>=3.8.0",
-    # The suite exercises every optional module, so it needs every extra's
-    # dependencies even though they are not required at runtime.
+    # The suite exercises every optional module; scipy and scikit-learn also
+    # serve as development metric oracles for tests/test_statistics.py.
     "jinja2>=3.1.6,<3.2.0",
     "pandas>=2.1.1,<3.0.0",
     "scipy>=1.12.0,<2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,6 @@ dependencies = [
     "numpy>=1.26.0,<3.0.0",
     "jsonschema>=4.17.3,<5.0.0",
     "python-dateutil>=2.8.2,<3.0.0",
-    # AUROC is the only metric that needs it; the other three calibration
-    # metrics are pure Python. Issue #216 replaces this with a numpy
-    # implementation, after which scikit-learn leaves the dependency set.
-    # Floor is 1.7.2 rather than 1.8.0 because 1.8.0 requires Python 3.11+.
-    "scikit-learn>=1.7.2,<2.0.0",
     # Phone number equality needs per-country rules that cannot be reproduced
     # with string normalization: "+1-555-123-4567" and "5551234567" are the same
     # number, while a one-digit change is not, and edit distance ranks those the
@@ -109,8 +104,6 @@ confidence = []
 # Document packet splitting: clustering and agreement metrics.
 docsplit = [
     "pandas>=2.1.1,<3.0.0",
-    "scipy>=1.12.0,<2.0.0",
-    "scikit-learn>=1.7.2,<2.0.0",
 ]
 # HTML reporting: ProcessEvaluation renders markdown tables from DataFrames.
 reporting = [

--- a/src/stickler/doc_split/packet_evaluation_metrics.py
+++ b/src/stickler/doc_split/packet_evaluation_metrics.py
@@ -26,20 +26,21 @@ from typing import Any, Dict, List, Tuple, Union
 
 import numpy as np
 
-# pandas, scipy, and scikit-learn are only needed by this module, so they live
-# behind the `docsplit` extra rather than in the core dependency set. Raise an
-# actionable error naming the extra instead of a bare ModuleNotFoundError.
+from stickler.utils.statistics import (
+    homogeneity_completeness_v_measure,
+    kendall_tau_b,
+    rand_index,
+)
+
+# pandas is only needed by this module, so it lives behind the `docsplit` extra
+# rather than in the core dependency set. Raise an actionable error naming the
+# extra instead of a bare ModuleNotFoundError.
 try:
     import pandas as pd
-    from scipy.stats import kendalltau
-    from sklearn.metrics import (
-        homogeneity_completeness_v_measure,
-        rand_score,
-    )
 except ImportError as exc:  # pragma: no cover - exercised by the extras gate
     raise ImportError(
-        "stickler.doc_split requires pandas, scipy, and scikit-learn. Install "
-        'them with: pip install "stickler-eval[docsplit]"'
+        "stickler.doc_split requires pandas. Install it with: "
+        'pip install "stickler-eval[docsplit]"'
     ) from exc
 
 logger = logging.getLogger(__name__)
@@ -132,7 +133,7 @@ def calculate_clustering_score(
     gt_ids, pred_ids = create_composite_group_ids(data, strict_clustering)
 
     _h, _c, v_measure = homogeneity_completeness_v_measure(gt_ids, pred_ids)
-    ri = rand_score(gt_ids, pred_ids)
+    ri = rand_index(gt_ids, pred_ids)
 
     clustering_score = v_measure_weight * v_measure + (1 - v_measure_weight) * ri
     return clustering_score, v_measure, ri
@@ -164,7 +165,7 @@ def calculate_ordering_score_per_group(
             group_scores[group_id] = 1.0
             continue
 
-        tau, _p_value = kendalltau(
+        tau = kendall_tau_b(
             group_data["page_number"], group_data["page_number_predicted"]
         )
         group_scores[group_id] = tau if not np.isnan(tau) else 0

--- a/src/stickler/structured_object_evaluator/models/confidence/metrics.py
+++ b/src/stickler/structured_object_evaluator/models/confidence/metrics.py
@@ -15,6 +15,8 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, field_validator
 
+from stickler.utils.statistics import binary_roc_auc
+
 
 class ConfidencePair(BaseModel):
     """A single observation pairing a match result with confidence and similarity.
@@ -94,25 +96,11 @@ class AUROCMetric(ConfidenceMetric):
     def compute(self, pairs: ConfidencePairs) -> Dict[str, Any]:
         if not pairs or len(set(p.is_match for p in pairs)) < 2:
             return {"value": None}
-        # scikit-learn is a core dependency, so this import is guaranteed to
-        # resolve. It stays function-local rather than at module scope because
-        # this module IS on the `import stickler` path, and importing sklearn
-        # eagerly would put ~33MB of it there for every user whether or not
-        # they compute AUROC. Issue #216 removes the dependency entirely by
-        # implementing the Mann-Whitney form in numpy.
-        try:
-            from sklearn.metrics import roc_auc_score
-        except ImportError as exc:  # pragma: no cover - core dep, should not happen
-            raise ImportError(
-                "AUROCMetric requires scikit-learn, which is a core dependency "
-                "of stickler-eval. Your environment looks broken; reinstall "
-                "with: pip install --force-reinstall stickler-eval"
-            ) from exc
-
-        y_true = [1 if p.is_match else 0 for p in pairs]
-        y_scores = [p.confidence for p in pairs]
-        # float() defends against numpy scalars from future ndarray callers.
-        return {"value": float(roc_auc_score(y_true, y_scores))}
+        return {
+            "value": binary_roc_auc(
+                [p.is_match for p in pairs], [p.confidence for p in pairs]
+            )
+        }
 
 
 class BrierScoreMetric(ConfidenceMetric):

--- a/src/stickler/utils/README.md
+++ b/src/stickler/utils/README.md
@@ -1,0 +1,8 @@
+# Utilities
+
+Shared helpers used across Stickler modules.
+
+- `statistics.py` implements the NumPy-based ranking, clustering, and ordering
+  statistics used by confidence and document-splitting metrics.
+- The remaining modules provide argument parsing, deprecation, normalization,
+  reporting, Markdown, and time helpers.

--- a/src/stickler/utils/statistics.py
+++ b/src/stickler/utils/statistics.py
@@ -1,0 +1,138 @@
+"""Small statistical primitives used by Stickler metrics."""
+
+from math import sqrt
+from typing import Any, Sequence
+
+import numpy as np
+
+
+def binary_roc_auc(labels: Sequence[bool], scores: Sequence[float]) -> float:
+    """Return binary ROC AUC using average ranks for tied scores."""
+    labels_array = np.asarray(labels, dtype=bool)
+    scores_array = np.asarray(scores, dtype=float)
+    if labels_array.ndim != 1 or scores_array.ndim != 1:
+        raise ValueError("labels and scores must be one-dimensional")
+    if labels_array.size != scores_array.size:
+        raise ValueError("labels and scores must have the same length")
+
+    positive_count = int(labels_array.sum())
+    negative_count = labels_array.size - positive_count
+    if not positive_count or not negative_count:
+        raise ValueError("ROC AUC requires both positive and negative labels")
+
+    order = np.argsort(scores_array, kind="mergesort")
+    sorted_scores = scores_array[order]
+    ranks = np.empty(labels_array.size, dtype=float)
+    start = 0
+    while start < labels_array.size:
+        end = start + 1
+        while end < labels_array.size and sorted_scores[end] == sorted_scores[start]:
+            end += 1
+        # Ranks are one-based. The tied group spans start + 1 through end.
+        ranks[order[start:end]] = (start + 1 + end) / 2
+        start = end
+
+    positive_rank_sum = float(ranks[labels_array].sum())
+    mann_whitney_u = positive_rank_sum - positive_count * (positive_count + 1) / 2
+    return mann_whitney_u / (positive_count * negative_count)
+
+
+def _contingency_matrix(
+    labels_true: Sequence[Any], labels_pred: Sequence[Any]
+) -> np.ndarray:
+    true_array = np.asarray(labels_true)
+    pred_array = np.asarray(labels_pred)
+    if true_array.ndim != 1 or pred_array.ndim != 1:
+        raise ValueError("clustering labels must be one-dimensional")
+    if true_array.size != pred_array.size:
+        raise ValueError("clustering label arrays must have the same length")
+    if not true_array.size:
+        return np.zeros((0, 0), dtype=np.int64)
+
+    _, true_inverse = np.unique(true_array, return_inverse=True)
+    _, pred_inverse = np.unique(pred_array, return_inverse=True)
+    contingency = np.zeros(
+        (int(true_inverse.max()) + 1, int(pred_inverse.max()) + 1),
+        dtype=np.int64,
+    )
+    np.add.at(contingency, (true_inverse, pred_inverse), 1)
+    return contingency
+
+
+def rand_index(labels_true: Sequence[Any], labels_pred: Sequence[Any]) -> float:
+    """Return the Rand index for two cluster assignments."""
+    contingency = _contingency_matrix(labels_true, labels_pred)
+    sample_count = int(contingency.sum())
+    pair_count = sample_count * (sample_count - 1) // 2
+    if not pair_count:
+        return 1.0
+
+    true_counts = contingency.sum(axis=1)
+    pred_counts = contingency.sum(axis=0)
+    true_positive = int(((contingency * (contingency - 1)) // 2).sum())
+    same_true = int(((true_counts * (true_counts - 1)) // 2).sum())
+    same_pred = int(((pred_counts * (pred_counts - 1)) // 2).sum())
+    true_negative = pair_count - same_true - same_pred + true_positive
+    return (true_positive + true_negative) / pair_count
+
+
+def homogeneity_completeness_v_measure(
+    labels_true: Sequence[Any], labels_pred: Sequence[Any]
+) -> tuple[float, float, float]:
+    """Return homogeneity, completeness and their harmonic mean."""
+    contingency = _contingency_matrix(labels_true, labels_pred).astype(float)
+    sample_count = float(contingency.sum())
+    if not sample_count:
+        return 1.0, 1.0, 1.0
+
+    true_counts = contingency.sum(axis=1)
+    pred_counts = contingency.sum(axis=0)
+    nonzero = contingency > 0
+    expected = np.outer(true_counts, pred_counts)
+    mutual_information = float(
+        (
+            (contingency[nonzero] / sample_count)
+            * np.log(
+                contingency[nonzero]
+                * sample_count
+                / expected[nonzero]
+            )
+        ).sum()
+    )
+
+    def entropy(counts: np.ndarray) -> float:
+        probabilities = counts[counts > 0] / sample_count
+        return float(-(probabilities * np.log(probabilities)).sum())
+
+    true_entropy = entropy(true_counts)
+    pred_entropy = entropy(pred_counts)
+    homogeneity = 1.0 if true_entropy == 0 else mutual_information / true_entropy
+    completeness = 1.0 if pred_entropy == 0 else mutual_information / pred_entropy
+    if homogeneity + completeness == 0:
+        v_measure = 0.0
+    else:
+        v_measure = 2 * homogeneity * completeness / (homogeneity + completeness)
+    return homogeneity, completeness, v_measure
+
+
+def kendall_tau_b(values_x: Sequence[float], values_y: Sequence[float]) -> float:
+    """Return Kendall's tau-b, including correction for ties."""
+    x = np.asarray(values_x, dtype=float)
+    y = np.asarray(values_y, dtype=float)
+    if x.ndim != 1 or y.ndim != 1:
+        raise ValueError("Kendall inputs must be one-dimensional")
+    if x.size != y.size:
+        raise ValueError("Kendall inputs must have the same length")
+
+    numerator = 0.0
+    untied_x = 0
+    untied_y = 0
+    for index in range(x.size - 1):
+        x_sign = np.sign(x[index + 1 :] - x[index])
+        y_sign = np.sign(y[index + 1 :] - y[index])
+        numerator += float(np.dot(x_sign, y_sign))
+        untied_x += int(np.count_nonzero(x_sign))
+        untied_y += int(np.count_nonzero(y_sign))
+
+    denominator = sqrt(untied_x * untied_y)
+    return numerator / denominator if denominator else float("nan")

--- a/tests/test_core_import_weight.py
+++ b/tests/test_core_import_weight.py
@@ -1,14 +1,10 @@
 """Guards that `import stickler` stays light.
 
 The comparison engine needs only pydantic, rapidfuzz, munkres, numpy,
-jsonschema, and python-dateutil. Everything heavier (pandas, scipy, jinja2, and
-the ML stack behind the optional comparators) belongs to a peripheral module
-and lives behind an extra.
-
-scikit-learn is the exception: it is a core dependency because confidence
-calibration is core functionality, but only ``AUROCMetric.compute()`` needs it,
-so its import stays function-local and must not appear on the import path
-either. Issue #216 removes the dependency altogether.
+jsonschema, and python-dateutil. Everything heavier (pandas, scipy, jinja2,
+scikit-learn, and the ML stack behind the optional comparators) belongs to a
+peripheral module or the development environment and must not appear on the
+core import path.
 
 These tests fail if a module-level import puts one of those packages back on
 the ``import stickler`` path. That regression is easy to introduce and silent:
@@ -32,10 +28,8 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # mapped to the extra that owns them.
 FORBIDDEN_ON_CORE_PATH = {
     "pandas": "docsplit / reporting",
-    "scipy": "semantic / docsplit",
-    # Core dependency, but imported inside AUROCMetric.compute() so it does
-    # not cost every user ~33MB at import time.
-    "sklearn": "core (function-local in AUROCMetric)",
+    "scipy": "semantic / development metric oracle",
+    "sklearn": "development metric oracle",
     "jinja2": "llm",
     "torch": "bert",
     "transformers": "bert",

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,0 +1,84 @@
+"""Equivalence tests for the dependency-free runtime statistics."""
+
+import numpy as np
+import pytest
+from scipy.stats import kendalltau
+from sklearn.metrics import (
+    homogeneity_completeness_v_measure as sklearn_v_measure,
+)
+from sklearn.metrics import rand_score, roc_auc_score
+
+from stickler.utils.statistics import (
+    binary_roc_auc,
+    homogeneity_completeness_v_measure,
+    kendall_tau_b,
+    rand_index,
+)
+
+
+def test_binary_roc_auc_matches_sklearn_with_ties():
+    rng = np.random.default_rng(216)
+    for _ in range(250):
+        sample_count = int(rng.integers(2, 80))
+        labels = rng.integers(0, 2, size=sample_count)
+        labels[0] = 0
+        labels[-1] = 1
+        scores = rng.integers(0, 5, size=sample_count) / 4
+
+        assert binary_roc_auc(labels, scores) == pytest.approx(
+            roc_auc_score(labels, scores), abs=1e-12
+        )
+
+
+def test_binary_roc_auc_all_equal_scores_is_half():
+    assert binary_roc_auc([False, True, False, True], [0.4] * 4) == 0.5
+
+
+def test_binary_roc_auc_rejects_a_single_class():
+    with pytest.raises(ValueError, match="both positive and negative"):
+        binary_roc_auc([True, True], [0.2, 0.8])
+
+
+def test_clustering_metrics_match_sklearn():
+    rng = np.random.default_rng(217)
+    for _ in range(250):
+        sample_count = int(rng.integers(1, 80))
+        labels_true = rng.integers(0, int(rng.integers(1, 10)), size=sample_count)
+        labels_pred = rng.integers(0, int(rng.integers(1, 10)), size=sample_count)
+
+        expected_h, expected_c, expected_v = sklearn_v_measure(
+            labels_true, labels_pred
+        )
+        actual_h, actual_c, actual_v = homogeneity_completeness_v_measure(
+            labels_true, labels_pred
+        )
+        assert actual_h == pytest.approx(expected_h, abs=1e-12)
+        assert actual_c == pytest.approx(expected_c, abs=1e-12)
+        assert actual_v == pytest.approx(expected_v, abs=1e-12)
+        assert rand_index(labels_true, labels_pred) == rand_score(
+            labels_true, labels_pred
+        )
+
+
+def test_empty_clusterings_are_perfect():
+    assert rand_index([], []) == 1.0
+    assert homogeneity_completeness_v_measure([], []) == (1.0, 1.0, 1.0)
+
+
+def test_kendall_tau_b_matches_scipy_with_ties():
+    rng = np.random.default_rng(218)
+    for _ in range(250):
+        sample_count = int(rng.integers(2, 60))
+        values_x = rng.integers(0, 10, size=sample_count)
+        values_y = rng.integers(0, 10, size=sample_count)
+
+        expected = kendalltau(values_x, values_y).statistic
+        actual = kendall_tau_b(values_x, values_y)
+        if np.isnan(expected):
+            assert np.isnan(actual)
+        else:
+            assert actual == pytest.approx(expected, abs=1e-12)
+
+
+def test_kendall_tau_b_all_tied_is_nan():
+    assert np.isnan(kendall_tau_b([1, 1, 1], [2, 2, 2]))

--- a/uv.lock
+++ b/uv.lock
@@ -4018,8 +4018,6 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "rapidfuzz" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [package.optional-dependencies]
@@ -4027,8 +4025,6 @@ all = [
     { name = "boto3" },
     { name = "jinja2" },
     { name = "pandas" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "strands-agents" },
@@ -4060,10 +4056,6 @@ dev = [
 ]
 docsplit = [
     { name = "pandas" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 llm = [
     { name = "jinja2" },
@@ -4153,11 +4145,8 @@ requires-dist = [
     { name = "python-dateutil", specifier = ">=2.8.2,<3.0.0" },
     { name = "rapidfuzz", specifier = ">=3.4.0,<4.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.10" },
-    { name = "scikit-learn", specifier = ">=1.7.2,<2.0.0" },
     { name = "scikit-learn", marker = "extra == 'dev'", specifier = ">=1.7.2,<2.0.0" },
-    { name = "scikit-learn", marker = "extra == 'docsplit'", specifier = ">=1.7.2,<2.0.0" },
     { name = "scipy", marker = "extra == 'dev'", specifier = ">=1.12.0,<2.0.0" },
-    { name = "scipy", marker = "extra == 'docsplit'", specifier = ">=1.12.0,<2.0.0" },
     { name = "scipy", marker = "extra == 'semantic'", specifier = ">=1.12.0,<2.0.0" },
     { name = "stickler-eval", extras = ["llm", "semantic", "confidence", "docsplit", "reporting"], marker = "extra == 'all'" },
     { name = "strands-agents", marker = "extra == 'llm'", specifier = ">=1.14.0,<2.0.0" },


### PR DESCRIPTION
## Issue Reference

Fixes #216

## Description of Changes

- implement binary ROC AUC, Rand index, V-measure, and Kendall tau-b with NumPy
- route confidence and document-splitting metrics through the shared implementations
- remove scikit-learn from core and reduce the `docsplit` extra to pandas
- retain SciPy and scikit-learn in the development environment as randomized test oracles
- update the lockfile, dependency documentation, and changelog

The lockfile change is limited to the Stickler package dependency arrays. Its dependency cooldown and CUDA/NVIDIA platform markers are preserved.

## Testing

- `uv lock --check`
- 130 affected/oracle tests passed, 2 skipped
- portable Windows suite: 1,947 passed, 12 skipped
- the remaining 6 full-suite cases are the existing `signal.SIGALRM`-based deep-nesting tests, which cannot run on Windows
- Ruff passed on every touched Python file

## Checklist

- [x] Unit tests added/updated
- [x] Code follows the project's coding standards
- [x] Documentation and `CHANGELOG.md` updated
- [x] Self-review completed
- [x] Ready for review

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
