### PR TITLE
docs: move the List[Dict] fix into the 0.7.0 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,28 +9,6 @@ Each release links to full notes on the
 
 ## [Unreleased]
 
-### Fixed
-
-- A `List[Dict[...]]` field no longer raises `TypeError` out of `compare_with()`,
-  and key order no longer affects its score. `LevenshteinComparator` raises for a
-  dict, and the comparators that accept one do so only via `str(dict)`, which
-  preserves insertion order -- which is why 0.6.0 scored two dicts with identical
-  content `0.5556`. Until the list-item normalization fix, that raise could not
-  reach the list path; afterwards it escaped to the caller, so a field that scored
-  in 0.6.0 crashed instead. A list item whose comparator refuses it with
-  `TypeError` is now retried as sorted-key JSON, so identical content scores `1.0`
-  regardless of key order. The retry is a fallback, not a pre-filter: the
-  comparator is offered the raw item first, so a mapping-aware comparator still
-  receives a `dict`, and anything but a `dict` re-raises -- a comparator bug stays
-  loud instead of becoming a silent `0.0`, and `List[bbox]` still parses. The
-  canonical form is the one `stickler.auto` already applies to a dict field, now
-  shared from `stickler.utils.canonical`, so the explicit and zero-config paths
-  cannot drift apart; it also no longer raises `PydanticSerializationError` on a
-  payload pydantic cannot serialize, such as a NumPy scalar under
-  `Dict[str, Any]`. A scalar `Dict` field still raises, and `Set`/`FrozenSet`
-  items are unchanged. Whether a dict deserves per-key comparison rather than
-  JSON-string similarity is [#277](https://github.com/awslabs/stickler/issues/277).
-
 ## [0.7.0] - 2026-08-18
 
 ### Added
@@ -358,6 +336,26 @@ Each release links to full notes on the
   ([#226](https://github.com/awslabs/stickler/issues/226))
 
 ### Fixed
+
+- A `List[Dict[...]]` field no longer raises `TypeError` out of `compare_with()`,
+  and key order no longer affects its score. `LevenshteinComparator` raises for a
+  dict, and the comparators that accept one do so only via `str(dict)`, which
+  preserves insertion order -- which is why 0.6.0 scored two dicts with identical
+  content `0.5556`. Until the list-item normalization fix, that raise could not
+  reach the list path; afterwards it escaped to the caller, so a field that scored
+  in 0.6.0 crashed instead. A list item whose comparator refuses it with
+  `TypeError` is now retried as sorted-key JSON, so identical content scores `1.0`
+  regardless of key order. The retry is a fallback, not a pre-filter: the
+  comparator is offered the raw item first, so a mapping-aware comparator still
+  receives a `dict`, and anything but a `dict` re-raises -- a comparator bug stays
+  loud instead of becoming a silent `0.0`, and `List[bbox]` still parses. The
+  canonical form is the one `stickler.auto` already applies to a dict field, now
+  shared from `stickler.utils.canonical`, so the explicit and zero-config paths
+  cannot drift apart; it also no longer raises `PydanticSerializationError` on a
+  payload pydantic cannot serialize, such as a NumPy scalar under
+  `Dict[str, Any]`. A scalar `Dict` field still raises, and `Set`/`FrozenSet`
+  items are unchanged. Whether a dict deserves per-key comparison rather than
+  JSON-string similarity is [#277](https://github.com/awslabs/stickler/issues/277).
 
 - A list-typed field's items now reach its comparator exactly as supplied.
   `ComparisonHelper.compare_unordered_lists` built its `HungarianMatcher` with


### PR DESCRIPTION
Release preflight. The `List[Dict]` fix from #281 was written under `## [Unreleased]`, because that PR was authored after the 0.7.0 notes were finished. It ships in 0.7.0, so the entry belongs in that section, and `RELEASING.md` expects `[Unreleased]` to be empty when the tag is cut.

Pure move, no rewording:

- Entry text is byte-identical to `HEAD` (1505 chars, 19 lines), verified programmatically rather than by eye
- `[Unreleased]` body is now empty
- The two extra deleted lines are the `### Fixed` heading and blank line `[Unreleased]` no longer needs; `[0.7.0]` already has its own
- Placed first under `[0.7.0]`'s `### Fixed`, immediately ahead of the list-item normalization entry it follows from
- Only `CHANGELOG.md` is touched

Last item on my release preflight. Everything else checks out on `dev` at `23639fc`:

- **1966 passed, 2 skipped** locally with the `bert` extra installed, which CI does not have
- Version reads `0.7.0` in `pyproject.toml`, `src/stickler/__init__.py` and `uv.lock`
- `phonenumberslite` is still present in the lockfile's resolved `dependencies` array, so #271 has not regressed
- `uv lock --check` passes, 168 packages
- Every fix in this release spot-checked individually: the `List[Dict]` crash and key-order sensitivity, #199 `ExactComparator` case-sensitivity on a list field, `List[bbox]`, #258 phone, #162 PEP 604 HTML thresholds, #259 `LLMComparator` parity, #257 `import stickler`, and that a genuinely broken comparator still raises rather than scoring 0.0
