### PR TITLE
refactor: remove deprecated ComparableField(aggregate=) parameter (#226)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Each release links to full notes on the
 
 ## [Unreleased]
 
+### Removed
+
+- The deprecated `aggregate` parameter on `ComparableField`, along with its dead
+  code path (`_is_aggregate_field`, `ConfigurationHelper.is_aggregate_field`, and
+  the `parent_is_aggregate` plumbing in the confusion-matrix calculator). The
+  flag had no effect once aggregation moved to the comparison layer in
+  [#94](https://github.com/awslabs/stickler/issues/94): every node in
+  `compare_with()` output already carries an `aggregate` block summing the
+  primitive field metrics below it. Passing `aggregate=` now raises `TypeError`
+  instead of emitting a `DeprecationWarning`. A JSON Schema carrying
+  `x-aws-stickler-aggregate` still imports — the key is accepted but ignored — so
+  existing schema files keep loading.
+  ([#226](https://github.com/awslabs/stickler/issues/226))
+
 ## [0.7.0] - 2026-08-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ Each release links to full notes on the
   [#94](https://github.com/awslabs/stickler/issues/94): every node in
   `compare_with()` output already carries an `aggregate` block summing the
   primitive field metrics below it. Passing `aggregate=` now raises `TypeError`
-  instead of emitting a `DeprecationWarning`. A JSON Schema carrying
+  instead of emitting a `DeprecationWarning`. The comparison parameters after
+  `default` (`clip_under_threshold`, `alias`, ...) are now keyword-only, so an
+  old five-positional call raises `TypeError` rather than silently rebinding its
+  fifth argument to `clip_under_threshold`. A JSON Schema carrying
   `x-aws-stickler-aggregate` still imports — the key is accepted but ignored — so
   existing schema files keep loading.
   ([#226](https://github.com/awslabs/stickler/issues/226))

--- a/README.md
+++ b/README.md
@@ -483,49 +483,6 @@ Controls whether similarity scores below threshold are clipped to 0.0.
 }
 ```
 
-#### `x-aws-stickler-aggregate`
-
-**Type:** `boolean`  
-**Required:** No  
-**Default:** `false`
-
-Controls whether this field's confusion matrix metrics (TP/FP/TN/FN) are included in parent-level aggregate counts.
-
-**How Aggregation Works:**
-- `true`: Field's metrics are **included** in parent's aggregate counts
-- `false`: Field's metrics are **calculated but not aggregated** to parent
-
-**When to Use:**
-
-| Setting | Use Case |
-|---------|----------|
-| `true` | Include field in overall accuracy/precision/recall calculations |
-| `false` | Exclude field from aggregate metrics (debugging, metadata, experimental fields) |
-
-**Example:**
-
-```json
-{
-  "type": "object",
-  "properties": {
-    "invoice_id": {
-      "type": "string",
-      "description": "Include in accuracy metrics",
-      "x-aws-stickler-comparator": "ExactComparator",
-      "x-aws-stickler-threshold": 1.0,
-      "x-aws-stickler-aggregate": true
-    },
-    "debug_field": {
-      "type": "string",
-      "description": "For debugging only - don't affect metrics",
-      "x-aws-stickler-comparator": "ExactComparator",
-      "x-aws-stickler-threshold": 1.0,
-      "x-aws-stickler-aggregate": false
-    }
-  }
-}
-```
-
 ### Model-Level Extensions
 
 Add these at the root level of your JSON Schema:
@@ -581,8 +538,7 @@ Here's a production-ready invoice schema with all extensions:
       "x-aws-stickler-comparator": "ExactComparator",
       "x-aws-stickler-threshold": 1.0,
       "x-aws-stickler-weight": 3.0,
-      "x-aws-stickler-clip-under-threshold": true,
-      "x-aws-stickler-aggregate": true
+      "x-aws-stickler-clip-under-threshold": true
     },
     "customer_name": {
       "type": "string",
@@ -591,8 +547,7 @@ Here's a production-ready invoice schema with all extensions:
       "x-aws-stickler-comparator": "LevenshteinComparator",
       "x-aws-stickler-threshold": 0.8,
       "x-aws-stickler-weight": 1.5,
-      "x-aws-stickler-clip-under-threshold": false,
-      "x-aws-stickler-aggregate": true
+      "x-aws-stickler-clip-under-threshold": false
     },
     "total_amount": {
       "type": "number",
@@ -601,8 +556,7 @@ Here's a production-ready invoice schema with all extensions:
       "x-aws-stickler-comparator": "NumericComparator",
       "x-aws-stickler-threshold": 0.95,
       "x-aws-stickler-weight": 2.5,
-      "x-aws-stickler-clip-under-threshold": false,
-      "x-aws-stickler-aggregate": true
+      "x-aws-stickler-clip-under-threshold": false
     },
     "line_items": {
       "type": "array",
@@ -641,8 +595,7 @@ Here's a production-ready invoice schema with all extensions:
       "x-aws-stickler-comparator": "FuzzyComparator",
       "x-aws-stickler-threshold": 0.5,
       "x-aws-stickler-weight": 0.2,
-      "x-aws-stickler-clip-under-threshold": false,
-      "x-aws-stickler-aggregate": false
+      "x-aws-stickler-clip-under-threshold": false
     }
   },
   "required": ["invoice_id", "customer_name", "total_amount", "line_items"]
@@ -702,7 +655,6 @@ print(f"Line Items: {result['field_scores']['line_items']:.3f}")  # ~1.0 - match
 | `x-aws-stickler-threshold` | number (0.0-1.0) | 0.5 or 1.0 | Match classification cutoff |
 | `x-aws-stickler-weight` | number (> 0.0) | 1.0 | Field importance multiplier |
 | `x-aws-stickler-clip-under-threshold` | boolean | false | Zero out low scores |
-| `x-aws-stickler-aggregate` | boolean | false | Include in parent metrics |
 | `x-aws-stickler-model-name` | string | "DynamicModel" | Generated class name |
 | `x-aws-stickler-match-threshold` | number (0.0-1.0) | 0.7 | Model-level threshold |
 

--- a/docs/docs/Advanced/aggregate-metrics.md
+++ b/docs/docs/Advanced/aggregate-metrics.md
@@ -8,7 +8,7 @@ Stickler automatically includes an `aggregate` field at every node in the confus
 
 ## Key Features
 
-- **Automatic** -- Every node gets an `aggregate` field. No `aggregate=True` parameter needed.
+- **Automatic** -- Every node gets an `aggregate` field, with no per-field configuration.
 - **Hierarchical** -- Parent nodes sum metrics from all child primitive fields.
 - **Consistent** -- The same access pattern works at every level: `result['confusion_matrix']['aggregate']` or `result['confusion_matrix']['fields']['contact']['aggregate']`.
 - **Derived metrics included** -- Each aggregate contains precision, recall, F1, and accuracy.

--- a/docs/docs/Guides/Evaluation/README.md
+++ b/docs/docs/Guides/Evaluation/README.md
@@ -49,7 +49,6 @@ When defining a `StructuredModel` subclass in Python, each field is declared wit
 | `threshold` | `float` (0.0--1.0) | `0.5` | Minimum similarity score required for a field to be classified as a match. |
 | `weight` | `float` (> 0.0) | `1.0` | Relative importance of this field when computing aggregate scores. |
 | `clip_under_threshold` | `bool` | `True` | When `True`, scores below `threshold` are zeroed out before contributing to the weighted average. |
-| `aggregate` | `bool` | `False` | **Deprecated, removed in 1.0.** Has no effect: every node already carries an `aggregate` block in the `compare_with()` output summing the primitive field metrics below it. Passing it at all emits a `DeprecationWarning`; remove the argument, there is no replacement to adopt ([#226](https://github.com/awslabs/stickler/issues/226)). |
 
 ### How Each Parameter Affects Scoring
 

--- a/docs/docs/Guides/Evaluation/README.md
+++ b/docs/docs/Guides/Evaluation/README.md
@@ -190,7 +190,6 @@ Add these extensions to any property in your JSON Schema to control comparison b
 | `x-aws-stickler-threshold` | number (0.0--1.0) | 0.5 or 1.0 | Match classification cutoff |
 | `x-aws-stickler-weight` | number (> 0.0) | 1.0 | Field importance multiplier |
 | `x-aws-stickler-clip-under-threshold` | boolean | `false` | Zero out scores below threshold |
-| `x-aws-stickler-aggregate` | boolean | `false` | Include in parent-level aggregate metrics |
 | `x-aws-stickler-model-name` | string | `"DynamicModel"` | Name of the generated Python class (root level) |
 | `x-aws-stickler-match-threshold` | number (0.0--1.0) | 0.7 | Model-level matching threshold for Hungarian algorithm (root level) |
 

--- a/examples/scripts/aggregate_metrics_demo.py
+++ b/examples/scripts/aggregate_metrics_demo.py
@@ -201,34 +201,9 @@ def demonstrate_aggregate_feature():
     print("   ✅ Includes derived metrics (precision, recall, F1)")
 
 
-def demonstrate_deprecation_warning():
-    """Show the deprecation warning for legacy aggregate parameter."""
-
-    print("\n⚠️  DEPRECATION WARNING DEMO")
-    print("=" * 40)
-    print("The old aggregate=True parameter is now deprecated:")
-
-    import warnings
-
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-
-        # This will trigger a deprecation warning
-        ComparableField(aggregate=True, comparator=ExactComparator())
-
-        if w:
-            print(f"   Warning: {w[0].message}")
-            print(f"   Category: {w[0].category.__name__}")
-
-    print("   ✅ Use the new universal aggregate fields instead!")
-
-
 if __name__ == "__main__":
     # Run the main demonstration
     demonstrate_aggregate_feature()
-
-    # Show deprecation warning
-    demonstrate_deprecation_warning()
 
     print("\n🎉 DEMO COMPLETE!")
     print("The universal aggregate field feature provides automatic")

--- a/examples/scripts/json_schema_demo.py
+++ b/examples/scripts/json_schema_demo.py
@@ -367,8 +367,7 @@ def advanced_extensions_and_refs_example():
                         "type": "string",
                         "x-aws-stickler-comparator": "LevenshteinComparator",
                         "x-aws-stickler-threshold": 0.9,
-                        "x-aws-stickler-weight": 2.0,
-                        "x-aws-stickler-aggregate": True
+                        "x-aws-stickler-weight": 2.0
                     },
                     "address": {"$ref": "#/definitions/Address"}
                 },
@@ -380,7 +379,6 @@ def advanced_extensions_and_refs_example():
                 "type": "string",
                 "x-aws-stickler-comparator": "ExactComparator",
                 "x-aws-stickler-weight": 3.0,
-                "x-aws-stickler-aggregate": True,
                 "x-aws-stickler-clip-under-threshold": True
             },
             "customer": {"$ref": "#/definitions/Customer"},
@@ -389,8 +387,7 @@ def advanced_extensions_and_refs_example():
                 "type": "number",
                 "x-aws-stickler-comparator": "NumericComparator",
                 "x-aws-stickler-threshold": 0.95,
-                "x-aws-stickler-weight": 2.5,
-                "x-aws-stickler-aggregate": True
+                "x-aws-stickler-weight": 2.5
             },
             "items": {
                 "type": "array",

--- a/src/stickler/structured_object_evaluator/models/comparable_field.py
+++ b/src/stickler/structured_object_evaluator/models/comparable_field.py
@@ -17,6 +17,7 @@ def ComparableField(
     threshold: float = 0.5,
     weight: float = 1.0,
     default: Any = None,
+    *,
     clip_under_threshold: bool = True,
     # Pydantic Field parameters (all optional, just like Field)
     alias: Optional[str] = None,

--- a/src/stickler/structured_object_evaluator/models/comparable_field.py
+++ b/src/stickler/structured_object_evaluator/models/comparable_field.py
@@ -4,8 +4,7 @@ This module provides the ComparableField function for creating fields in structu
 with comparison configuration parameters.
 """
 
-import warnings
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 from pydantic import Field
 
@@ -13,36 +12,11 @@ from stickler.comparators.base import BaseComparator
 from stickler.comparators.levenshtein import LevenshteinComparator
 
 
-class _Unset:
-    """Sentinel distinguishing "argument omitted" from "argument passed".
-
-    Needed because ``aggregate=False`` is both the historical default and a
-    value a user may pass explicitly. Only the explicit case should warn.
-
-    Detection is by identity (``is not _UNSET``). That is sound within one
-    import namespace; a codebase importing stickler under two names (say
-    ``stickler.x`` and ``src.stickler.x``) creates two distinct sentinels, and
-    handing one namespace's to the other would read as an explicit argument.
-    Harmless -- the result is a spurious deprecation warning about a parameter
-    that is going away regardless.
-    """
-
-    def __bool__(self) -> bool:  # pragma: no cover - defensive
-        return False
-
-    def __repr__(self) -> str:  # pragma: no cover - defensive
-        return "<unset>"
-
-
-_UNSET = _Unset()
-
-
 def ComparableField(
     comparator: Optional[BaseComparator] = None,
     threshold: float = 0.5,
     weight: float = 1.0,
     default: Any = None,
-    aggregate: Union[bool, _Unset] = _UNSET,
     clip_under_threshold: bool = True,
     # Pydantic Field parameters (all optional, just like Field)
     alias: Optional[str] = None,
@@ -60,13 +34,6 @@ def ComparableField(
         threshold: Minimum similarity score to consider a match (default: 0.5)
         weight: Weight of this field in overall score calculation (default: 1.0)
         default: Default value for the field (default: None)
-        aggregate: DEPRECATED, has no effect, and will be removed in 1.0.
-                  Passing it at all (either value) emits a DeprecationWarning.
-                  Aggregation is applied at the comparison layer: every node in
-                  compare_with() output already carries an 'aggregate' block
-                  summing the primitive field metrics below it. Remove the
-                  argument; there is no replacement to adopt.
-                  See https://github.com/awslabs/stickler/issues/226
         clip_under_threshold: Whether to zero out scores below threshold (default: True)
         alias: Pydantic field alias for serialization (default: None)
         description: Field description for documentation (default: None)
@@ -89,25 +56,14 @@ def ComparableField(
                 examples=["user@example.com"]
             )
     """
-    # Warn on ANY explicit use, not just aggregate=True. Passing False was
-    # silent before, so those callers had no signal that the parameter is going
-    # away; they would have met a bare TypeError on upgrade. The value itself
-    # has no effect either way: aggregation is applied at the comparison layer
-    # and every node in compare_with() output carries an `aggregate` block.
-    if aggregate is not _UNSET:
-        warnings.warn(
-            "The 'aggregate' parameter in ComparableField is deprecated, has no "
-            "effect, and will be removed in 1.0. All nodes automatically "
-            "include an 'aggregate' field in the compare_with() output that "
-            "sums primitive field metrics below that node. Remove the argument; "
-            "no replacement is needed. See "
-            "https://github.com/awslabs/stickler/issues/226",
-            DeprecationWarning,
-            stacklevel=2,
+
+    if "aggregate" in field_kwargs:
+        raise TypeError(
+            "The 'aggregate' parameter was removed in 1.0; it had no effect. "
+            "Aggregation is computed automatically for every node in compare_with() "
+            "output. Remove the argument. "
+            "See https://github.com/awslabs/stickler/issues/226"
         )
-        aggregate = bool(aggregate)
-    else:
-        aggregate = False
 
     # Create the actual comparator instance
     actual_comparator = comparator or LevenshteinComparator()
@@ -119,8 +75,7 @@ def ComparableField(
         "comparator_config": getattr(actual_comparator, "config", {}),
         "threshold": threshold,
         "weight": weight,
-        "clip_under_threshold": clip_under_threshold,
-        "aggregate": aggregate,
+        "clip_under_threshold": clip_under_threshold
     }
 
     # Create json_schema_extra function that stores runtime data
@@ -133,7 +88,6 @@ def ComparableField(
     json_schema_extra_func._threshold = threshold
     json_schema_extra_func._weight = weight
     json_schema_extra_func._clip_under_threshold = clip_under_threshold
-    json_schema_extra_func._aggregate = aggregate
     json_schema_extra_func._comparison_metadata = serializable_metadata
 
     # Merge with existing json_schema_extra if provided
@@ -149,7 +103,6 @@ def ComparableField(
         enhanced_json_schema_extra._threshold = threshold
         enhanced_json_schema_extra._weight = weight
         enhanced_json_schema_extra._clip_under_threshold = clip_under_threshold
-        enhanced_json_schema_extra._aggregate = aggregate
         enhanced_json_schema_extra._comparison_metadata = serializable_metadata
         final_json_schema_extra = enhanced_json_schema_extra
     elif isinstance(existing_json_schema_extra, dict):
@@ -163,7 +116,6 @@ def ComparableField(
         enhanced_json_schema_extra._threshold = threshold
         enhanced_json_schema_extra._weight = weight
         enhanced_json_schema_extra._clip_under_threshold = clip_under_threshold
-        enhanced_json_schema_extra._aggregate = aggregate
         enhanced_json_schema_extra._comparison_metadata = serializable_metadata
         final_json_schema_extra = enhanced_json_schema_extra
     else:
@@ -185,30 +137,6 @@ def ComparableField(
     )
 
     return field
-
-
-
-def _restore_deprecated_aggregate(field: Any, value: Any) -> None:
-    """Set a field's stored ``aggregate`` value without emitting a warning.
-
-    Reading an exported config is not an explicit use of the deprecated
-    parameter, so ``ComparableField`` is called with the sentinel and the value
-    is written afterwards. That keeps ``to_stickler_config()`` faithful --
-    export -> import -> export is unchanged, including for ``aggregate=True``
-    -- while the warning stays reserved for code a user can actually edit.
-
-    Internal, and removed with the parameter in 1.0
-    (https://github.com/awslabs/stickler/issues/226).
-    """
-    if not isinstance(value, bool):
-        return
-    extra = getattr(field, "json_schema_extra", None)
-    if extra is None or not callable(extra):
-        return
-    extra._aggregate = value
-    metadata = getattr(extra, "_comparison_metadata", None)
-    if isinstance(metadata, dict):
-        metadata["aggregate"] = value
 
 
 def _reconstruct_comparator_from_type(

--- a/src/stickler/structured_object_evaluator/models/comparison_info.py
+++ b/src/stickler/structured_object_evaluator/models/comparison_info.py
@@ -84,7 +84,6 @@ class ComparableFieldConfig:
         comparator: The comparator to use for string similarity
         threshold: Minimum score to consider a match (like ANLS threshold)
         weight: Weight of this field in the overall score calculation
-        aggregate: Whether to aggregate metrics from child fields
         clip_under_threshold: Whether to zero out scores below threshold
     """
 
@@ -93,7 +92,6 @@ class ComparableFieldConfig:
         comparator: Optional[BaseComparator] = None,
         threshold: float = 0.5,
         weight: float = 1.0,
-        aggregate: bool = False,
         clip_under_threshold: bool = True,
     ):
         """Initialize comparison configuration.
@@ -102,13 +100,11 @@ class ComparableFieldConfig:
             comparator: Comparator to use (default: LevenshteinComparator)
             threshold: Minimum similarity score to consider a match (default: 0.5)
             weight: Weight of this field in the overall score (default: 1.0)
-            aggregate: Whether to aggregate metrics from child fields (default: False)
             clip_under_threshold: Whether to zero out scores below threshold (default: True)
         """
         self.comparator = comparator or LevenshteinComparator()
         self.threshold = threshold
         self.weight = weight
-        self.aggregate = aggregate
         self.clip_under_threshold = clip_under_threshold
 
     def compare(self, value1: Any, value2: Any) -> float:
@@ -136,7 +132,7 @@ class ComparableFieldConfig:
 
     def __repr__(self) -> str:
         """Return string representation."""
-        return f"ComparableFieldConfig(comparator={self.comparator}, threshold={self.threshold}, weight={self.weight}, aggregate={self.aggregate}, clip_under_threshold={self.clip_under_threshold})"
+        return f"ComparableFieldConfig(comparator={self.comparator}, threshold={self.threshold}, weight={self.weight}, clip_under_threshold={self.clip_under_threshold})"
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to a serializable dictionary for JSON schema."""
@@ -146,7 +142,6 @@ class ComparableFieldConfig:
             "comparator_config": getattr(self.comparator, "config", {}),
             "threshold": self.threshold,
             "weight": self.weight,
-            "aggregate": self.aggregate,
             "clip_under_threshold": self.clip_under_threshold,
         }
 

--- a/src/stickler/structured_object_evaluator/models/configuration_helper.py
+++ b/src/stickler/structured_object_evaluator/models/configuration_helper.py
@@ -209,7 +209,6 @@ class ConfigurationHelper:
                 threshold = getattr(json_func, "_threshold", 0.5)
                 weight = getattr(json_func, "_weight", 1.0)
                 clip_under_threshold = getattr(json_func, "_clip_under_threshold", True)
-                aggregate = getattr(json_func, "_aggregate", False)
 
                 from .comparison_info import ComparableFieldConfig
 
@@ -218,7 +217,6 @@ class ConfigurationHelper:
                     threshold=threshold,
                     weight=weight,
                     clip_under_threshold=clip_under_threshold,
-                    aggregate=aggregate,
                 )
 
         # FALLBACK: Legacy JSON schema approach for backward compatibility
@@ -252,7 +250,6 @@ class ConfigurationHelper:
                 clip_under_threshold = comparison_config.get(
                     "clip_under_threshold", True
                 )
-                aggregate = comparison_config.get("aggregate", False)
 
                 from .comparison_info import ComparableFieldConfig
 
@@ -261,7 +258,6 @@ class ConfigurationHelper:
                     threshold=threshold,
                     weight=weight,
                     clip_under_threshold=clip_under_threshold,
-                    aggregate=aggregate,
                 )
 
         # Check if this is a structured field type that needs special handling
@@ -283,29 +279,6 @@ class ConfigurationHelper:
             comparator=LevenshteinComparator(), threshold=default_threshold, weight=1.0
         )
 
-    @staticmethod
-    def is_aggregate_field(cls, field_name: str) -> bool:
-        """Check if field is marked for confusion matrix aggregation.
-
-        Args:
-            cls: StructuredModel class
-            field_name: Name of the field to check
-
-        Returns:
-            True if the field is marked for aggregation, False otherwise
-        """
-        field_info = cls.model_fields[field_name]
-
-        # Since ComparableField is now always a function, check for json_schema_extra
-        if hasattr(field_info, "json_schema_extra") and callable(
-            field_info.json_schema_extra
-        ):
-            schema = {}
-            field_info.json_schema_extra(schema)
-            comparison_config = schema.get("x-comparison", {})
-            return comparison_config.get("aggregate", False)
-
-        return False
 
     @staticmethod
     def is_immediate_child(nested_path: str, field_name: str) -> bool:

--- a/src/stickler/structured_object_evaluator/models/confusion_matrix_calculator.py
+++ b/src/stickler/structured_object_evaluator/models/confusion_matrix_calculator.py
@@ -150,14 +150,6 @@ class ConfusionMatrixCalculator:
         # List-level metrics count object matches from the Hungarian algorithm;
         # nested field metrics count field matches within those objects. They are
         # separate concerns and are deliberately not rolled together here.
-        #
-        # A branch used to zero these and re-sum them from nested_fields when
-        # `_is_aggregate_field(field_name)` was true and `gt_list` was not a
-        # list. It was dead by construction -- this method is only ever called
-        # with a list, so the guard was self-contradictory (instrumented the
-        # whole suite: 0 calls with a non-list). It is removed here rather than
-        # left as a path keyed on a flag that is deprecated and has no other
-        # effect (#226).
 
         # Add derived metrics
         metrics_helper = MetricsHelper()
@@ -567,7 +559,6 @@ class ConfusionMatrixCalculator:
         parent_field_name: str,
         gt_nested: "StructuredModel",
         pred_nested: "StructuredModel",
-        parent_is_aggregate: bool = False,
     ) -> Dict[str, Dict[str, Any]]:
         """Calculate confusion matrix metrics for fields within a single nested StructuredModel.
 
@@ -575,7 +566,6 @@ class ConfusionMatrixCalculator:
             parent_field_name: Name of the parent field (e.g., "address")
             gt_nested: Ground truth nested StructuredModel
             pred_nested: Predicted nested StructuredModel
-            parent_is_aggregate: Whether the parent field should aggregate child metrics
 
         Returns:
             Dictionary mapping nested field paths to their confusion matrix metrics
@@ -598,15 +588,7 @@ class ConfusionMatrixCalculator:
                 return nested_metrics
             return nested_metrics
 
-        # Initialize aggregation metrics for parent field if it's an aggregated field
-        parent_metrics = (
-            {"tp": 0, "fa": 0, "fd": 0, "fp": 0, "tn": 0, "fn": 0}
-            if parent_is_aggregate
-            else None
-        )
-
-        # Track which fields are aggregate fields themselves to avoid double counting
-        child_aggregate_fields = set()
+    
 
         # For each field in the nested model
         for field_name in gt_nested.__class__.model_fields:
@@ -615,13 +597,7 @@ class ConfusionMatrixCalculator:
 
             nested_field_path = f"{parent_field_name}.{field_name}"
 
-            # Check if this nested field is itself an aggregate field
-            is_child_aggregate = False
-            if hasattr(gt_nested.__class__, "_is_aggregate_field"):
-                is_child_aggregate = gt_nested.__class__._is_aggregate_field(field_name)
-                if is_child_aggregate:
-                    child_aggregate_fields.add(field_name)
-
+         
             # Get the field value from the prediction
             pred_value = getattr(pred_nested, field_name, None)
             gt_value = getattr(gt_nested, field_name)
@@ -663,50 +639,12 @@ class ConfusionMatrixCalculator:
 
                 # Recursively calculate metrics for deeper nesting
                 deeper_metrics = self.calculate_single_nested_field_metrics(
-                    nested_field_path, gt_value, pred_value, is_child_aggregate
+                    nested_field_path, gt_value, pred_value
                 )
                 nested_metrics.update(deeper_metrics)
 
-                # If this is an aggregate child field, we need to use its aggregated metrics
-                # instead of the direct field comparison metrics
-                if is_child_aggregate and nested_field_path in deeper_metrics:
-                    # For an aggregate child field, we replace its direct metrics with
-                    # the aggregation of its children's metrics
-                    nested_metrics[nested_field_path] = deeper_metrics[
-                        nested_field_path
-                    ]
+        
 
-            # For parent aggregation, we need to be careful not to double count metrics
-            if parent_is_aggregate:
-                if is_child_aggregate:
-                    # If child is an aggregate, use its aggregated metrics for parent
-                    if nested_field_path in deeper_metrics:
-                        child_agg_metrics = deeper_metrics[nested_field_path]
-                        for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                            parent_metrics[metric] += child_agg_metrics.get(metric, 0)
-                else:
-                    # If child is not an aggregate, use its direct field metrics
-                    field_metrics = nested_metrics[nested_field_path]
-                    for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                        parent_metrics[metric] += field_metrics.get(metric, 0)
 
-        # If parent is an aggregated field, add the aggregated metrics to the result
-        if parent_is_aggregate:
-            # Don't include metrics from child aggregate fields in the parent's metrics
-            # as they've already been counted through their own aggregation
-            for field_name in child_aggregate_fields:
-                nested_field_path = f"{parent_field_name}.{field_name}"
-                if nested_field_path in nested_metrics:
-                    # Don't double count these metrics in the parent
-                    field_metrics = nested_metrics[nested_field_path]
-                    # Subtract these metrics from parent_metrics to avoid double counting
-                    for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
-                        parent_metrics[metric] -= field_metrics.get(metric, 0)
-
-            nested_metrics[parent_field_name] = parent_metrics
-            # Add derived metrics
-            nested_metrics[parent_field_name]["derived"] = (
-                MetricsHelper().calculate_derived_metrics(parent_metrics)
-            )
 
         return nested_metrics

--- a/src/stickler/structured_object_evaluator/models/confusion_matrix_calculator.py
+++ b/src/stickler/structured_object_evaluator/models/confusion_matrix_calculator.py
@@ -588,7 +588,7 @@ class ConfusionMatrixCalculator:
                 return nested_metrics
             return nested_metrics
 
-    
+
 
         # For each field in the nested model
         for field_name in gt_nested.__class__.model_fields:
@@ -597,7 +597,7 @@ class ConfusionMatrixCalculator:
 
             nested_field_path = f"{parent_field_name}.{field_name}"
 
-         
+
             # Get the field value from the prediction
             pred_value = getattr(pred_nested, field_name, None)
             gt_value = getattr(gt_nested, field_name)
@@ -643,7 +643,7 @@ class ConfusionMatrixCalculator:
                 )
                 nested_metrics.update(deeper_metrics)
 
-        
+
 
 
 

--- a/src/stickler/structured_object_evaluator/models/field_converter.py
+++ b/src/stickler/structured_object_evaluator/models/field_converter.py
@@ -69,7 +69,7 @@ class FieldConverter:
         threshold = field_config.get("threshold", 0.5)
         weight = field_config.get("weight", 1.0)
         clip_under_threshold = field_config.get("clip_under_threshold", True)
-       
+
 
         # Extract Pydantic field parameters
         default = field_config.get("default", ...)  # Use Ellipsis for required fields

--- a/src/stickler/structured_object_evaluator/models/field_converter.py
+++ b/src/stickler/structured_object_evaluator/models/field_converter.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional, Tuple, Type
 
 from pydantic import Field
 
-from .comparable_field import _UNSET, ComparableField, _restore_deprecated_aggregate
+from .comparable_field import ComparableField
 from .comparator_registry import create_comparator
 from .type_resolver import resolve_type_string
 
@@ -69,14 +69,7 @@ class FieldConverter:
         threshold = field_config.get("threshold", 0.5)
         weight = field_config.get("weight", 1.0)
         clip_under_threshold = field_config.get("clip_under_threshold", True)
-        # Reading a config is not an explicit use of the deprecated `aggregate`
-        # parameter: `to_stickler_config()` writes the key for every field, so
-        # passing it through would warn on every round trip -- blaming this
-        # frame for a key the caller never wrote, and hard-failing under
-        # `-W error::DeprecationWarning`. Construct with the sentinel, then
-        # restore the config's value below so export stays faithful (issue #226).
-        aggregate = _UNSET
-        config_aggregate = field_config.get("aggregate")
+       
 
         # Extract Pydantic field parameters
         default = field_config.get("default", ...)  # Use Ellipsis for required fields
@@ -109,14 +102,12 @@ class FieldConverter:
             threshold=threshold,
             weight=weight,
             default=default,
-            aggregate=aggregate,
             clip_under_threshold=clip_under_threshold,
             alias=alias,
             description=description,
             examples=examples,
         )
 
-        _restore_deprecated_aggregate(comparable_field, config_aggregate)
 
         return field_type, comparable_field
 
@@ -181,14 +172,7 @@ class FieldConverter:
         # Extract threshold and weight from field configuration
         weight = field_config.get("weight", 1.0)  # Default weight
         clip_under_threshold = field_config.get("clip_under_threshold", True)
-        # Reading a config is not an explicit use of the deprecated `aggregate`
-        # parameter: `to_stickler_config()` writes the key for every field, so
-        # passing it through would warn on every round trip -- blaming this
-        # frame for a key the caller never wrote, and hard-failing under
-        # `-W error::DeprecationWarning`. Construct with the sentinel, then
-        # restore the config's value below so export stays faithful (issue #226).
-        aggregate = _UNSET
-        config_aggregate = field_config.get("aggregate")
+
 
         # For list_structured_model, don't set threshold (Hungarian matching uses model's match_threshold)
         # For single structured_model, use threshold from config
@@ -210,14 +194,12 @@ class FieldConverter:
             threshold=threshold,
             weight=weight,
             default=default,
-            aggregate=aggregate,
             clip_under_threshold=clip_under_threshold,
             alias=alias,
             description=description,
             examples=examples,
         )
 
-        _restore_deprecated_aggregate(comparable_field, config_aggregate)
 
         return field_type, comparable_field
 
@@ -299,7 +281,7 @@ class FieldConverter:
                     )
 
         # Validate boolean parameters
-        boolean_params = ["required", "aggregate", "clip_under_threshold"]
+        boolean_params = ["required", "clip_under_threshold"]
         for param in boolean_params:
             if param in field_config:
                 value = field_config[param]

--- a/src/stickler/structured_object_evaluator/models/json_schema_field_converter.py
+++ b/src/stickler/structured_object_evaluator/models/json_schema_field_converter.py
@@ -445,14 +445,6 @@ class JsonSchemaFieldConverter:
                 )
             extensions["clip_under_threshold"] = clip_value
         
-        if "x-aws-stickler-aggregate" in property_schema:
-            aggregate_value = property_schema["x-aws-stickler-aggregate"]
-            if not isinstance(aggregate_value, bool):
-                field_info = f" for field '{field_path}'" if field_path else ""
-                raise ValueError(
-                    f"x-aws-stickler-aggregate must be a boolean{field_info}, got: {type(aggregate_value).__name__}"
-                )
-            extensions["aggregate"] = aggregate_value
         
         return extensions
 
@@ -761,8 +753,6 @@ class JsonSchemaFieldConverter:
         if metadata.get("clip_under_threshold") is not None:
             clip_key = f"{prefix}clip-under-threshold" if output_format == "json_schema" else "clip_under_threshold"
             extensions[clip_key] = metadata["clip_under_threshold"]
-        if metadata.get("aggregate") is not None:
-            extensions[f"{prefix}aggregate"] = metadata["aggregate"]
         
         return extensions
     
@@ -799,8 +789,5 @@ class JsonSchemaFieldConverter:
         
         if hasattr(json_func, "_clip_under_threshold"):
             metadata["clip_under_threshold"] = json_func._clip_under_threshold
-        
-        if hasattr(json_func, "_aggregate"):
-            metadata["aggregate"] = json_func._aggregate
-        
+
         return metadata

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -652,7 +652,6 @@ class StructuredModel(BaseModel):
         - x-aws-stickler-threshold: Similarity threshold for match/no-match (0.0-1.0, default: 0.5)
         - x-aws-stickler-weight: Field importance in overall scoring (>0.0, default: 1.0)
         - x-aws-stickler-clip-under-threshold: Clip scores below threshold to 0.0 (bool, default: false)
-        - x-aws-stickler-aggregate: Include field metrics in parent aggregation (bool, default: false)
 
         Model-Level Extensions:
         -----------------------
@@ -716,7 +715,6 @@ class StructuredModel(BaseModel):
             ...             "x-aws-stickler-comparator": "LevenshteinComparator",
             ...             "x-aws-stickler-threshold": 0.9,
             ...             "x-aws-stickler-weight": 2.0,
-            ...             "x-aws-stickler-aggregate": true
             ...         },
             ...         "price": {
             ...             "type": "number",
@@ -890,17 +888,6 @@ class StructuredModel(BaseModel):
         """
         return ConfigurationHelper.get_comparison_info(cls, field_name)
 
-    @classmethod
-    def _is_aggregate_field(cls, field_name: str) -> bool:
-        """Check if field is marked for confusion matrix aggregation.
-
-        Args:
-            field_name: Name of the field to check
-
-        Returns:
-            True if the field is marked for aggregation, False otherwise
-        """
-        return ConfigurationHelper.is_aggregate_field(cls, field_name)
 
     def _should_use_hierarchical_structure(self, val: Any, field_name: str) -> bool:
         """Check if a list value should maintain hierarchical structure.
@@ -1238,7 +1225,6 @@ class StructuredModel(BaseModel):
         parent_field_name: str,
         gt_nested: "StructuredModel",
         pred_nested: "StructuredModel",
-        parent_is_aggregate: bool = False,
     ) -> Dict[str, Dict[str, Any]]:
         """Calculate confusion matrix metrics for fields within a single nested StructuredModel.
 
@@ -1248,7 +1234,6 @@ class StructuredModel(BaseModel):
             parent_field_name: Name of the parent field (e.g., "address")
             gt_nested: Ground truth nested StructuredModel
             pred_nested: Predicted nested StructuredModel
-            parent_is_aggregate: Whether the parent field should aggregate child metrics
 
         Returns:
             Dictionary mapping nested field paths to their confusion matrix metrics
@@ -1258,7 +1243,7 @@ class StructuredModel(BaseModel):
 
         calculator = ConfusionMatrixCalculator(self)
         return calculator.calculate_single_nested_field_metrics(
-            parent_field_name, gt_nested, pred_nested, parent_is_aggregate
+            parent_field_name, gt_nested, pred_nested
         )
 
     def _collect_enhanced_non_matches(

--- a/tests/structured_object_evaluator/test_from_json_schema.py
+++ b/tests/structured_object_evaluator/test_from_json_schema.py
@@ -1057,8 +1057,7 @@ class TestFromJsonSchemaExtensions:
                     "x-aws-stickler-comparator": "LevenshteinComparator",
                     "x-aws-stickler-threshold": 0.85,
                     "x-aws-stickler-weight": 2.5,
-                    "x-aws-stickler-clip-under-threshold": True,
-                    "x-aws-stickler-aggregate": True
+                    "x-aws-stickler-clip-under-threshold": True
                 }
             }
         }
@@ -1148,29 +1147,6 @@ class TestFromJsonSchemaExtensions:
         
         score = obj1.compare(obj2)
         assert score == 1.0
-
-    def test_extension_aggregate(self):
-        """Test x-aws-stickler-aggregate for confusion matrix aggregation."""
-        schema = {
-            "type": "object",
-            "properties": {
-                "field1": {
-                    "type": "string",
-                    "x-aws-stickler-aggregate": True
-                },
-                "field2": {
-                    "type": "string",
-                    "x-aws-stickler-aggregate": False
-                }
-            }
-        }
-        
-        Model = StructuredModel.from_json_schema(schema)
-        obj1 = Model(field1="A", field2="B")
-        obj2 = Model(field1="A", field2="B")
-        
-        result = obj1.compare_with(obj2)
-        assert "overall_score" in result
 
     def test_multiple_comparator_types(self):
         """Test schema with multiple different comparator types."""

--- a/tests/structured_object_evaluator/test_json_schema_error_handling.py
+++ b/tests/structured_object_evaluator/test_json_schema_error_handling.py
@@ -266,35 +266,27 @@ class TestBooleanExtensionValidation:
         with pytest.raises(ValueError, match="x-aws-stickler-clip-under-threshold must be a boolean"):
             StructuredModel.from_json_schema(schema)
 
-    def test_aggregate_non_boolean_raises_error(self):
-        """Test that non-boolean aggregate raises ValueError."""
-        schema = {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "x-aws-stickler-aggregate": "false"
-                }
-            }
-        }
-        
-        with pytest.raises(ValueError, match="x-aws-stickler-aggregate must be a boolean"):
-            StructuredModel.from_json_schema(schema)
+    def test_aggregate_extension_is_ignored_on_import(self):
+        """The removed x-aws-stickler-aggregate key is accepted but ignored.
 
-    def test_aggregate_integer_raises_error(self):
-        """Test that integer aggregate raises ValueError."""
+        Old schema files may still carry it; importing them must not raise and
+        the key must have no effect (issue #226). Even a non-boolean value is
+        ignored, since the key is no longer read at all.
+        """
         schema = {
             "type": "object",
             "properties": {
                 "name": {
                     "type": "string",
-                    "x-aws-stickler-aggregate": 0
+                    "x-aws-stickler-aggregate": "not-a-bool"
                 }
             }
         }
-        
-        with pytest.raises(ValueError, match="x-aws-stickler-aggregate must be a boolean"):
-            StructuredModel.from_json_schema(schema)
+
+        model_cls = StructuredModel.from_json_schema(schema)
+        # Imports without error; the ignored key does not surface in the config.
+        field_config = model_cls.to_stickler_config()["fields"]["name"]
+        assert "aggregate" not in field_config
 
     def test_boolean_true_is_valid(self):
         """Test that boolean True is valid."""
@@ -303,8 +295,7 @@ class TestBooleanExtensionValidation:
             "properties": {
                 "name": {
                     "type": "string",
-                    "x-aws-stickler-clip-under-threshold": True,
-                    "x-aws-stickler-aggregate": True
+                    "x-aws-stickler-clip-under-threshold": True
                 }
             }
         }
@@ -320,8 +311,7 @@ class TestBooleanExtensionValidation:
             "properties": {
                 "name": {
                     "type": "string",
-                    "x-aws-stickler-clip-under-threshold": False,
-                    "x-aws-stickler-aggregate": False
+                    "x-aws-stickler-clip-under-threshold": False
                 }
             }
         }
@@ -632,7 +622,7 @@ class TestErrorMessageQuality:
             "properties": {
                 "name": {
                     "type": "string",
-                    "x-aws-stickler-aggregate": "yes"
+                    "x-aws-stickler-clip-under-threshold": "yes"
                 }
             }
         }

--- a/tests/structured_object_evaluator/test_json_schema_field_converter.py
+++ b/tests/structured_object_evaluator/test_json_schema_field_converter.py
@@ -171,7 +171,6 @@ class TestConvertPropertiesToFields:
                     "x-aws-stickler-threshold": 0.9,
                     "x-aws-stickler-weight": 2.0,
                     "x-aws-stickler-clip-under-threshold": False,
-                    "x-aws-stickler-aggregate": True,
                 },
                 "age": {
                     "type": "integer",
@@ -194,7 +193,6 @@ class TestConvertPropertiesToFields:
         assert name_field.json_schema_extra._threshold == 0.9
         assert name_field.json_schema_extra._weight == 2.0
         assert name_field.json_schema_extra._clip_under_threshold is False
-        assert name_field.json_schema_extra._aggregate is False  # aggregate param is deprecated; auto-aggregation is used
 
         # Check age field extensions
         age_field = field_definitions["age"][1]
@@ -609,7 +607,6 @@ class TestNestedObjectHandling:
                 "address": {
                     "type": "object",
                     "x-aws-stickler-weight": 2.0,
-                    "x-aws-stickler-aggregate": True,
                     "properties": {
                         "street": {"type": "string"},
                         "city": {"type": "string"},
@@ -627,7 +624,6 @@ class TestNestedObjectHandling:
         # Check extensions are applied to the field
         address_field = field_definitions["address"][1]
         assert address_field.json_schema_extra._weight == 2.0
-        assert address_field.json_schema_extra._aggregate is False  # aggregate param is deprecated; auto-aggregation is used
 
     def test_deeply_nested_objects(self):
         """Test deeply nested object structures."""
@@ -938,29 +934,6 @@ class TestErrorHandling:
         
         assert "x-aws-stickler-clip-under-threshold must be a boolean" in str(exc_info.value)
         assert "str" in str(exc_info.value)
-
-    def test_invalid_aggregate_type(self):
-        """Test error when aggregate is not boolean."""
-        schema = {
-            "type": "object",
-            "properties": {
-                "count": {
-                    "type": "integer",
-                    "x-aws-stickler-aggregate": 1,  # Invalid: not boolean
-                },
-            },
-            "required": [],
-        }
-
-        converter = JsonSchemaFieldConverter(schema)
-        
-        with pytest.raises(ValueError) as exc_info:
-            converter.convert_properties_to_fields(
-                schema["properties"], schema["required"]
-            )
-        
-        assert "x-aws-stickler-aggregate must be a boolean" in str(exc_info.value)
-        assert "int" in str(exc_info.value)
 
     def test_error_includes_field_path(self):
         """Test that errors include field path for context."""

--- a/tests/structured_object_evaluator/test_json_schema_integration.py
+++ b/tests/structured_object_evaluator/test_json_schema_integration.py
@@ -1001,35 +1001,6 @@ class TestComparisonBehaviorCustomExtensions:
         # Fuzzy field should have partial match
         assert 0.0 < result["field_scores"]["fuzzy_field"] < 1.0
 
-    def test_aggregate_extension_in_nested_structure(self):
-        """Test x-aws-stickler-aggregate in nested structures."""
-        schema = {
-            "type": "object",
-            "properties": {
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "x-aws-stickler-aggregate": True
-                            },
-                            "value": {"type": "number"}
-                        }
-                    }
-                }
-            }
-        }
-        
-        Model = StructuredModel.from_json_schema(schema)
-        
-        obj1 = Model(items=[{"name": "A", "value": 1}, {"name": "B", "value": 2}])
-        obj2 = Model(items=[{"name": "A", "value": 1}, {"name": "B", "value": 2}])
-        
-        result = obj1.compare_with(obj2)
-        assert result["overall_score"] == 1.0
-
     def test_clip_under_threshold_behavior(self):
         """Test x-aws-stickler-clip-under-threshold behavior."""
         schema = {
@@ -1080,8 +1051,7 @@ class TestComparisonBehaviorCustomExtensions:
                     "type": "number",
                     "x-aws-stickler-comparator": "NumericComparator",
                     "x-aws-stickler-weight": 1.0,
-                    "x-aws-stickler-threshold": 0.95,
-                    "x-aws-stickler-aggregate": True
+                    "x-aws-stickler-threshold": 0.95
                 }
             }
         }

--- a/tests/structured_object_evaluator/test_model_export.py
+++ b/tests/structured_object_evaluator/test_model_export.py
@@ -4,7 +4,6 @@ This module tests the to_json_schema() and to_stickler_config() methods
 that export StructuredModel configurations for serialization.
 """
 
-import warnings
 from typing import List, Optional
 
 from stickler.comparators.levenshtein import LevenshteinComparator
@@ -205,24 +204,14 @@ def test_to_stickler_config_primitive_list():
 
 
 def test_export_preserves_metadata():
-    """Test that all comparison metadata is preserved in export.
+    """Test that all comparison metadata is preserved in export."""
 
-    Still exercises the deprecated ``aggregate`` parameter on purpose: it is
-    part of the serialized export format, so the round trip has to keep working
-    until the field is removed in 1.0 (issue #226). The warning is expected
-    here and suppressed rather than silenced globally.
-    """
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-
-        class DetailedModel(StructuredModel):
-            field1: str = ComparableField(
-                threshold=0.75,
-                weight=1.5,
-                clip_under_threshold=False,
-                aggregate=True
-            )
+    class DetailedModel(StructuredModel):
+        field1: str = ComparableField(
+            threshold=0.75,
+            weight=1.5,
+            clip_under_threshold=False,
+        )
     
     # Test JSON Schema export
     schema = DetailedModel.to_json_schema()
@@ -230,7 +219,6 @@ def test_export_preserves_metadata():
     assert field_prop["x-aws-stickler-threshold"] == 0.75
     assert field_prop["x-aws-stickler-weight"] == 1.5
     assert field_prop["x-aws-stickler-clip-under-threshold"] is False
-    assert field_prop["x-aws-stickler-aggregate"] is True
     
     # Test Stickler config export
     config = DetailedModel.to_stickler_config()
@@ -238,57 +226,6 @@ def test_export_preserves_metadata():
     assert field_config["threshold"] == 0.75
     assert field_config["weight"] == 1.5
     assert field_config["clip_under_threshold"] is False
-    assert field_config["aggregate"] is True
-
-
-def test_round_trip_preserves_deprecated_aggregate():
-    """The *import* direction, which the export test above does not cover.
-
-    `to_stickler_config()` writes `aggregate`, so `model_from_json()` has to
-    read it back or export stops being idempotent: export -> import -> export
-    would differ on exactly this key. Reading a config is not an explicit use of
-    the deprecated parameter, so this must happen without a warning (issue
-    #226).
-    """
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-
-        class Aggregated(StructuredModel):
-            field1: str = ComparableField(threshold=0.75, aggregate=True)
-
-    first_export = Aggregated.to_stickler_config()
-
-    with warnings.catch_warnings(record=True) as recorded:
-        warnings.simplefilter("always")
-        rebuilt = StructuredModel.model_from_json(first_export)
-
-    deprecations = [w for w in recorded if w.category is DeprecationWarning]
-    assert deprecations == [], "reading a config is not an explicit use"
-
-    # The value survives the import, not just the export.
-    assert rebuilt._is_aggregate_field("field1") is True
-
-    # And the format is idempotent.
-    assert rebuilt.to_stickler_config() == first_export
-
-
-def test_round_trip_preserves_aggregate_false():
-    """The default value round-trips too, without warning."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-
-        class NotAggregated(StructuredModel):
-            field1: str = ComparableField(threshold=0.75, aggregate=False)
-
-    first_export = NotAggregated.to_stickler_config()
-
-    with warnings.catch_warnings(record=True) as recorded:
-        warnings.simplefilter("always")
-        rebuilt = StructuredModel.model_from_json(first_export)
-
-    assert [w for w in recorded if w.category is DeprecationWarning] == []
-    assert rebuilt._is_aggregate_field("field1") is False
-    assert rebuilt.to_stickler_config() == first_export
 
 
 class OptionalFieldModel(StructuredModel):

--- a/tests/structured_object_evaluator/test_universal_aggregate_field_comprehensive.py
+++ b/tests/structured_object_evaluator/test_universal_aggregate_field_comprehensive.py
@@ -11,7 +11,6 @@ This test suite validates that the new universal aggregate field feature works c
 5. Structure is consistent across all levels
 """
 
-import warnings
 from typing import List, Optional
 
 import pytest
@@ -158,33 +157,15 @@ class TestUniversalAggregateField:
         }
 
     @pytest.mark.parametrize("value", [True, False])
-    def test_deprecation_warning_for_legacy_aggregate_parameter(self, value):
-        """Passing 'aggregate' at all warns, whichever value is given.
+    def test_aggregate_parameter_raises_type_error(self, value):
+        """The removed 'aggregate' parameter is now a hard error (issue #226).
 
-        aggregate=False used to be silent, so those callers had no signal the
-        parameter is going away and would have met a bare TypeError on the
-        1.0 removal (issue #226). The value has no effect either way.
+        Aggregation moved to the comparison layer, so the per-field flag had no
+        effect and was deprecated; 1.0 removes it, so passing it at all must
+        raise rather than warn.
         """
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-
+        with pytest.raises(TypeError, match="aggregate"):
             ComparableField(aggregate=value)
-
-            assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
-            message = str(w[0].message)
-            assert "aggregate" in message
-            assert "deprecated" in message
-            assert "1.0" in message, "the warning should name the removal version"
-
-    def test_no_warning_when_aggregate_is_omitted(self):
-        """The common case stays quiet."""
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-
-            ComparableField(threshold=0.8)
-
-            assert [x for x in w if issubclass(x.category, DeprecationWarning)] == []
 
     def test_universal_aggregate_field_presence(self):
         """Test that aggregate fields are present at every level."""

--- a/tests/structured_object_evaluator/test_universal_aggregate_field_comprehensive.py
+++ b/tests/structured_object_evaluator/test_universal_aggregate_field_comprehensive.py
@@ -167,6 +167,17 @@ class TestUniversalAggregateField:
         with pytest.raises(TypeError, match="aggregate"):
             ComparableField(aggregate=value)
 
+    def test_removed_positional_slot_not_silently_reused(self):
+        """A five-positional call must raise, not silently rebind (issue #226 review).
+
+        `aggregate` used to be the fifth positional parameter, ahead of
+        `clip_under_threshold`. Removing it and making the remaining comparison
+        parameters keyword-only means an old five-positional call raises
+        `TypeError` instead of quietly flipping the clipping policy.
+        """
+        with pytest.raises(TypeError):
+            ComparableField(ExactComparator(), 0.9, 1.0, None, False)
+
     def test_universal_aggregate_field_presence(self):
         """Test that aggregate fields are present at every level."""
         gt = VeterinaryRecord(**self.gt_record)


### PR DESCRIPTION
## Issue Reference
Fixes #226

## Description of Changes
Removes the deprecated `aggregate=` parameter on `ComparableField` and its dead
code path. Aggregation moved to the comparison layer in #94 — every node in
`compare_with()` output already carries an `aggregate` block — so the flag had no
effect (output is byte-identical with it on or off).

### Changes Made
- Removed the `aggregate=` parameter, `_UNSET` sentinel, deprecation warning, and
  `_restore_deprecated_aggregate` from `ComparableField`.
- Removed the dead readers/plumbing: `_is_aggregate_field`,
  `ConfigurationHelper.is_aggregate_field`, the `aggregate` field on
  `ComparableFieldConfig`, `parent_is_aggregate` in the confusion-matrix
  calculator, and the export/import threading of `x-aws-stickler-aggregate`.
- `from_json_schema()` now ignores `x-aws-stickler-aggregate` so existing schema
  files still import.
- Updated/removed tests; added a `TypeError` test and an "ignored on import" test.
- Cleaned stale docs (README, MkDocs guides), fixed a broken example that called
  the removed parameter, and added a CHANGELOG `Removed` entry.

## Testing
- [x] `uv run pytest tests/` green (a pre-existing perf test flakes only under `-n auto`; passes in isolation)
- [x] `ruff check src/ tests/` clean
- [x] Manual: `aggregate=True` raises a clear `TypeError`; old schemas still import; automatic `aggregate` output unchanged; fixed demo runs

## Notes for reviewer
- The AC asks that `aggregate=True` raise `TypeError`, but simply removing the
  parameter doesn't achieve that — `**field_kwargs` swallows the arg and forwards
  it to Pydantic (a warning). I added an explicit guard. Happy to adjust.
- Rebased on latest `dev`; user-facing text says removal lands in **1.0** (per the
  0.8.0→1.0 milestone rename), consistent with the CHANGELOG corrections.
