### PR TITLE
docs(288): state which confusion-matrix rollup node answers which question

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -319,30 +319,8 @@ Each release links to full notes on the
 
   ```python
   clean = (
-      cm['aggregate']['fd'] + cm['aggregate']['fn'] == 0
-      and cm['overall']['fd'] + cm['overall']['fn'] + cm['overall']['fa'] == 0
-  )
-  ```
-
-  A below-threshold object is a spurious non-match, so not descending into it is
-  deliberate: `overall` carries the object verdict and `aggregate` carries leaf
-  detail for the objects that were comparable. A caller wanting leaf detail for a
-  marginal object lowers `match_threshold` until it qualifies. See
-  [#288](https://github.com/awslabs/stickler/issues/288) for the naming.
-
-
-  Replacements, all of which already existed: `overall_score` for the scalar
-  summary, `EvalResult.matched` for a single object-level verdict, and
-  `field_comparisons` for the individual failures. To ask whether anything failed
-  at all, both rollup nodes have to be read, because a list item that scores
-  below `match_threshold` is recorded as one `fd` on `confusion_matrix.overall`
-  and is not descended into, so its leaves never appear under
-  `confusion_matrix.aggregate`:
-
-  ```python
-  clean = (
-      cm['aggregate']['fd'] + cm['aggregate']['fn'] == 0
-      and cm['overall']['fd'] + cm['overall']['fn'] + cm['overall']['fa'] == 0
+      cm['aggregate']['fp'] + cm['aggregate']['fn'] == 0
+      and cm['overall']['fp'] + cm['overall']['fn'] == 0
   )
   ```
 
@@ -522,6 +500,28 @@ Each release links to full notes on the
   populated skips the annotation entirely (0.537s, within noise of the original).
   A test pins the superset property so adding a case to either rule without
   widening the guard fails loudly rather than silently skipping the check.
+
+### Documentation
+
+- Documented what the two confusion-matrix rollup nodes answer. `overall` gives
+  object verdicts (was this pairing genuine or spurious); `aggregate` gives leaf
+  detail for the objects that were comparable. `match_threshold` is the line
+  between them: an object below it is a single FD, a spurious non-match, and is
+  not descended into, so a caller wanting leaf detail for a marginal object
+  lowers `match_threshold` until the object qualifies as comparable.
+
+  Both nodes were previously described only mechanically ("this node's own direct
+  classification" / "sums all primitive-field classifications beneath"), which
+  said nothing about which to read for which question, or that they diverge on
+  any model with nesting. They coincide only where there is no accepted subtree
+  to expand: a flat model, or a subtree rejected outright.
+
+  Also documents that `EvalResult.precision`, `.recall`, `.f1` and `.accuracy`
+  are the object-level metrics, read from `confusion_matrix.overall.derived`, so
+  `precision` of `1.0` beside an `overall_score` of `0.9667` is two correct
+  answers to two different questions rather than a contradiction. The naming is
+  under review for 1.0 in
+  [#288](https://github.com/awslabs/stickler/issues/288).
 
 ## [0.7.0] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,27 +141,6 @@ Each release links to full notes on the
   `match_threshold=` explicitly still overrides the declaration, and a class that
   declares nothing is unaffected.
 
-- JSON Schema import now delegates standard types, local references, combiners,
-  and constraint parsing to `json-schema-to-pydantic`. Stickler retains a narrow
-  adapter for comparison metadata and nested `StructuredModel` creation. Parsed
-  types still choose comparison behavior, but schema constraints do not reject
-  imperfect predictions before scoring: malformed enum, date, and
-  constraint-violating values remain constructible and reach their comparator.
-
-  Unconfigured enum fields now use `ExactComparator` at threshold `1.0`, and
-  `date` / `date-time` formats use `DateComparator` at threshold `1.0`; both used
-  `LevenshteinComparator` at threshold `0.5` before this change, so default scores
-  can move for those fields.
-  This adds support for valid Draft 7 multi-type unions and multi-arm `allOf`,
-  `anyOf`, and `oneOf` schemas; recursive models and `patternProperties` remain
-  explicit unsupported boundaries ([#212](https://github.com/awslabs/stickler/issues/212)).
-
-- Confidence AUROC and document-splitting statistics now use NumPy
-  implementations with randomized scikit-learn and SciPy equivalence tests.
-  `scikit-learn` is no longer a core dependency, and the `docsplit` extra now
-  adds only pandas; SciPy remains isolated to the `semantic` extra
-  ([#216](https://github.com/awslabs/stickler/issues/216)).
-
 ### Fixed
 
 - **Breaking:** `HungarianMatcher.calculate_metrics` no longer reports a paired

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -312,10 +312,12 @@ Each release links to full notes on the
   Replacements, all of which already existed: `overall_score` for the scalar
   summary, `EvalResult.matched` for a single object-level verdict, and
   `field_comparisons` for the individual failures. To ask whether anything failed
-  at all, both rollup nodes have to be read, because a list item that scores
-  below `match_threshold` is recorded as one `fd` on `confusion_matrix.overall`
-  and is not descended into, so its leaves never appear under
-  `confusion_matrix.aggregate`:
+  at all, both rollup nodes have to be read, because each is blind to the other's
+  failures. A list item scoring below `match_threshold` is recorded as one `fd` on
+  `confusion_matrix.overall` and is not descended into, so its leaves never appear
+  under `confusion_matrix.aggregate`; conversely a value invented where the ground
+  truth is null is `fa` at that leaf and rolls into `confusion_matrix.aggregate`,
+  while `overall` stays clean because the item still paired:
 
   ```python
   clean = (
@@ -514,7 +516,16 @@ Each release links to full notes on the
   classification" / "sums all primitive-field classifications beneath"), which
   said nothing about which to read for which question, or that they diverge on
   any model with nesting. They coincide only where there is no accepted subtree
-  to expand: a flat model, or a subtree rejected outright.
+  to expand: a flat model, or a document in which *every* subtree was rejected.
+  One rejected subtree among several makes them diverge further, not converge,
+  because `aggregate` then reports a flawless precision over the accepted items
+  only.
+
+  Both pages carry the same two-stage framing as mean Average Precision, and now
+  also name where the analogy stops: a below-threshold bounding box counts as both
+  FP and FN so mAP recall falls, while a below-threshold object is `fd` only, so
+  `overall` recall reads `1.0` on a document with a spurious pairing unless
+  `recall_with_fd=True` is passed.
 
   Also documents that `EvalResult.precision`, `.recall`, `.f1` and `.accuracy`
   are the object-level metrics, read from `confusion_matrix.overall.derived`, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,11 +305,34 @@ Each release links to full notes on the
   )
   ```
 
-  A below-threshold object is a spurious non-match, so not descending into it is
-  deliberate: `overall` carries the object verdict and `aggregate` carries leaf
-  detail for the objects that were comparable. A caller wanting leaf detail for a
-  marginal object lowers `match_threshold` until it qualifies. See
-  [#288](https://github.com/awslabs/stickler/issues/288) for the naming.
+  A below-threshold **list item** is a spurious non-match, so not descending into it
+  is deliberate: `overall` carries the object verdict and `aggregate` carries leaf
+  detail for the items that were comparable. A caller wanting leaf detail for a
+  marginal list item lowers `match_threshold` until it qualifies.
+
+  That gating is a property of `List[StructuredModel]` pairing, not of nested
+  objects generally, and the pages now say so. `StructuredListComparator` pairs
+  items and then accepts or rejects; a single nested `StructuredModel` field goes
+  through `FieldComparator`, which has no such stage. So for a nested object field
+  the leaves are **always** reported on `aggregate`, and the verdict comes from the
+  field's own `threshold` -- `match_threshold` is never consulted, which made the
+  published "lower `match_threshold`" remedy a no-op for that shape. Measured on a
+  three-leaf nested object with one leaf wrong:
+
+  ```
+  field threshold=0.9   overall tp=1 fd=1   aggregate tp=3 fd=1
+  field threshold=0.5   overall tp=2 fd=0   aggregate tp=3 fd=1
+  match_threshold  0.9 / 0.7 / 0.5 / 0.1 -> identical at every value
+  ```
+
+  Also documented: on a document where **every** subtree was rejected, `aggregate`
+  stops counting leaves. `AggregateMetricsCalculator` falls back to summing
+  children's `overall` when the recursive leaf sum is all-zero, so the unit of the
+  count changes with the data -- two rejected items of six fields report
+  `aggregate tp=0 fd=2`, two object rows where twelve leaves exist. An `aggregate`
+  count is therefore not a safe denominator for a leaf total on such a document.
+
+  See [#288](https://github.com/awslabs/stickler/issues/288) for the naming.
 
 - An unrecognized `x-aws-stickler-*` extension key in a JSON Schema now raises
   instead of being silently dropped. The sharpest shape was a typo beside a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -526,20 +526,23 @@ Each release links to full notes on the
   is not gated this way; its leaves are always reported, and the field's own
   `threshold` decides its verdict.
 
-  Both nodes were previously described only mechanically ("this node's own direct
-  classification" / "sums all primitive-field classifications beneath"), which
-  said nothing about which to read for which question, or that they diverge on
-  any model with nesting. They coincide wherever the node being read has no
-  accepted subtree left to expand: a flat model, or one whose every nested subtree
-  was rejected. One rejected subtree among several usually makes them diverge
+  Both nodes were previously described only in terms of their own mechanics -- one
+  as a classification the node makes directly, the other as a sum of the primitive
+  fields beneath it -- which said nothing about which to read for which question,
+  or that they diverge on any model with nesting. They coincide whenever every
+  child contributes the same number of rows to each: a flat model, a list whose
+  items were all rejected, and also a nested object holding exactly one leaf, where
+  the object is one row and its leaf is one row. That last case is an accepted,
+  expanded subtree, so "they coincide only where there is nothing left to expand"
+  is not the rule. One rejected subtree among several usually makes them diverge
   further rather than converge, because `aggregate` then reports a flawless
   precision over the accepted items only.
 
   Coinciding is not evidence that nothing was hidden, and the pages say so. With
-  three header fields beside a list whose items were all rejected, the root reads
-  `overall tp=3 fd=2` and `aggregate tp=3 fd=2` -- equal, with an accepted subtree
-  present and 15 leaves in the document, because the list contributed object rows
-  to both.
+  three header fields beside a two-item list whose items were both rejected, the
+  root reads `overall tp=3 fd=2` and `aggregate tp=3 fd=2` -- equal, while 15
+  leaves exist in the document and `aggregate` counted 5 rows, because the list
+  contributed object rows to both.
 
   Older sections of the same pages were brought into line, since a page that
   disagrees with itself about this is the defect being fixed. `Calculation Logic`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -336,9 +336,21 @@ Each release links to full notes on the
   of six fields report `aggregate tp=0 fd=2`, two object rows where twelve leaves
   exist. It fires per node, so it can happen for one list while the document is
   plainly not all-rejected, and an `aggregate` count is therefore not a safe
-  denominator for a leaf total. The condition to test is
-  `'fields' in node and not node['fields']`, not `overall['tp'] == 0`, which is also
-  true of a primitive field that simply failed.
+  denominator for a leaf total.
+
+  The unit **cannot be derived from the confusion matrix**, which is why the
+  published snippet takes the answer from the model. A list of primitives with one
+  element wrong and an object list whose only item was rejected are identical in the
+  matrix -- both `fields == {}` with non-zero `aggregate` counts -- and yet the first
+  counts element comparisons, which are leaves. Two derived conditions were tried
+  and both were wrong, in opposite directions: `overall['tp'] == 0` is also true of a
+  primitive field that simply failed, and `'fields' in node and not node['fields']`
+  is also true of that primitive list and of a scalar null on both sides. The
+  documented form names the `List[StructuredModel]` fields explicitly:
+
+  ```python
+  counts_objects = section in OBJECT_LISTS and node['overall']['tp'] == 0
+  ```
 
   See [#288](https://github.com/awslabs/stickler/issues/288) for the naming.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -507,12 +507,16 @@ Each release links to full notes on the
 
 ### Documentation
 
-- Documented what the two confusion-matrix rollup nodes answer. `overall` gives
-  object verdicts (was this pairing genuine or spurious); `aggregate` gives leaf
-  detail for the objects that were comparable. `match_threshold` is the line
-  between them: an object below it is a single FD, a spurious non-match, and is
-  not descended into, so a caller wanting leaf detail for a marginal object
-  lowers `match_threshold` until the object qualifies as comparable.
+- Documented what the two confusion-matrix rollup nodes answer. `overall`
+  classifies a node's direct children, so on a list field it reads as a per-item
+  verdict (was this pairing genuine or spurious) while at the root it classifies
+  the root's own fields; `aggregate` gives leaf detail for the objects that were
+  comparable. `match_threshold` is the line between them for a **list item**: an
+  item below it is a single FD, a spurious non-match, and is not descended into,
+  so a caller wanting leaf detail for a marginal item lowers `match_threshold`
+  until the item qualifies as comparable. A single nested `StructuredModel` field
+  is not gated this way; its leaves are always reported, and the field's own
+  `threshold` decides its verdict.
 
   Both nodes were previously described only mechanically ("this node's own direct
   classification" / "sums all primitive-field classifications beneath"), which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -533,6 +533,19 @@ Each release links to full notes on the
   present and 15 leaves in the document, because the list contributed object rows
   to both.
 
+  Older sections of the same pages were brought into line, since a page that
+  disagrees with itself about this is the defect being fixed. `Calculation Logic`
+  and `Key Features` in `aggregate-metrics.md` stated the parent-node rule as an
+  unconditional sum of child `aggregate` values, which is the model the new
+  warning corrects, and `Field-Level Aggregate Metrics` in
+  `understanding-results.md` repeated it 350 lines below the corrected bullet --
+  with a worked snippet that ranked sections by `aggregate` error counts, mixing
+  leaf rows and object rows in one ranking. That snippet now reports which unit it
+  got. The "lower `match_threshold` to get a marginal object's leaves" remedy also
+  survived in `threshold-gated-evaluation.md` and in two headings, where
+  `test_match_threshold_is_inert_for_this_shape` pins it as a no-op; those now say
+  **list item**.
+
   Both pages carry the same two-stage framing as mean Average Precision, and now
   also name where the analogy stops: a below-threshold bounding box counts as both
   FP and FN so mAP recall falls, while a below-threshold object is `fd` only, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -517,11 +517,17 @@ Each release links to full notes on the
   Both nodes were previously described only mechanically ("this node's own direct
   classification" / "sums all primitive-field classifications beneath"), which
   said nothing about which to read for which question, or that they diverge on
-  any model with nesting. They coincide only where there is no accepted subtree
-  to expand: a flat model, or a document in which *every* subtree was rejected.
-  One rejected subtree among several makes them diverge further, not converge,
-  because `aggregate` then reports a flawless precision over the accepted items
-  only.
+  any model with nesting. They coincide wherever the node being read has no
+  accepted subtree left to expand: a flat model, or one whose every nested subtree
+  was rejected. One rejected subtree among several usually makes them diverge
+  further rather than converge, because `aggregate` then reports a flawless
+  precision over the accepted items only.
+
+  Coinciding is not evidence that nothing was hidden, and the pages say so. With
+  three header fields beside a list whose items were all rejected, the root reads
+  `overall tp=3 fd=2` and `aggregate tp=3 fd=2` -- equal, with an accepted subtree
+  present and 15 leaves in the document, because the list contributed object rows
+  to both.
 
   Both pages carry the same two-stage framing as mean Average Precision, and now
   also name where the analogy stops: a below-threshold bounding box counts as both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,9 +306,12 @@ Each release links to full notes on the
   ```
 
   A below-threshold **list item** is a spurious non-match, so not descending into it
-  is deliberate: `overall` carries the object verdict and `aggregate` carries leaf
-  detail for the items that were comparable. A caller wanting leaf detail for a
-  marginal list item lowers `match_threshold` until it qualifies.
+  is deliberate: on the list field, `overall` classifies the item pairings, and
+  `aggregate` carries leaf detail for the items that were comparable. Read that on
+  the list field rather than at the root, whose direct children are the root's own
+  fields, so a document with three header fields beside a five-item list reads
+  `tp = 8` -- 3 leaves plus 5 pairings, two units in one count. A caller wanting
+  leaf detail for a marginal list item lowers `match_threshold` until it qualifies.
 
   That gating is a property of `List[StructuredModel]` pairing, not of nested
   objects generally, and the pages now say so. `StructuredListComparator` pairs
@@ -325,12 +328,17 @@ Each release links to full notes on the
   match_threshold  0.9 / 0.7 / 0.5 / 0.1 -> identical at every value
   ```
 
-  Also documented: on a document where **every** subtree was rejected, `aggregate`
-  stops counting leaves. `AggregateMetricsCalculator` falls back to summing
-  children's `overall` when the recursive leaf sum is all-zero, so the unit of the
-  count changes with the data -- two rejected items of six fields report
-  `aggregate tp=0 fd=2`, two object rows where twelve leaves exist. An `aggregate`
-  count is therefore not a safe denominator for a leaf total on such a document.
+  Also documented: on a list whose items were **all** rejected, `aggregate` stops
+  counting leaves. A rejected item is not descended into, so such a node has no
+  child fields at all, and `AggregateMetricsCalculator` decides leaf versus parent on
+  exactly that -- so the node is treated as a leaf and its `aggregate` is a copy of
+  its own `overall`. The unit of the count changes with the data: two rejected items
+  of six fields report `aggregate tp=0 fd=2`, two object rows where twelve leaves
+  exist. It fires per node, so it can happen for one list while the document is
+  plainly not all-rejected, and an `aggregate` count is therefore not a safe
+  denominator for a leaf total. The condition to test is
+  `'fields' in node and not node['fields']`, not `overall['tp'] == 0`, which is also
+  true of a primitive field that simply failed.
 
   See [#288](https://github.com/awslabs/stickler/issues/288) for the naming.
 
@@ -552,11 +560,14 @@ Each release links to full notes on the
   `overall` recall reads `1.0` on a document with a spurious pairing unless
   `recall_with_fd=True` is passed.
 
-  Also documents that `EvalResult.precision`, `.recall`, `.f1` and `.accuracy`
-  are the object-level metrics, read from `confusion_matrix.overall.derived`, so
-  `precision` of `1.0` beside an `overall_score` of `0.9667` is two correct
-  answers to two different questions rather than a contradiction. The naming is
-  under review for 1.0 in
+  Also documents that `EvalResult.precision`, `.recall`, `.f1` and `.accuracy` are
+  read from `confusion_matrix.overall.derived` at the **root**, so they inherit the
+  root's unit and classify the root's direct children. That is an object rate only
+  where the list is the model's sole field; with header fields beside it the same
+  numbers are a rate over header leaves and item pairings mixed. On a list-only
+  five-item model, `precision` of `1.0` beside an `overall_score` of `0.9667` is two
+  correct answers to two different questions rather than a contradiction. The naming
+  is under review for 1.0 in
   [#288](https://github.com/awslabs/stickler/issues/288).
 
 ## [0.7.0] - 2026-08-18

--- a/docs/docs/Advanced/aggregate-metrics.md
+++ b/docs/docs/Advanced/aggregate-metrics.md
@@ -91,7 +91,9 @@ The two nodes are the two stages of the evaluation:
 
 `match_threshold` is the handoff, and it is really the definition of "the same object". Above it, the pair is the same thing, so grading its fields is meaningful. Below it, it is not the same thing, so grading its fields would be scoring the fields of a *different* object. Such an object is classified as a single false discovery and is not descended into.
 
-This is the same two-stage structure as mean Average Precision, which Stickler also implements for bounding boxes: an IoU threshold decides whether a detection matched, and only matched pairs are evaluated further. See [Bounding Box mAP Metrics](bbox-map-metrics.md#iou-thresholds), where a below-threshold detection is likewise a failure at the matching stage rather than a source of per-attribute errors. Nobody expects an unmatched detection to contribute attribute-level accuracy, and the reasoning here is identical.
+This is the same two-stage structure as mean Average Precision, which Stickler also implements for bounding boxes: an IoU threshold decides whether a detection matched, and only matched pairs are evaluated further. See [Bounding Box mAP Metrics](bbox-map-metrics.md#iou-thresholds), where a below-threshold detection is likewise a failure at the matching stage rather than a source of per-attribute errors. Nobody expects an unmatched detection to contribute attribute-level accuracy, and the reasoning for objects is the same.
+
+The two paths differ on recall, though. A below-threshold detection counts as both FP and FN, so mAP recall falls; a below-threshold object is an `fd` only, so `overall` recall still reads `1.0` on a document with a spurious pairing. Pass `recall_with_fd=True` to `compare_with()` for the mAP convention.
 
 Five line items of six fields each, one field of one item wrong. That item scores 5/6, clears a 0.7 threshold, and is comparable:
 
@@ -104,34 +106,51 @@ cm['aggregate']   tp=29  fd=1   P=0.9667  R=1.0000  F1=0.9831
 
 Five comparable objects and no spurious pairings, which is what `overall` measures. The wrong field is one of 30 leaves, which is what `aggregate` measures. Both numbers are correct for their own question.
 
-Drop the same item below the threshold (two fields wrong, so 4/6) and it becomes a rejected object:
+Drop the same item below the threshold (two fields wrong, so 4/6) and it becomes a rejected object. The nodes do not converge, they diverge further:
 
 ```
-cm['overall']     tp=0   fd=1
-cm['aggregate']   tp=0   fd=1
+overall_score   0.9333
+
+cm['overall']     tp=4   fd=1   P=0.8000  R=1.0000  F1=0.8889
+cm['aggregate']   tp=24  fd=0   P=1.0000  R=1.0000  F1=1.0000
 ```
 
-The two nodes now agree, because there is no accepted subtree to expand. They coincide in exactly two situations: a model with no nesting, and a subtree that was rejected outright.
+`aggregate` now reports a flawless `P=1.0000` precisely because the rejected item contributes no leaf rows: 24 leaves from the four accepted items, all correct. Reading `aggregate` alone here is the same trap as reading `overall` alone one level up.
+
+The two nodes coincide only where there is no accepted subtree to expand at all: a model with no nesting, or a document in which *every* subtree was rejected. Reject all five items and both nodes read `tp=0 fd=5`.
 
 #### Getting leaf detail for a marginal object
 
-`match_threshold` controls how much leaf detail you get. Lower it so the object qualifies as comparable, and its leaves are scored individually:
+`match_threshold` controls how much leaf detail you get. Lower it so the object qualifies as comparable, and its leaves are scored individually. Same five items, with the third still at 4/6:
 
 ```
 match_threshold   comparable?   overall            aggregate
-0.70              no            tp=0 fd=1          tp=0 fd=1
-0.66              yes           tp=1 fd=0          tp=4 fd=2
+0.70              no            tp=4 fd=1          tp=24 fd=0
+0.66              yes           tp=5 fd=0          tp=28 fd=2
 ```
+
+At `0.66` the marginal item's six leaves join the other 24, and the two wrong ones finally appear as `fd`.
 
 #### Asking whether anything failed
 
-Because the nodes scope different things, a complete check reads both. `overall` is also the only node carrying `fa`, since an invented field corresponds to no ground truth leaf:
+Because the nodes scope different things, a complete check reads both:
 
 ```python
 clean = (
-    cm['aggregate']['fd'] + cm['aggregate']['fn'] == 0
-    and cm['overall']['fd'] + cm['overall']['fn'] + cm['overall']['fa'] == 0
+    cm['aggregate']['fp'] + cm['aggregate']['fn'] == 0
+    and cm['overall']['fp'] + cm['overall']['fn'] == 0
 )
+```
+
+Sum `fp` rather than `fa + fd`. `FP = FA + FD` by construction, so the two are equivalent today, and reading `fp` cannot go stale if a class is ever added.
+
+Both nodes carry `fa`. A value invented where the ground truth is null is `fa` at that leaf and rolls into `aggregate`, leaving `overall` clean because the item still paired; an item invented wholesale is `fa` on `overall`. A check that names only one node reports clean on a hallucinated value:
+
+```
+one item, ground truth total=None, prediction total="INVENTED", five other leaves exact
+
+overall     tp=1  fp=0  fn=0  fa=0  fd=0
+aggregate   tp=5  fp=1  fn=0  fa=1  fd=0
 ```
 
 The `overall` name predates the aggregate rollup and reads as "the whole document" when it means "object verdicts at this level". Renaming is breaking, so it is under consideration for 1.0 in [#288](https://github.com/awslabs/stickler/issues/288).

--- a/docs/docs/Advanced/aggregate-metrics.md
+++ b/docs/docs/Advanced/aggregate-metrics.md
@@ -84,9 +84,14 @@ Note the difference between `overall` and `aggregate`:
 
 ### Which node answers which question
 
-`overall` reports **object verdicts**: were these two objects comparable, or was the pairing spurious. `aggregate` reports **leaf detail for the objects that were comparable**. `match_threshold` is the line between the two.
+The two nodes are the two stages of the evaluation:
 
-An object scoring below `match_threshold` is classified as a single false discovery and is not descended into. Its leaves are not enumerated, because reporting the parts of an object already rejected as a whole would be scoring something declared not comparable.
+- **`overall` is detection.** The unit is the object. Did we find the right things? Five line items paired, none spurious.
+- **`aggregate` is extraction.** The unit is the leaf. Among the objects established to be the same object, how many field values were correct? 29 of 30.
+
+`match_threshold` is the handoff, and it is really the definition of "the same object". Above it, the pair is the same thing, so grading its fields is meaningful. Below it, it is not the same thing, so grading its fields would be scoring the fields of a *different* object. Such an object is classified as a single false discovery and is not descended into.
+
+This is the same two-stage structure as mean Average Precision, which Stickler also implements for bounding boxes: an IoU threshold decides whether a detection matched, and only matched pairs are evaluated further. See [Bounding Box mAP Metrics](bbox-map-metrics.md#iou-thresholds), where a below-threshold detection is likewise a failure at the matching stage rather than a source of per-attribute errors. Nobody expects an unmatched detection to contribute attribute-level accuracy, and the reasoning here is identical.
 
 Five line items of six fields each, one field of one item wrong. That item scores 5/6, clears a 0.7 threshold, and is comparable:
 

--- a/docs/docs/Advanced/aggregate-metrics.md
+++ b/docs/docs/Advanced/aggregate-metrics.md
@@ -82,6 +82,55 @@ Note the difference between `overall` and `aggregate`:
 - **`overall`** reflects this node's own direct classification.
 - **`aggregate`** sums all primitive-field classifications beneath this node (including itself if it is a leaf).
 
+### Which node answers which question
+
+`overall` reports **object verdicts**: were these two objects comparable, or was the pairing spurious. `aggregate` reports **leaf detail for the objects that were comparable**. `match_threshold` is the line between the two.
+
+An object scoring below `match_threshold` is classified as a single false discovery and is not descended into. Its leaves are not enumerated, because reporting the parts of an object already rejected as a whole would be scoring something declared not comparable.
+
+Five line items of six fields each, one field of one item wrong. That item scores 5/6, clears a 0.7 threshold, and is comparable:
+
+```
+overall_score   0.9667
+
+cm['overall']     tp=5   fd=0   P=1.0000  R=1.0000  F1=1.0000
+cm['aggregate']   tp=29  fd=1   P=0.9667  R=1.0000  F1=0.9831
+```
+
+Five comparable objects and no spurious pairings, which is what `overall` measures. The wrong field is one of 30 leaves, which is what `aggregate` measures. Both numbers are correct for their own question.
+
+Drop the same item below the threshold (two fields wrong, so 4/6) and it becomes a rejected object:
+
+```
+cm['overall']     tp=0   fd=1
+cm['aggregate']   tp=0   fd=1
+```
+
+The two nodes now agree, because there is no accepted subtree to expand. They coincide in exactly two situations: a model with no nesting, and a subtree that was rejected outright.
+
+#### Getting leaf detail for a marginal object
+
+`match_threshold` controls how much leaf detail you get. Lower it so the object qualifies as comparable, and its leaves are scored individually:
+
+```
+match_threshold   comparable?   overall            aggregate
+0.70              no            tp=0 fd=1          tp=0 fd=1
+0.66              yes           tp=1 fd=0          tp=4 fd=2
+```
+
+#### Asking whether anything failed
+
+Because the nodes scope different things, a complete check reads both. `overall` is also the only node carrying `fa`, since an invented field corresponds to no ground truth leaf:
+
+```python
+clean = (
+    cm['aggregate']['fd'] + cm['aggregate']['fn'] == 0
+    and cm['overall']['fd'] + cm['overall']['fn'] + cm['overall']['fa'] == 0
+)
+```
+
+The `overall` name predates the aggregate rollup and reads as "the whole document" when it means "object verdicts at this level". Renaming is breaking, so it is under consideration for 1.0 in [#288](https://github.com/awslabs/stickler/issues/288).
+
 ## Calculation Logic
 
 1. **Leaf nodes** (primitive fields): `aggregate` equals `overall`.

--- a/docs/docs/Advanced/aggregate-metrics.md
+++ b/docs/docs/Advanced/aggregate-metrics.md
@@ -96,7 +96,7 @@ The gating applies to **`List[StructuredModel]` items only**. It is a property o
 - its leaves are **always** reported on `aggregate`, whether or not the object was rejected;
 - its `overall` verdict comes from the **field's own `threshold`**, not from `match_threshold`, which is never consulted for that shape.
 
-The worked output above is that case, and shows it: `contact` scores 0.5 and is `fd=1` on `overall`, and its leaves are still counted (`aggregate tp=1 fd=1`) and still roll into the root. If your schema is nested objects rather than lists of them, `aggregate` is showing you your failing leaves, not hiding them.
+The worked output above is that case, and shows it: one of `contact`'s two leaves is wrong, so its subtree mean is 0.5, which is below the field's `threshold=1.0` and reports `fd=1` on `overall` (with `clip_under_threshold` at its default, `field_scores['contact']` reads `0.0` rather than `0.5`). Its leaves are still counted (`aggregate tp=1 fd=1`) and still roll into the root. If your schema is nested objects rather than lists of them, `aggregate` is showing you your failing leaves, not hiding them.
 
 This is the same two-stage structure as mean Average Precision, which Stickler also implements for bounding boxes: an IoU threshold decides whether a detection matched, and only matched pairs are evaluated further. See [Bounding Box mAP Metrics](bbox-map-metrics.md#iou-calculation), where a below-threshold detection is likewise a failure at the matching stage rather than a source of per-attribute errors. Nobody expects an unmatched detection to contribute attribute-level accuracy, and the reasoning for objects is the same.
 
@@ -124,9 +124,16 @@ cm['aggregate']   tp=24  fd=0   P=1.0000  R=1.0000  F1=1.0000
 
 `aggregate` now reports a flawless `P=1.0000` precisely because the rejected item contributes no leaf rows: 24 leaves from the four accepted items, all correct. Reading `aggregate` alone here is the same trap as reading `overall` alone one level up.
 
-The two nodes coincide wherever the node being read has no accepted subtree left to expand: a model with no nesting, or one whose every nested subtree was rejected. Reject all five items and both nodes read `tp=0 fd=5`.
+The two nodes coincide whenever every child contributes the same number of rows to each: a model with no nesting, a list whose items were all rejected (reject all five and both read `tp=0 fd=5`), and also a nested object holding exactly one leaf, where the object is one row and its single leaf is one row. That last case is worth stating because it is an *accepted, expanded* subtree, so "they coincide only where there is nothing left to expand" is not the rule:
 
-Coinciding is not evidence that nothing was hidden. Put three header fields beside that list and reject every item, and the root reads `overall tp=3 fd=2` and `aggregate tp=3 fd=2` -- equal, with an accepted subtree present and 15 leaves in the document. They agree because the list contributed object rows to both, not because the leaf view confirmed the object view.
+```
+one nested object, one leaf, everything correct
+
+cm['overall']     tp=1        the object
+cm['aggregate']   tp=1        its one leaf
+```
+
+Coinciding is not evidence that nothing was hidden, which is the separate and more useful point. Put three header fields beside a **two-item** list and reject both items, and the root reads `overall tp=3 fd=2` and `aggregate tp=3 fd=2` -- equal, while 15 leaves exist in the document and `aggregate` counted 5 rows. They agree because the list contributed object rows to both, not because the leaf view confirmed the object view.
 {: #aggregate-counts-objects-for-an-all-rejected-list }
 
 !!! warning "When a list's items are all rejected, `aggregate` counts objects there, not leaves"
@@ -201,7 +208,7 @@ The `overall` name predates the aggregate rollup and reads as "the whole documen
 ## Calculation Logic
 
 1. **Leaf nodes**: `aggregate` equals `overall`. A node counts as a leaf when `fields` has no entries, which is every primitive field and also any structured node that was not descended into.
-2. **Parent nodes**: `aggregate` is the sum of the child `aggregate` values. Nothing sums a node's children's `overall`, so a list whose items were *all* rejected does not take this branch at all: with no children left it is a leaf by step 1, and reports one row per rejected item rather than one per leaf ([why](#aggregate-counts-objects-for-an-all-rejected-list)).
+2. **Parent nodes**: `aggregate` is the sum of the child `aggregate` values. A list whose items were *all* rejected does not reach this step: with no children left it is a leaf by step 1, and so reports one row per rejected item rather than one per leaf ([why](#aggregate-counts-objects-for-an-all-rejected-list)). `AggregateMetricsCalculator` also carries a guard that sums the children's `overall` when the summed child aggregates come out all-zero, but it cannot be what produces that behaviour, since a childless node never gets here; instrumented across this repo's suite it contributes to no result.
 3. **Derived metrics**: Precision, recall, F1, and accuracy are recomputed at each level from the summed counts. They inherit whichever unit produced those counts, so they are not a leaf rate on a node whose list items were all rejected.
 
 ## Hierarchical Reporting Example

--- a/docs/docs/Advanced/aggregate-metrics.md
+++ b/docs/docs/Advanced/aggregate-metrics.md
@@ -162,12 +162,39 @@ Coinciding is not evidence that nothing was hidden, which is the separate and mo
 
     Five rows where fifteen leaves exist. So checking whether the document was
     all-rejected does not protect you, and neither does reading the root `overall`,
-    which reports the same numbers. Before dividing an `aggregate` count by a leaf
-    total, ask each node whether it still has children:
-    `'fields' in node and not node['fields']` is exactly the condition under which
-    its `aggregate` stopped being a leaf count. Do not test the node's `overall` for
-    `tp == 0` instead: that is also true of a primitive field that simply failed,
-    which is one leaf and was never anything else.
+    which reports the same numbers.
+
+    **The unit cannot be derived from the confusion matrix.** Deciding it needs to
+    know which fields are `List[StructuredModel]`, and the matrix does not carry
+    that. A **list of primitives** with one element wrong is indistinguishable from
+    an object list whose only item was rejected:
+
+    ```
+    tags   List[str],   one of two elements wrong    fields={}   aggregate tp=1 fd=1
+    rows   List[Line],  its only item rejected       fields={}   aggregate tp=0 fd=1
+    ```
+
+    Same empty `fields`, same non-zero counts, different unit: the first is two
+    element comparisons, and an element of a primitive list **is** a leaf, while the
+    second is one row for one rejected object.
+
+    Two conditions were published here before this and both were wrong, in opposite
+    directions. `node['overall']['tp'] == 0` is also true of a primitive field that
+    simply failed, which is one leaf and was never anything else.
+    `'fields' in node and not node['fields']` is also true of the `tags` row above,
+    and of a scalar that was null on both sides.
+
+    So supply the answer from the model, and read `overall['tp'] == 0` as "every item
+    in this list was rejected":
+
+    ```python
+    OBJECT_LISTS = {'lines'}      # the List[StructuredModel] fields of your model
+
+    counts_objects = section in OBJECT_LISTS and node['overall']['tp'] == 0
+    ```
+
+    See [the ranking snippet](../Guides/Evaluation/understanding-results.md#field-level-aggregate-metrics)
+    for this in context.
 
 #### Getting leaf detail for a marginal list item
 

--- a/docs/docs/Advanced/aggregate-metrics.md
+++ b/docs/docs/Advanced/aggregate-metrics.md
@@ -9,7 +9,7 @@ Stickler automatically includes an `aggregate` field at every node in the confus
 ## Key Features
 
 - **Automatic** -- Every node gets an `aggregate` field, with no per-field configuration.
-- **Hierarchical** -- Parent nodes sum metrics from all child primitive fields.
+- **Hierarchical** -- Parent nodes sum metrics from all child primitive fields, except where a list's items were all rejected and the node reports object rows instead ([why](#aggregate-counts-objects-for-an-all-rejected-list)).
 - **Consistent** -- The same access pattern works at every level: `result['confusion_matrix']['aggregate']` or `result['confusion_matrix']['fields']['contact']['aggregate']`.
 - **Derived metrics included** -- Each aggregate contains precision, recall, F1, and accuracy.
 
@@ -195,8 +195,8 @@ The `overall` name predates the aggregate rollup and reads as "the whole documen
 ## Calculation Logic
 
 1. **Leaf nodes** (primitive fields): `aggregate` equals `overall`.
-2. **Parent nodes**: `aggregate` is the sum of all child `aggregate` values.
-3. **Derived metrics**: Precision, recall, F1, and accuracy are recomputed at each level from the summed counts.
+2. **Parent nodes**: `aggregate` is the sum of all child `aggregate` values, unless every one of them is zero, in which case the children's `overall` values are summed instead and the unit of the count becomes the object rather than the leaf ([why](#aggregate-counts-objects-for-an-all-rejected-list)).
+3. **Derived metrics**: Precision, recall, F1, and accuracy are recomputed at each level from the summed counts. They inherit whichever unit step 2 produced, so they are not a leaf rate on a node whose list items were all rejected.
 
 ## Hierarchical Reporting Example
 

--- a/docs/docs/Advanced/aggregate-metrics.md
+++ b/docs/docs/Advanced/aggregate-metrics.md
@@ -127,6 +127,7 @@ cm['aggregate']   tp=24  fd=0   P=1.0000  R=1.0000  F1=1.0000
 The two nodes coincide wherever the node being read has no accepted subtree left to expand: a model with no nesting, or one whose every nested subtree was rejected. Reject all five items and both nodes read `tp=0 fd=5`.
 
 Coinciding is not evidence that nothing was hidden. Put three header fields beside that list and reject every item, and the root reads `overall tp=3 fd=2` and `aggregate tp=3 fd=2` -- equal, with an accepted subtree present and 15 leaves in the document. They agree because the list contributed object rows to both, not because the leaf view confirmed the object view.
+{: #aggregate-counts-objects-for-an-all-rejected-list }
 
 !!! warning "When a list's items are all rejected, `aggregate` counts objects there, not leaves"
 
@@ -189,7 +190,7 @@ overall     tp=1  fp=0  fn=0  fa=0  fd=0
 aggregate   tp=5  fp=1  fn=0  fa=1  fd=0
 ```
 
-The `overall` name predates the aggregate rollup and reads as "the whole document" when it means "object verdicts at this level". Renaming is breaking, so it is under consideration for 1.0 in [#288](https://github.com/awslabs/stickler/issues/288).
+The `overall` name predates the aggregate rollup and reads as "the whole document" when it means "a classification of this node's direct children". Renaming is breaking, so it is under consideration for 1.0 in [#288](https://github.com/awslabs/stickler/issues/288).
 
 ## Calculation Logic
 

--- a/docs/docs/Advanced/aggregate-metrics.md
+++ b/docs/docs/Advanced/aggregate-metrics.md
@@ -89,9 +89,16 @@ The two nodes are the two stages of the evaluation:
 - **`overall` is detection.** The unit is the object. Did we find the right things? Five line items paired, none spurious.
 - **`aggregate` is extraction.** The unit is the leaf. Among the objects established to be the same object, how many field values were correct? 29 of 30.
 
-`match_threshold` is the handoff, and it is really the definition of "the same object". Above it, the pair is the same thing, so grading its fields is meaningful. Below it, it is not the same thing, so grading its fields would be scoring the fields of a *different* object. Such an object is classified as a single false discovery and is not descended into.
+`match_threshold` is the handoff, and it is really the definition of "the same object". Above it, the pair is the same thing, so grading its fields is meaningful. Below it, it is not the same thing, so grading its fields would be scoring the fields of a *different* object. Such an **item** is classified as a single false discovery and is not descended into.
 
-This is the same two-stage structure as mean Average Precision, which Stickler also implements for bounding boxes: an IoU threshold decides whether a detection matched, and only matched pairs are evaluated further. See [Bounding Box mAP Metrics](bbox-map-metrics.md#iou-thresholds), where a below-threshold detection is likewise a failure at the matching stage rather than a source of per-attribute errors. Nobody expects an unmatched detection to contribute attribute-level accuracy, and the reasoning for objects is the same.
+The gating applies to **`List[StructuredModel]` items only**. It is a property of `StructuredListComparator`, which pairs items and then decides which pairs are the same object. A single nested `StructuredModel` field goes through `FieldComparator`, which has no such stage, so:
+
+- its leaves are **always** reported on `aggregate`, whether or not the object was rejected;
+- its `overall` verdict comes from the **field's own `threshold`**, not from `match_threshold`, which is never consulted for that shape.
+
+The worked output above is that case, and shows it: `contact` scores 0.5 and is `fd=1` on `overall`, and its leaves are still counted (`aggregate tp=1 fd=1`) and still roll into the root. If your schema is nested objects rather than lists of them, `aggregate` is showing you your failing leaves, not hiding them.
+
+This is the same two-stage structure as mean Average Precision, which Stickler also implements for bounding boxes: an IoU threshold decides whether a detection matched, and only matched pairs are evaluated further. See [Bounding Box mAP Metrics](bbox-map-metrics.md#iou-calculation), where a below-threshold detection is likewise a failure at the matching stage rather than a source of per-attribute errors. Nobody expects an unmatched detection to contribute attribute-level accuracy, and the reasoning for objects is the same.
 
 The two paths differ on recall, though. A below-threshold detection counts as both FP and FN, so mAP recall falls; a below-threshold object is an `fd` only, so `overall` recall still reads `1.0` on a document with a spurious pairing. Pass `recall_with_fd=True` to `compare_with()` for the mAP convention.
 
@@ -119,9 +126,26 @@ cm['aggregate']   tp=24  fd=0   P=1.0000  R=1.0000  F1=1.0000
 
 The two nodes coincide only where there is no accepted subtree to expand at all: a model with no nesting, or a document in which *every* subtree was rejected. Reject all five items and both nodes read `tp=0 fd=5`.
 
-#### Getting leaf detail for a marginal object
+!!! warning "On an all-rejected document, `aggregate` counts objects, not leaves"
 
-`match_threshold` controls how much leaf detail you get. Lower it so the object qualifies as comparable, and its leaves are scored individually. Same five items, with the third still at 4/6:
+    That convergence is not the leaf view agreeing with the object view. When the
+    recursive leaf sum comes out all-zero, `aggregate` falls back to summing its
+    children's `overall`, so the **unit of the count changes with the data**:
+
+    ```
+    two items of six fields
+      1 of 2 rejected    aggregate tp=6 fd=0   P=1.0000    6 leaf rows
+      2 of 2 rejected    aggregate tp=0 fd=2   P=0.0000    2 OBJECT rows, though 12 leaves exist
+    ```
+
+    So `aggregate` counts are not a reliable denominator for a leaf total, and a
+    `derived` block from an all-rejected document is not leaf-level precision. Read
+    `overall` to know how many objects were rejected before dividing anything by an
+    `aggregate` count.
+
+#### Getting leaf detail for a marginal list item
+
+`match_threshold` controls how much leaf detail you get for a **list item**. It does nothing for a single nested `StructuredModel` field, whose leaves are always reported. Lower it so the object qualifies as comparable, and its leaves are scored individually. Same five items, with the third still at 4/6:
 
 ```
 match_threshold   comparable?   overall            aggregate

--- a/docs/docs/Advanced/aggregate-metrics.md
+++ b/docs/docs/Advanced/aggregate-metrics.md
@@ -86,7 +86,7 @@ Note the difference between `overall` and `aggregate`:
 
 The two nodes are the two stages of the evaluation:
 
-- **`overall` is detection.** The unit is the object. Did we find the right things? Five line items paired, none spurious.
+- **`overall` is detection.** The unit is whatever this node's direct children are. Did we find the right things? Read it on the list field: five line items paired, none spurious. Read it at the root and the children are the root's own fields, so three header fields beside that list give `tp = 8` -- 3 leaves plus 5 pairings, two units in one number.
 - **`aggregate` is extraction.** The unit is the leaf, except where noted in the warning below. Among the objects established to be the same object, how many field values were correct? 29 of 30.
 
 `match_threshold` is the handoff, and it is really the definition of "the same object". Above it, the pair is the same thing, so grading its fields is meaningful. Below it, it is not the same thing, so grading its fields would be scoring the fields of a *different* object. Such an **item** is classified as a single false discovery and is not descended into.
@@ -131,10 +131,13 @@ Coinciding is not evidence that nothing was hidden. Put three header fields besi
 
 !!! warning "When a list's items are all rejected, `aggregate` counts objects there, not leaves"
 
-    When a node's recursive leaf sum comes out all-zero, `aggregate` falls back to
-    summing its children's `overall`, so the **unit of the count changes with the
-    data**. It fires per node, and needs only that one list's items to be rejected
-    -- not the whole document:
+    A rejected item is not descended into, so a list whose items were *all* rejected
+    has **no child field nodes at all**. `AggregateMetricsCalculator` decides leaf
+    versus parent on exactly that -- whether `fields` has any entries -- so such a
+    node is treated as a leaf and its `aggregate` becomes a copy of its own
+    `overall`: one row per rejected item. The **unit of the count changes with the
+    data**. This is decided per node, and needs only that one list's items to be
+    rejected -- not the whole document:
 
     ```
     two items of six fields
@@ -153,8 +156,11 @@ Coinciding is not evidence that nothing was hidden. Put three header fields besi
     Five rows where fifteen leaves exist. So checking whether the document was
     all-rejected does not protect you, and neither does reading the root `overall`,
     which reports the same numbers. Before dividing an `aggregate` count by a leaf
-    total, check each list field's own `overall` for `tp == 0`: that is the condition
-    under which its `aggregate` stops being a leaf count.
+    total, ask each node whether it still has children:
+    `'fields' in node and not node['fields']` is exactly the condition under which
+    its `aggregate` stopped being a leaf count. Do not test the node's `overall` for
+    `tp == 0` instead: that is also true of a primitive field that simply failed,
+    which is one leaf and was never anything else.
 
 #### Getting leaf detail for a marginal list item
 
@@ -194,9 +200,9 @@ The `overall` name predates the aggregate rollup and reads as "the whole documen
 
 ## Calculation Logic
 
-1. **Leaf nodes** (primitive fields): `aggregate` equals `overall`.
-2. **Parent nodes**: `aggregate` is the sum of all child `aggregate` values, unless every one of them is zero, in which case the children's `overall` values are summed instead and the unit of the count becomes the object rather than the leaf ([why](#aggregate-counts-objects-for-an-all-rejected-list)).
-3. **Derived metrics**: Precision, recall, F1, and accuracy are recomputed at each level from the summed counts. They inherit whichever unit step 2 produced, so they are not a leaf rate on a node whose list items were all rejected.
+1. **Leaf nodes**: `aggregate` equals `overall`. A node counts as a leaf when `fields` has no entries, which is every primitive field and also any structured node that was not descended into.
+2. **Parent nodes**: `aggregate` is the sum of the child `aggregate` values. Nothing sums a node's children's `overall`, so a list whose items were *all* rejected does not take this branch at all: with no children left it is a leaf by step 1, and reports one row per rejected item rather than one per leaf ([why](#aggregate-counts-objects-for-an-all-rejected-list)).
+3. **Derived metrics**: Precision, recall, F1, and accuracy are recomputed at each level from the summed counts. They inherit whichever unit produced those counts, so they are not a leaf rate on a node whose list items were all rejected.
 
 ## Hierarchical Reporting Example
 

--- a/docs/docs/Advanced/aggregate-metrics.md
+++ b/docs/docs/Advanced/aggregate-metrics.md
@@ -79,7 +79,7 @@ print(cm['fields']['contact']['aggregate'])
 
 Note the difference between `overall` and `aggregate`:
 
-- **`overall`** reflects this node's own direct classification.
+- **`overall`** classifies this node's direct children. Where the field is a list, those children are item pairings; at the root they are the root's own fields, so the two units can mix in one count.
 - **`aggregate`** sums all primitive-field classifications beneath this node (including itself if it is a leaf).
 
 ### Which node answers which question
@@ -87,7 +87,7 @@ Note the difference between `overall` and `aggregate`:
 The two nodes are the two stages of the evaluation:
 
 - **`overall` is detection.** The unit is the object. Did we find the right things? Five line items paired, none spurious.
-- **`aggregate` is extraction.** The unit is the leaf. Among the objects established to be the same object, how many field values were correct? 29 of 30.
+- **`aggregate` is extraction.** The unit is the leaf, except where noted in the warning below. Among the objects established to be the same object, how many field values were correct? 29 of 30.
 
 `match_threshold` is the handoff, and it is really the definition of "the same object". Above it, the pair is the same thing, so grading its fields is meaningful. Below it, it is not the same thing, so grading its fields would be scoring the fields of a *different* object. Such an **item** is classified as a single false discovery and is not descended into.
 
@@ -124,13 +124,16 @@ cm['aggregate']   tp=24  fd=0   P=1.0000  R=1.0000  F1=1.0000
 
 `aggregate` now reports a flawless `P=1.0000` precisely because the rejected item contributes no leaf rows: 24 leaves from the four accepted items, all correct. Reading `aggregate` alone here is the same trap as reading `overall` alone one level up.
 
-The two nodes coincide only where there is no accepted subtree to expand at all: a model with no nesting, or a document in which *every* subtree was rejected. Reject all five items and both nodes read `tp=0 fd=5`.
+The two nodes coincide wherever the node being read has no accepted subtree left to expand: a model with no nesting, or one whose every nested subtree was rejected. Reject all five items and both nodes read `tp=0 fd=5`.
 
-!!! warning "On an all-rejected document, `aggregate` counts objects, not leaves"
+Coinciding is not evidence that nothing was hidden. Put three header fields beside that list and reject every item, and the root reads `overall tp=3 fd=2` and `aggregate tp=3 fd=2` -- equal, with an accepted subtree present and 15 leaves in the document. They agree because the list contributed object rows to both, not because the leaf view confirmed the object view.
 
-    That convergence is not the leaf view agreeing with the object view. When the
-    recursive leaf sum comes out all-zero, `aggregate` falls back to summing its
-    children's `overall`, so the **unit of the count changes with the data**:
+!!! warning "When a list's items are all rejected, `aggregate` counts objects there, not leaves"
+
+    When a node's recursive leaf sum comes out all-zero, `aggregate` falls back to
+    summing its children's `overall`, so the **unit of the count changes with the
+    data**. It fires per node, and needs only that one list's items to be rejected
+    -- not the whole document:
 
     ```
     two items of six fields
@@ -138,10 +141,19 @@ The two nodes coincide only where there is no accepted subtree to expand at all:
       2 of 2 rejected    aggregate tp=0 fd=2   P=0.0000    2 OBJECT rows, though 12 leaves exist
     ```
 
-    So `aggregate` counts are not a reliable denominator for a leaf total, and a
-    `derived` block from an all-rejected document is not leaf-level precision. Read
-    `overall` to know how many objects were rejected before dividing anything by an
-    `aggregate` count.
+    That propagates upward. With three correct header fields beside such a list, the
+    document is plainly **not** all-rejected, and the root still reads:
+
+    ```
+    root  overall    tp=3 fd=2
+    root  aggregate  tp=3 fd=2    derived.cm_precision = 0.6000
+    ```
+
+    Five rows where fifteen leaves exist. So checking whether the document was
+    all-rejected does not protect you, and neither does reading the root `overall`,
+    which reports the same numbers. Before dividing an `aggregate` count by a leaf
+    total, check each list field's own `overall` for `tp == 0`: that is the condition
+    under which its `aggregate` stops being a leaf count.
 
 #### Getting leaf detail for a marginal list item
 

--- a/docs/docs/Advanced/classification-logic.md
+++ b/docs/docs/Advanced/classification-logic.md
@@ -119,6 +119,8 @@ neither term. The mixed-matching example above scores recall `1.000` even though
 `0.667`. `HungarianMatcher.calculate_metrics` always uses that second formula.
 See [FD and recall](hungarian-matching.md#fd-and-recall).
 
+These are computed at every node of the result tree, from that node's own counts, and which counts those are depends on which node you read. `overall` gives object verdicts at that level: was the pairing genuine or spurious. `aggregate` gives leaf detail for the objects that were comparable, since an object below `match_threshold` is one FD and is not descended into. See [Which node answers which question](aggregate-metrics.md#which-node-answers-which-question).
+
 ## Edge Cases
 
 **Null vs. empty equivalence** -- Empty strings (`""`), empty lists (`[]`), and empty objects (`{}`) are treated as null. Comparing any of these with `null` yields TN.

--- a/docs/docs/Advanced/classification-logic.md
+++ b/docs/docs/Advanced/classification-logic.md
@@ -119,7 +119,7 @@ neither term. The mixed-matching example above scores recall `1.000` even though
 `0.667`. `HungarianMatcher.calculate_metrics` always uses that second formula.
 See [FD and recall](hungarian-matching.md#fd-and-recall).
 
-These are computed at every node of the result tree, from that node's own counts, and which counts those are depends on which node you read. `overall` gives object verdicts at that level: was the pairing genuine or spurious. `aggregate` gives leaf detail, and for a list of objects that means only the items that were comparable, since a list item below the element class's `match_threshold` is one FD and is not descended into. A single nested `StructuredModel` field is not gated this way: its leaves are always reported. See [Which node answers which question](aggregate-metrics.md#which-node-answers-which-question).
+These are computed at every node of the result tree, from that node's own counts, and which counts those are depends on which node you read. `overall` classifies that node's direct children: for a list field, whether each pairing was genuine or spurious; at the root, its own fields, which means the two units can mix in a single count. `aggregate` gives leaf detail, and for a list of objects that means only the items that were comparable, since a list item below the element class's `match_threshold` is one FD and is not descended into. A single nested `StructuredModel` field is not gated this way: its leaves are always reported. See [Which node answers which question](aggregate-metrics.md#which-node-answers-which-question).
 
 ## Edge Cases
 

--- a/docs/docs/Advanced/classification-logic.md
+++ b/docs/docs/Advanced/classification-logic.md
@@ -119,7 +119,7 @@ neither term. The mixed-matching example above scores recall `1.000` even though
 `0.667`. `HungarianMatcher.calculate_metrics` always uses that second formula.
 See [FD and recall](hungarian-matching.md#fd-and-recall).
 
-These are computed at every node of the result tree, from that node's own counts, and which counts those are depends on which node you read. `overall` gives object verdicts at that level: was the pairing genuine or spurious. `aggregate` gives leaf detail for the objects that were comparable, since an object below `match_threshold` is one FD and is not descended into. See [Which node answers which question](aggregate-metrics.md#which-node-answers-which-question).
+These are computed at every node of the result tree, from that node's own counts, and which counts those are depends on which node you read. `overall` gives object verdicts at that level: was the pairing genuine or spurious. `aggregate` gives leaf detail, and for a list of objects that means only the items that were comparable, since a list item below the element class's `match_threshold` is one FD and is not descended into. A single nested `StructuredModel` field is not gated this way: its leaves are always reported. See [Which node answers which question](aggregate-metrics.md#which-node-answers-which-question).
 
 ## Edge Cases
 

--- a/docs/docs/Advanced/threshold-gated-evaluation.md
+++ b/docs/docs/Advanced/threshold-gated-evaluation.md
@@ -180,10 +180,15 @@ whole would score something the comparison declared not comparable.
 
 ```python
 clean = (
-    cm['aggregate']['fd'] + cm['aggregate']['fn'] == 0
-    and cm['overall']['fd'] + cm['overall']['fn'] + cm['overall']['fa'] == 0
+    cm['aggregate']['fp'] + cm['aggregate']['fn'] == 0
+    and cm['overall']['fp'] + cm['overall']['fn'] == 0
 )
 ```
+
+Read `fp`, not `fa + fd`. The two are equal by construction, and `fp` also catches
+the mirror-image case: a value invented where the ground truth is null is `fa` at
+that leaf and rolls into `aggregate`, while `overall` stays clean because the item
+still paired.
 
 So `match_threshold` is also the knob for how much leaf detail you get. If you
 want a marginal object's leaves scored individually, lower it until that object

--- a/docs/docs/Advanced/threshold-gated-evaluation.md
+++ b/docs/docs/Advanced/threshold-gated-evaluation.md
@@ -185,10 +185,14 @@ clean = (
 )
 ```
 
-Read `fp`, not `fa + fd`. The two are equal by construction, and `fp` also catches
-the mirror-image case: a value invented where the ground truth is null is `fa` at
-that leaf and rolls into `aggregate`, while `overall` stays clean because the item
-still paired.
+Read **both nodes**. That is the fix: the earlier version of this snippet summed
+`fd` on `aggregate` but took `fa` from `overall` only, so a value invented where the
+ground truth is null went unseen. Such a value is `fa` at that leaf and rolls into
+`aggregate`, while `overall` stays clean because the item still paired.
+
+`fa + fd` on a node would work just as well, since `FP = FA + FD` by construction.
+`fp` is preferred only because it is one term instead of two and cannot go stale if a
+class is ever added -- not because the classes are unsafe to read.
 
 So `match_threshold` is also the knob for how much leaf detail you get. If you
 want a marginal object's leaves scored individually, lower it until that object

--- a/docs/docs/Advanced/threshold-gated-evaluation.md
+++ b/docs/docs/Advanced/threshold-gated-evaluation.md
@@ -194,9 +194,11 @@ ground truth is null went unseen. Such a value is `fa` at that leaf and rolls in
 `fp` is preferred only because it is one term instead of two and cannot go stale if a
 class is ever added -- not because the classes are unsafe to read.
 
-So `match_threshold` is also the knob for how much leaf detail you get. If you
-want a marginal object's leaves scored individually, lower it until that object
-qualifies as comparable. See
+So `match_threshold` is also the knob for how much leaf detail you get, for a
+**list item**. If you want a marginal item's leaves scored individually, lower it
+until that item qualifies as comparable. It does nothing for a single nested
+`StructuredModel` field, which is never gated and always reports its leaves; the
+field's own `threshold` decides that verdict. See
 [Aggregate Metrics](aggregate-metrics.md#which-node-answers-which-question).
 
 `overall_score` is the scalar summary, and `EvalResult.matched` from

--- a/docs/docs/Guides/Evaluation/understanding-results.md
+++ b/docs/docs/Guides/Evaluation/understanding-results.md
@@ -105,12 +105,14 @@ The `confusion_matrix` object has four keys:
 
 ### `overall` vs `aggregate`
 
-The two nodes answer two different questions, and you generally want both:
+The two nodes are the two stages of the evaluation, and you generally want both:
 
-- **`overall`**: were these objects comparable at all? For a list of 5 line items that each paired above `match_threshold`, `tp = 5`.
-- **`aggregate`**: among the objects that *were* comparable, how many individual leaves landed? For those same 5 items with 6 fields each, `tp` counts up to 30.
+- **`overall` is detection.** The unit is the object. Did we find the right things? For a list of 5 line items that each paired above `match_threshold`, `tp = 5`.
+- **`aggregate` is extraction.** The unit is the leaf. Among the objects established to be the same object, how many field values were correct? For those same 5 items with 6 fields each, `tp` counts up to 30.
 
-`match_threshold` is the line between them. An object scoring below it is classified as a single **false discovery**: a spurious non-match, counted once at the item level and not descended into. Leaf detail is not reported for it, because enumerating the parts of an object you have already rejected as a whole would be counting a thing you declared not comparable.
+`match_threshold` is the handoff, and it is really the definition of "the same object". Above it, the pair is the same thing, so grading its fields is meaningful. Below it, it is not the same thing, so grading its fields would be scoring the fields of a *different* object. Such an object is classified as a single **false discovery** and is not descended into.
+
+If that split is familiar, it should be: it is the structure of mean Average Precision, which Stickler also implements for bounding boxes. An IoU threshold decides whether a detection matched, and only matched pairs are scored further. See [Bounding Box mAP Metrics](../../Advanced/bbox-map-metrics.md#iou-thresholds).
 
 Two examples make the split concrete.
 

--- a/docs/docs/Guides/Evaluation/understanding-results.md
+++ b/docs/docs/Guides/Evaluation/understanding-results.md
@@ -98,26 +98,88 @@ The distinction between FA and FD is important for debugging:
 
 The `confusion_matrix` object has four keys:
 
-- **`overall`** -- Object-level metrics for the current hierarchical level.
+- **`overall`** -- Object-level metrics for the current hierarchical level. Counts item pairings, not leaves.
 - **`fields`** -- Field-by-field breakdown, with nested structure for objects and lists.
 - **`non_matches`** -- Populated when `document_non_matches=True` (empty otherwise).
-- **`aggregate`** -- Sum of all primitive field metrics recursively below this node.
+- **`aggregate`** -- Primitive field metrics summed recursively below this node, for the subtrees the traversal reached. See the caveat below.
 
 ### `overall` vs `aggregate`
 
-These serve different purposes:
+The two nodes answer two different questions, and you generally want both:
 
-- **`overall`**: Counts at the current level only. For a list of 2 line items that both matched, `tp = 2`.
-- **`aggregate`**: Sums all primitive fields recursively below. For 2 line items with 3 fields each, all matching: `tp = 6`.
+- **`overall`**: were these objects comparable at all? For a list of 5 line items that each paired above `match_threshold`, `tp = 5`.
+- **`aggregate`**: among the objects that *were* comparable, how many individual leaves landed? For those same 5 items with 6 fields each, `tp` counts up to 30.
 
-The `aggregate` field exists at every node in the confusion matrix hierarchy, making it easy to get field-level granularity at any depth.
+`match_threshold` is the line between them. An object scoring below it is classified as a single **false discovery**: a spurious non-match, counted once at the item level and not descended into. Leaf detail is not reported for it, because enumerating the parts of an object you have already rejected as a whole would be counting a thing you declared not comparable.
+
+Two examples make the split concrete.
+
+**A wrong leaf inside a comparable object.** Five line items of six fields each, one field of one item wrong. That item scores 5/6, clears the 0.7 threshold, and is comparable:
+
+```
+overall_score   0.9667
+
+cm['overall']     tp=5   fd=0   P=1.0000  R=1.0000  F1=1.0000
+cm['aggregate']   tp=29  fd=1   P=0.9667  R=1.0000  F1=0.9831
+```
+
+`overall` reports five comparable objects and no spurious matches, which is exactly what it measures. The wrong field is one of 30 leaves, and `aggregate` is where you see it.
+
+**An object that was not comparable.** Two items of six fields, two fields of one item wrong. That item scores 4/6, below the threshold:
+
+```
+cm['overall']     tp=1   fd=1
+cm['aggregate']   tp=6   fd=0
+```
+
+`overall` records the spurious non-match. `aggregate` reports the six leaves of the one comparable object, and none of them failed. The rejected object contributes no leaf rows.
+
+#### Getting leaf detail for a marginal object
+
+If you want those leaves counted, lower `match_threshold` so the object qualifies as comparable. Same data as above:
+
+```
+match_threshold   comparable?   overall            aggregate
+0.70              no            tp=0 fd=1          tp=0 fd=1
+0.66              yes           tp=1 fd=0          tp=4 fd=2
+```
+
+At `0.66` the object is comparable, so its six leaves are scored individually and the two bad ones appear as `fd`. This is the knob for how much leaf detail you get: `match_threshold` decides what counts as the same object, and leaf reporting follows from that.
+
+#### Which node answers which question
+
+| Question | Node |
+|---|---|
+| Were the objects comparable, and how many were spurious? | `overall` |
+| Among comparable objects, which leaves landed? | `aggregate` |
+| How many list items did the model find? | `overall` |
+| Did anything at all fail? | both, see below |
+
+Because the two nodes scope different things, a complete "did anything fail" check reads both:
 
 ```python
-# Total primitive field metrics across the entire comparison
+clean = (
+    cm['aggregate']['fd'] + cm['aggregate']['fn'] == 0
+    and cm['overall']['fd'] + cm['overall']['fn'] + cm['overall']['fa'] == 0
+)
+```
+
+`overall` is the only node carrying `fa`, the fields the prediction invented, since those correspond to no ground truth leaf.
+
+!!! note "`EvalResult.precision` is the object-level metric"
+
+    `EvalResult.precision`, `.recall`, `.f1` and `.accuracy` from `stickler.evaluate()` come from `cm['overall']['derived']`, so they answer "how many objects were comparable rather than spurious". On the first example above `result.precision` is `1.0` while `result.overall_score` is `0.9667`: the five items were all comparable, and the score is a weighted mean over the leaves. Both numbers are right for what they measure. For leaf-level precision, read `result.confusion_matrix['aggregate']['derived']`.
+
+    That two similar-looking numbers on one object mean different things is tracked in [#288](https://github.com/awslabs/stickler/issues/288), where the naming is under review for 1.0.
+
+`aggregate` exists at every node, so the same access pattern gives field-level granularity at any depth:
+
+```python
+# Leaf-level counts across the entire comparison
 total = cm['aggregate']
 print(f"Total TP: {total['tp']}, Total FP: {total['fp']}")
 
-# Metrics for a specific section
+# The same question, scoped to one section
 contact = cm['fields']['contact']['aggregate']
 print(f"Contact section F1: {contact['derived']['cm_f1']:.3f}")
 ```

--- a/docs/docs/Guides/Evaluation/understanding-results.md
+++ b/docs/docs/Guides/Evaluation/understanding-results.md
@@ -51,12 +51,12 @@ To ask whether anything at all went wrong, read **both** rollup nodes, because t
 ```python
 cm = result['confusion_matrix']
 clean = (
-    cm['aggregate']['fd'] + cm['aggregate']['fn'] == 0
-    and cm['overall']['fd'] + cm['overall']['fn'] + cm['overall']['fa'] == 0
+    cm['aggregate']['fp'] + cm['aggregate']['fn'] == 0
+    and cm['overall']['fp'] + cm['overall']['fn'] == 0
 )
 ```
 
-`aggregate` gives leaf detail for the objects that were comparable: `fd` is a leaf that scored below its threshold, `fn` a leaf absent from the prediction. `overall` gives the object verdicts, and it is the only node carrying `fa`, the fields the prediction invented, since those correspond to no ground truth leaf.
+`aggregate` gives leaf detail for the objects that were comparable: `fp` covers a leaf that scored below its threshold and a value invented where the ground truth was null, `fn` a leaf absent from the prediction. `overall` gives the object verdicts. Sum `fp` rather than `fa + fd`, since `FP = FA + FD` by construction and `fp` cannot go stale if a class is ever added.
 
 The second half of that check is what catches an object rejected outright. An object scoring below `match_threshold` is a spurious non-match, counted once as `fd` on `overall` and not descended into, so it contributes no leaf rows. If you want leaf detail for a marginal object, lower `match_threshold` until it qualifies as comparable. `field_comparisons` names the individual failures.
 
@@ -98,10 +98,10 @@ The distinction between FA and FD is important for debugging:
 
 The `confusion_matrix` object has four keys:
 
-- **`overall`** -- Object-level metrics for the current hierarchical level. Counts item pairings, not leaves.
+- **`overall`** -- Metrics for this node's direct children. Where the field is a list, those children are item pairings rather than leaves.
 - **`fields`** -- Field-by-field breakdown, with nested structure for objects and lists.
 - **`non_matches`** -- Populated when `document_non_matches=True` (empty otherwise).
-- **`aggregate`** -- Primitive field metrics summed recursively below this node, for the subtrees the traversal reached. See the caveat below.
+- **`aggregate`** -- Primitive field metrics summed recursively below this node, excluding subtrees rejected at `match_threshold`. See [`overall` vs `aggregate`](#overall-vs-aggregate).
 
 ### `overall` vs `aggregate`
 
@@ -113,6 +113,15 @@ The two nodes are the two stages of the evaluation, and you generally want both:
 `match_threshold` is the handoff, and it is really the definition of "the same object". Above it, the pair is the same thing, so grading its fields is meaningful. Below it, it is not the same thing, so grading its fields would be scoring the fields of a *different* object. Such an object is classified as a single **false discovery** and is not descended into.
 
 If that split is familiar, it should be: it is the structure of mean Average Precision, which Stickler also implements for bounding boxes. An IoU threshold decides whether a detection matched, and only matched pairs are scored further. See [Bounding Box mAP Metrics](../../Advanced/bbox-map-metrics.md#iou-thresholds).
+
+The analogy stops at recall. A below-threshold *detection* counts as both a false positive and a false negative, so recall falls. A below-threshold *object* is an `fd` only, so the unmatched ground-truth item leaves no trace and `overall` recall still reads `1.0`. Pass `recall_with_fd=True` to `compare_with()` for the mAP convention:
+
+```
+five items, one rejected
+
+recall_with_fd=False   overall tp=4 fd=1 fn=0   R=1.0000
+recall_with_fd=True    overall tp=4 fd=1 fn=0   R=0.8000
+```
 
 Two examples make the split concrete.
 
@@ -138,15 +147,15 @@ cm['aggregate']   tp=6   fd=0
 
 #### Getting leaf detail for a marginal object
 
-If you want those leaves counted, lower `match_threshold` so the object qualifies as comparable. Same data as above:
+If you want those leaves counted, lower `match_threshold` so the object qualifies as comparable. Same two items as above, with the second still at 4/6:
 
 ```
 match_threshold   comparable?   overall            aggregate
-0.70              no            tp=0 fd=1          tp=0 fd=1
-0.66              yes           tp=1 fd=0          tp=4 fd=2
+0.70              no            tp=1 fd=1          tp=6  fd=0
+0.66              yes           tp=2 fd=0          tp=10 fd=2
 ```
 
-At `0.66` the object is comparable, so its six leaves are scored individually and the two bad ones appear as `fd`. This is the knob for how much leaf detail you get: `match_threshold` decides what counts as the same object, and leaf reporting follows from that.
+At `0.66` the marginal item is comparable, so its six leaves join the first item's in `aggregate`: 12 leaves, of which the two wrong ones appear as `fd`. This is the knob for how much leaf detail you get: `match_threshold` decides what counts as the same object, and leaf reporting follows from that.
 
 #### Which node answers which question
 
@@ -161,12 +170,21 @@ Because the two nodes scope different things, a complete "did anything fail" che
 
 ```python
 clean = (
-    cm['aggregate']['fd'] + cm['aggregate']['fn'] == 0
-    and cm['overall']['fd'] + cm['overall']['fn'] + cm['overall']['fa'] == 0
+    cm['aggregate']['fp'] + cm['aggregate']['fn'] == 0
+    and cm['overall']['fp'] + cm['overall']['fn'] == 0
 )
 ```
 
-`overall` is the only node carrying `fa`, the fields the prediction invented, since those correspond to no ground truth leaf.
+Sum `fp` rather than `fa + fd`. `FP = FA + FD` by construction, so the two are equivalent today, and reading `fp` cannot go stale if a class is ever added.
+
+Both nodes carry `fa`, for different kinds of invention. A field invented where the ground truth has no value at all is `fa` at that leaf and rolls up into `aggregate`, while `overall` stays clean because the item still paired. An item invented wholesale is `fa` on `overall`. Naming only one node here is how a hallucinated value slips through:
+
+```
+one item, ground truth total=None, prediction total="INVENTED", five other leaves exact
+
+overall     tp=1  fp=0  fn=0  fa=0  fd=0
+aggregate   tp=5  fp=1  fn=0  fa=1  fd=0
+```
 
 !!! note "`EvalResult.precision` is the object-level metric"
 

--- a/docs/docs/Guides/Evaluation/understanding-results.md
+++ b/docs/docs/Guides/Evaluation/understanding-results.md
@@ -471,11 +471,24 @@ This displays processing statistics (document count, throughput), overall confus
 
 Every node in the confusion matrix automatically includes an `aggregate` field that sums all primitive field metrics recursively below that node. This gives you hierarchical analysis without any configuration.
 
-One caveat before you rank anything by these counts: where a list's items were *all* rejected, that node's `aggregate` reports one row per rejected object rather than its leaves, so counts from such a node are not comparable with leaf counts from another ([why](../../Advanced/aggregate-metrics.md#aggregate-counts-objects-for-an-all-rejected-list)). The check is `'fields' in node and not node['fields']` -- a structured node with nothing left below it to descend into. A primitive field has no `fields` key at all, so it is not caught, however badly it failed.
+One caveat before you rank anything by these counts: where a list's items were *all* rejected, that node's `aggregate` reports one row per rejected object rather than its leaves, so counts from such a node are not comparable with leaf counts from another ([why](../../Advanced/aggregate-metrics.md#aggregate-counts-objects-for-an-all-rejected-list)).
+
+**The unit cannot be derived from the confusion matrix.** You have to tell the snippet which fields are `List[StructuredModel]`, because the matrix does not carry that. A list of primitives with one element wrong and a list of objects whose only item was rejected are *identical* in shape -- both have `fields == {}` with non-zero `aggregate` counts -- and yet the first counts element comparisons, which are leaves, and the second counts one row per rejected object:
+
+```
+tags   List[str],   one of two elements wrong    fields={}   aggregate tp=1 fd=1   leaves
+rows   List[Line],  its only item rejected       fields={}   aggregate tp=0 fd=1   object rows
+```
+
+Two earlier versions of this snippet tried to derive it and were wrong in opposite directions. `data['overall']['tp'] == 0` is also true of a primitive field that simply failed, which is one leaf and nothing else. `'fields' in data and not data['fields']` is also true of the primitive list above, and of a scalar that was null on both sides. So the schema has to supply the answer, and `overall['tp'] == 0` then means every item in that list was rejected.
 
 ```python
 result = ground_truth.compare_with(prediction, include_confusion_matrix=True)
 cm = result['confusion_matrix']
+
+# The List[StructuredModel] fields of your model. Only you know these; the
+# confusion matrix cannot tell them from a list of primitives.
+OBJECT_LISTS = {'lines'}
 
 # Top-level aggregate: all primitive fields in the entire document
 print(f"Total F1: {cm['aggregate']['derived']['cm_f1']:.3f}")
@@ -485,13 +498,11 @@ for section, data in cm['fields'].items():
     if 'aggregate' in data:
         f1 = data['aggregate']['derived']['cm_f1']
         errors = data['aggregate']['fp'] + data['aggregate']['fn']
-        # A structured node with an empty 'fields' reports its own rows here, not
-        # leaves: a list whose items were ALL rejected, or one that was null on
-        # both sides. Say so rather than ranking it against leaf counts. Do not
-        # test `data['overall']['tp'] == 0` instead -- that is also true of a
-        # primitive field that simply failed, which is one leaf and nothing else.
-        childless = 'fields' in data and not data['fields']
-        unit = 'object rows' if childless else 'leaves'
+        # An object list whose items were ALL rejected reports its own rows here
+        # rather than leaves, so say which unit the numbers are in instead of
+        # ranking the two against each other.
+        counts_objects = section in OBJECT_LISTS and data['overall']['tp'] == 0
+        unit = 'object rows' if counts_objects else 'leaves'
         print(f"  {section}: F1={f1:.3f}, Errors={errors} ({unit})")
 ```
 

--- a/docs/docs/Guides/Evaluation/understanding-results.md
+++ b/docs/docs/Guides/Evaluation/understanding-results.md
@@ -56,11 +56,11 @@ clean = (
 )
 ```
 
-`aggregate` gives leaf detail for the objects that were comparable: `fp` covers a leaf that scored below its threshold and a value invented where the ground truth was null, `fn` a leaf absent from the prediction. `overall` gives the object verdicts. Sum `fp` rather than `fa + fd`, since `FP = FA + FD` by construction and `fp` cannot go stale if a class is ever added.
+`aggregate` gives leaf detail for the objects that were comparable: `fp` covers a leaf that scored below its threshold and a value invented where the ground truth was null, `fn` a leaf absent from the prediction. `overall` classifies the node's direct children, so on a list field it gives the per-item verdicts. Sum `fp` rather than `fa + fd`, since `FP = FA + FD` by construction and `fp` cannot go stale if a class is ever added.
 
 The second half of that check is what catches an object rejected outright. A **list item** scoring below the element class's `match_threshold` is a spurious non-match, counted once as `fd` on `overall` and not descended into, so it contributes no leaf rows. If you want leaf detail for a marginal list item, lower `match_threshold` until it qualifies as comparable. `field_comparisons` names the individual failures.
 
-A single nested `StructuredModel` field behaves differently and is worth knowing separately: it is never gated, so its leaves appear on `aggregate` even when the object itself is a false discovery, and `match_threshold` is not the knob — the field's own `threshold` is.
+A single nested `StructuredModel` field behaves differently and is worth knowing separately: it is never gated, so its leaves appear on `aggregate` even when the object itself is a false discovery, and `match_threshold` is not the knob; the field's own `threshold` is.
 
 ---
 
@@ -103,7 +103,7 @@ The `confusion_matrix` object has four keys:
 - **`overall`** -- Metrics for this node's direct children. Where the field is a list, those children are item pairings rather than leaves.
 - **`fields`** -- Field-by-field breakdown, with nested structure for objects and lists.
 - **`non_matches`** -- Populated when `document_non_matches=True` (empty otherwise).
-- **`aggregate`** -- Primitive field metrics summed recursively below this node, excluding list items rejected at their element class's `match_threshold`. A single nested `StructuredModel` field is not excluded; its leaves are always counted. Where a list's items were *all* rejected the counts become object rows rather than primitive-field metrics, so check that before computing a leaf rate ([why](../../Advanced/aggregate-metrics.md#getting-leaf-detail-for-a-marginal-list-item)). See [`overall` vs `aggregate`](#overall-vs-aggregate).
+- **`aggregate`** -- Primitive field metrics summed recursively below this node, excluding list items rejected at their element class's `match_threshold`. A single nested `StructuredModel` field is not excluded; its leaves are always counted. Where a list's items were *all* rejected the counts become object rows rather than primitive-field metrics, so check that before computing a leaf rate ([why](../../Advanced/aggregate-metrics.md#aggregate-counts-objects-for-an-all-rejected-list)). See [`overall` vs `aggregate`](#overall-vs-aggregate).
 
 ### `overall` vs `aggregate`
 

--- a/docs/docs/Guides/Evaluation/understanding-results.md
+++ b/docs/docs/Guides/Evaluation/understanding-results.md
@@ -146,7 +146,8 @@ cm['fields']['lines']['overall'] tp=5     the item count
 ```
 
 The root number is not wrong, it is a different question: it classifies the root's
-own four fields. But it is not a count of line items, and reading it as one
+own fields, and the list field contributes one row per item pairing rather than one
+row for the field. But it is not a count of line items, and reading it as one
 overstates by the number of header fields. For "how many items did we find", read the
 list field's own node.
 
@@ -172,9 +173,9 @@ cm['aggregate']   tp=6   fd=0
 
 `overall` records the spurious non-match. `aggregate` reports the six leaves of the one comparable object, and none of them failed. The rejected object contributes no leaf rows.
 
-#### Getting leaf detail for a marginal object
+#### Getting leaf detail for a marginal list item
 
-If you want those leaves counted, lower `match_threshold` so the object qualifies as comparable. Same two items as above, with the second still at 4/6:
+If you want those leaves counted, lower `match_threshold` so the **list item** qualifies as comparable. This is the knob for a list item only: a single nested `StructuredModel` field is never gated, so lowering `match_threshold` cannot change what it reports. Same two items as above, with the second still at 4/6:
 
 ```
 match_threshold   comparable?   overall            aggregate
@@ -452,7 +453,9 @@ This displays processing statistics (document count, throughput), overall confus
 
 ## Field-Level Aggregate Metrics
 
-Every node in the confusion matrix automatically includes an `aggregate` field that sums all primitive field metrics recursively below that node. This gives you hierarchical analysis without any configuration:
+Every node in the confusion matrix automatically includes an `aggregate` field that sums all primitive field metrics recursively below that node. This gives you hierarchical analysis without any configuration.
+
+One caveat before you rank anything by these counts: where a list's items were *all* rejected, that node's `aggregate` reports one row per rejected object rather than its leaves, so counts from such a node are not comparable with leaf counts from another ([why](../../Advanced/aggregate-metrics.md#aggregate-counts-objects-for-an-all-rejected-list)). The check is `cm['fields'][name]['overall']['tp'] == 0` on a list field.
 
 ```python
 result = ground_truth.compare_with(prediction, include_confusion_matrix=True)
@@ -465,8 +468,11 @@ print(f"Total F1: {cm['aggregate']['derived']['cm_f1']:.3f}")
 for section, data in cm['fields'].items():
     if 'aggregate' in data:
         f1 = data['aggregate']['derived']['cm_f1']
-        errors = data['aggregate']['fd'] + data['aggregate']['fa'] + data['aggregate']['fn']
-        print(f"  {section}: F1={f1:.3f}, Errors={errors}")
+        errors = data['aggregate']['fp'] + data['aggregate']['fn']
+        # A list whose items were ALL rejected reports object rows here, not
+        # leaves, so say so rather than ranking it against leaf counts.
+        unit = 'objects' if data['overall']['tp'] == 0 else 'leaves'
+        print(f"  {section}: F1={f1:.3f}, Errors={errors} ({unit})")
 ```
 
-This is especially useful for identifying which sections of your data have the most extraction issues, without needing to manually aggregate individual field metrics.
+This is especially useful for identifying which sections of your data have the most extraction issues, without needing to manually aggregate individual field metrics. Sum `fp` rather than `fa + fd`, for the reason given under [Asking whether anything failed](#asking-whether-anything-failed): the two are equal by construction and `fp` cannot go stale if a class is ever added.

--- a/docs/docs/Guides/Evaluation/understanding-results.md
+++ b/docs/docs/Guides/Evaluation/understanding-results.md
@@ -58,7 +58,9 @@ clean = (
 
 `aggregate` gives leaf detail for the objects that were comparable: `fp` covers a leaf that scored below its threshold and a value invented where the ground truth was null, `fn` a leaf absent from the prediction. `overall` gives the object verdicts. Sum `fp` rather than `fa + fd`, since `FP = FA + FD` by construction and `fp` cannot go stale if a class is ever added.
 
-The second half of that check is what catches an object rejected outright. An object scoring below `match_threshold` is a spurious non-match, counted once as `fd` on `overall` and not descended into, so it contributes no leaf rows. If you want leaf detail for a marginal object, lower `match_threshold` until it qualifies as comparable. `field_comparisons` names the individual failures.
+The second half of that check is what catches an object rejected outright. A **list item** scoring below the element class's `match_threshold` is a spurious non-match, counted once as `fd` on `overall` and not descended into, so it contributes no leaf rows. If you want leaf detail for a marginal list item, lower `match_threshold` until it qualifies as comparable. `field_comparisons` names the individual failures.
+
+A single nested `StructuredModel` field behaves differently and is worth knowing separately: it is never gated, so its leaves appear on `aggregate` even when the object itself is a false discovery, and `match_threshold` is not the knob — the field's own `threshold` is.
 
 ---
 
@@ -101,7 +103,7 @@ The `confusion_matrix` object has four keys:
 - **`overall`** -- Metrics for this node's direct children. Where the field is a list, those children are item pairings rather than leaves.
 - **`fields`** -- Field-by-field breakdown, with nested structure for objects and lists.
 - **`non_matches`** -- Populated when `document_non_matches=True` (empty otherwise).
-- **`aggregate`** -- Primitive field metrics summed recursively below this node, excluding subtrees rejected at `match_threshold`. See [`overall` vs `aggregate`](#overall-vs-aggregate).
+- **`aggregate`** -- Primitive field metrics summed recursively below this node, excluding list items rejected at their element class's `match_threshold`. A single nested `StructuredModel` field is not excluded; its leaves are always counted. See [`overall` vs `aggregate`](#overall-vs-aggregate).
 
 ### `overall` vs `aggregate`
 
@@ -110,9 +112,9 @@ The two nodes are the two stages of the evaluation, and you generally want both:
 - **`overall` is detection.** The unit is the object. Did we find the right things? For a list of 5 line items that each paired above `match_threshold`, `tp = 5`.
 - **`aggregate` is extraction.** The unit is the leaf. Among the objects established to be the same object, how many field values were correct? For those same 5 items with 6 fields each, `tp` counts up to 30.
 
-`match_threshold` is the handoff, and it is really the definition of "the same object". Above it, the pair is the same thing, so grading its fields is meaningful. Below it, it is not the same thing, so grading its fields would be scoring the fields of a *different* object. Such an object is classified as a single **false discovery** and is not descended into.
+`match_threshold` is the handoff, and it is really the definition of "the same object". Above it, the pair is the same thing, so grading its fields is meaningful. Below it, it is not the same thing, so grading its fields would be scoring the fields of a *different* object. Such an **item** is classified as a single **false discovery** and is not descended into. This gating is a property of `List[StructuredModel]` pairing, not of nested objects generally: a single nested `StructuredModel` field always reports its leaves, and is judged against the field's own `threshold` rather than `match_threshold`.
 
-If that split is familiar, it should be: it is the structure of mean Average Precision, which Stickler also implements for bounding boxes. An IoU threshold decides whether a detection matched, and only matched pairs are scored further. See [Bounding Box mAP Metrics](../../Advanced/bbox-map-metrics.md#iou-thresholds).
+If that split is familiar, it should be: it is the structure of mean Average Precision, which Stickler also implements for bounding boxes. An IoU threshold decides whether a detection matched, and only matched pairs are scored further. See [Bounding Box mAP Metrics](../../Advanced/bbox-map-metrics.md#iou-calculation).
 
 The analogy stops at recall. A below-threshold *detection* counts as both a false positive and a false negative, so recall falls. A below-threshold *object* is an `fd` only, so the unmatched ground-truth item leaves no trace and `overall` recall still reads `1.0`. Pass `recall_with_fd=True` to `compare_with()` for the mAP convention:
 

--- a/docs/docs/Guides/Evaluation/understanding-results.md
+++ b/docs/docs/Guides/Evaluation/understanding-results.md
@@ -110,7 +110,7 @@ The `confusion_matrix` object has four keys:
 The two nodes are the two stages of the evaluation, and you generally want both:
 
 - **`overall` is detection.** The unit is whatever this node's direct children are. On a list field whose 5 items each paired above `match_threshold`, that field's `overall` reads `tp = 5`. Read it on the list field, not at the root: the root's children are its own fields, so a document with 3 header fields beside that list reads `tp = 8` at the root -- 3 leaves plus 5 pairings, mixing the two units in one number.
-- **`aggregate` is extraction.** The unit is the leaf. Among the objects established to be the same object, how many field values were correct? For those same 5 items with 6 fields each, `tp` counts up to 30.
+- **`aggregate` is extraction.** The unit is the leaf, except on a node that has no leaves left to report because every one of its list items was rejected ([why](../../Advanced/aggregate-metrics.md#aggregate-counts-objects-for-an-all-rejected-list)). Among the objects established to be the same object, how many field values were correct? For those same 5 items with 6 fields each, `tp` counts up to 30.
 
 `match_threshold` is the handoff, and it is really the definition of "the same object". Above it, the pair is the same thing, so grading its fields is meaningful. Below it, it is not the same thing, so grading its fields would be scoring the fields of a *different* object. Such an **item** is classified as a single **false discovery** and is not descended into. This gating is a property of `List[StructuredModel]` pairing, not of nested objects generally: a single nested `StructuredModel` field always reports its leaves, and is judged against the field's own `threshold` rather than `match_threshold`.
 
@@ -189,10 +189,10 @@ At `0.66` the marginal item is comparable, so its six leaves join the first item
 
 | Question | Node |
 |---|---|
-| Were the objects comparable, and how many were spurious? | `overall` |
-| Among comparable objects, which leaves landed? | `aggregate` |
-| How many list items did the model find? | that list field's own `overall`, e.g. `cm['fields']['lines']['overall']` |
-| Did anything at all fail? | both, see below |
+| Were the objects comparable, and how many were spurious? | that list field's own `overall`, e.g. `cm['fields']['lines']['overall']` -- not the root's, which also counts the root's own fields |
+| Among comparable objects, which leaves landed? | that same field's `aggregate`, e.g. `cm['fields']['lines']['aggregate']` |
+| How many list items did the model find? | the list field's `overall` again, `cm['fields']['lines']['overall']` |
+| Did anything at all fail? | both `overall` and `aggregate`, on whichever node you are reading, see below |
 
 Because the two nodes scope different things, a complete "did anything fail" check reads both:
 
@@ -214,9 +214,21 @@ overall     tp=1  fp=0  fn=0  fa=0  fd=0
 aggregate   tp=5  fp=1  fn=0  fa=1  fd=0
 ```
 
-!!! note "`EvalResult.precision` is the object-level metric"
+!!! note "`EvalResult.precision` comes from the root `overall`"
 
-    `EvalResult.precision`, `.recall`, `.f1` and `.accuracy` from `stickler.evaluate()` come from `cm['overall']['derived']`, so they answer "how many objects were comparable rather than spurious". On the first example above `result.precision` is `1.0` while `result.overall_score` is `0.9667`: the five items were all comparable, and the score is a weighted mean over the leaves. Both numbers are right for what they measure. For leaf-level precision, read `result.confusion_matrix['aggregate']['derived']`.
+    `EvalResult.precision`, `.recall`, `.f1` and `.accuracy` from `stickler.evaluate()` come from `cm['overall']['derived']` at the **root**, so they inherit the root's unit: they classify the root's direct children. On a model whose only field is the list that is a count of objects. Put three header fields beside it and it is a rate over 3 header leaves plus 5 item pairings, so it is not an object rate at all -- see [Read the node whose children you mean](#read-the-node-whose-children-you-mean). For an object rate, read the list field's own node.
+
+    These are attributes, so they need the entry point that returns an `EvalResult`. Every other example on this page calls `compare_with()`, which returns a plain `dict`, so reaching for `.precision` on one of those raises `AttributeError`. Run the first example above through `stickler.evaluate()` instead:
+
+    ```python
+    result = stickler.evaluate(ground_truth, prediction)   # the first example, same data
+
+    result.precision                                                # 1.0
+    result.overall_score                                            # 0.9667
+    result.confusion_matrix['aggregate']['derived']['cm_precision']  # 0.9667, per leaf
+    ```
+
+    The five items were all comparable, so the root `overall` rate is perfect; the score is a weighted mean over the leaves, and one of the thirty is wrong. Both numbers are right for what they measure.
 
     That two similar-looking numbers on one object mean different things is tracked in [#288](https://github.com/awslabs/stickler/issues/288), where the naming is under review for 1.0.
 
@@ -455,7 +467,7 @@ This displays processing statistics (document count, throughput), overall confus
 
 Every node in the confusion matrix automatically includes an `aggregate` field that sums all primitive field metrics recursively below that node. This gives you hierarchical analysis without any configuration.
 
-One caveat before you rank anything by these counts: where a list's items were *all* rejected, that node's `aggregate` reports one row per rejected object rather than its leaves, so counts from such a node are not comparable with leaf counts from another ([why](../../Advanced/aggregate-metrics.md#aggregate-counts-objects-for-an-all-rejected-list)). The check is `cm['fields'][name]['overall']['tp'] == 0` on a list field.
+One caveat before you rank anything by these counts: where a list's items were *all* rejected, that node's `aggregate` reports one row per rejected object rather than its leaves, so counts from such a node are not comparable with leaf counts from another ([why](../../Advanced/aggregate-metrics.md#aggregate-counts-objects-for-an-all-rejected-list)). The check is `'fields' in node and not node['fields']` -- a structured node with nothing left below it to descend into. A primitive field has no `fields` key at all, so it is not caught, however badly it failed.
 
 ```python
 result = ground_truth.compare_with(prediction, include_confusion_matrix=True)
@@ -469,9 +481,13 @@ for section, data in cm['fields'].items():
     if 'aggregate' in data:
         f1 = data['aggregate']['derived']['cm_f1']
         errors = data['aggregate']['fp'] + data['aggregate']['fn']
-        # A list whose items were ALL rejected reports object rows here, not
-        # leaves, so say so rather than ranking it against leaf counts.
-        unit = 'objects' if data['overall']['tp'] == 0 else 'leaves'
+        # A structured node with an empty 'fields' reports its own rows here, not
+        # leaves: a list whose items were ALL rejected, or one that was null on
+        # both sides. Say so rather than ranking it against leaf counts. Do not
+        # test `data['overall']['tp'] == 0` instead -- that is also true of a
+        # primitive field that simply failed, which is one leaf and nothing else.
+        childless = 'fields' in data and not data['fields']
+        unit = 'object rows' if childless else 'leaves'
         print(f"  {section}: F1={f1:.3f}, Errors={errors} ({unit})")
 ```
 

--- a/docs/docs/Guides/Evaluation/understanding-results.md
+++ b/docs/docs/Guides/Evaluation/understanding-results.md
@@ -103,13 +103,13 @@ The `confusion_matrix` object has four keys:
 - **`overall`** -- Metrics for this node's direct children. Where the field is a list, those children are item pairings rather than leaves.
 - **`fields`** -- Field-by-field breakdown, with nested structure for objects and lists.
 - **`non_matches`** -- Populated when `document_non_matches=True` (empty otherwise).
-- **`aggregate`** -- Primitive field metrics summed recursively below this node, excluding list items rejected at their element class's `match_threshold`. A single nested `StructuredModel` field is not excluded; its leaves are always counted. See [`overall` vs `aggregate`](#overall-vs-aggregate).
+- **`aggregate`** -- Primitive field metrics summed recursively below this node, excluding list items rejected at their element class's `match_threshold`. A single nested `StructuredModel` field is not excluded; its leaves are always counted. Where a list's items were *all* rejected the counts become object rows rather than primitive-field metrics, so check that before computing a leaf rate ([why](../../Advanced/aggregate-metrics.md#getting-leaf-detail-for-a-marginal-list-item)). See [`overall` vs `aggregate`](#overall-vs-aggregate).
 
 ### `overall` vs `aggregate`
 
 The two nodes are the two stages of the evaluation, and you generally want both:
 
-- **`overall` is detection.** The unit is the object. Did we find the right things? For a list of 5 line items that each paired above `match_threshold`, `tp = 5`.
+- **`overall` is detection.** The unit is whatever this node's direct children are. On a list field whose 5 items each paired above `match_threshold`, that field's `overall` reads `tp = 5`. Read it on the list field, not at the root: the root's children are its own fields, so a document with 3 header fields beside that list reads `tp = 8` at the root -- 3 leaves plus 5 pairings, mixing the two units in one number.
 - **`aggregate` is extraction.** The unit is the leaf. Among the objects established to be the same object, how many field values were correct? For those same 5 items with 6 fields each, `tp` counts up to 30.
 
 `match_threshold` is the handoff, and it is really the definition of "the same object". Above it, the pair is the same thing, so grading its fields is meaningful. Below it, it is not the same thing, so grading its fields would be scoring the fields of a *different* object. Such an **item** is classified as a single **false discovery** and is not descended into. This gating is a property of `List[StructuredModel]` pairing, not of nested objects generally: a single nested `StructuredModel` field always reports its leaves, and is judged against the field's own `threshold` rather than `match_threshold`.
@@ -124,6 +124,31 @@ five items, one rejected
 recall_with_fd=False   overall tp=4 fd=1 fn=0   R=1.0000
 recall_with_fd=True    overall tp=4 fd=1 fn=0   R=0.8000
 ```
+
+### Read the node whose children you mean
+
+`overall` counts a node's direct children, so which node you read decides what the
+number means. On a document with fields beside a list:
+
+```python
+class Doc(StructuredModel):
+    invoice_id: str = ComparableField(...)
+    vendor: str = ComparableField(...)
+    date: str = ComparableField(...)
+    lines: List[Line] = ComparableField(...)      # Line has 6 leaves
+```
+
+Five items, everything correct:
+
+```
+cm['overall']                    tp=8     3 header leaves + 5 item pairings
+cm['fields']['lines']['overall'] tp=5     the item count
+```
+
+The root number is not wrong, it is a different question: it classifies the root's
+own four fields. But it is not a count of line items, and reading it as one
+overstates by the number of header fields. For "how many items did we find", read the
+list field's own node.
 
 Two examples make the split concrete.
 
@@ -165,7 +190,7 @@ At `0.66` the marginal item is comparable, so its six leaves join the first item
 |---|---|
 | Were the objects comparable, and how many were spurious? | `overall` |
 | Among comparable objects, which leaves landed? | `aggregate` |
-| How many list items did the model find? | `overall` |
+| How many list items did the model find? | that list field's own `overall`, e.g. `cm['fields']['lines']['overall']` |
 | Did anything at all fail? | both, see below |
 
 Because the two nodes scope different things, a complete "did anything fail" check reads both:

--- a/docs/docs/Guides/Evaluation/understanding-results.md
+++ b/docs/docs/Guides/Evaluation/understanding-results.md
@@ -151,7 +151,7 @@ row for the field. But it is not a count of line items, and reading it as one
 overstates by the number of header fields. For "how many items did we find", read the
 list field's own node.
 
-Two examples make the split concrete.
+Two examples make the split concrete. Both drop the header fields and use a model whose **only** field is the list, so `cm['overall']` at the root is the list's own count and the mixing described just above does not apply. Add header fields back and the root numbers below gain one row per header field.
 
 **A wrong leaf inside a comparable object.** Five line items of six fields each, one field of one item wrong. That item scores 5/6, clears the 0.7 threshold, and is comparable:
 
@@ -218,10 +218,14 @@ aggregate   tp=5  fp=1  fn=0  fa=1  fd=0
 
     `EvalResult.precision`, `.recall`, `.f1` and `.accuracy` from `stickler.evaluate()` come from `cm['overall']['derived']` at the **root**, so they inherit the root's unit: they classify the root's direct children. On a model whose only field is the list that is a count of objects. Put three header fields beside it and it is a rate over 3 header leaves plus 5 item pairings, so it is not an object rate at all -- see [Read the node whose children you mean](#read-the-node-whose-children-you-mean). For an object rate, read the list field's own node.
 
-    These are attributes, so they need the entry point that returns an `EvalResult`. Every other example on this page calls `compare_with()`, which returns a plain `dict`, so reaching for `.precision` on one of those raises `AttributeError`. Run the first example above through `stickler.evaluate()` instead:
+    These are attributes, so they need the entry point that returns an `EvalResult`. Every other example on this page calls `compare_with()`, which returns a plain `dict`, so reaching for `.precision` on one of those raises `AttributeError`. The numbers below are the five-item, one-wrong-leaf document from [A wrong leaf inside a comparable object](#overall-vs-aggregate) above, evaluated through `stickler.evaluate()`:
 
     ```python
-    result = stickler.evaluate(ground_truth, prediction)   # the first example, same data
+    import stickler
+
+    # `ground_truth` and `prediction` are the five line items of six fields each,
+    # with one field of one item wrong -- the first worked example above.
+    result = stickler.evaluate(ground_truth, prediction)
 
     result.precision                                                # 1.0
     result.overall_score                                            # 0.9667

--- a/src/stickler/structured_object_evaluator/models/comparison_engine.py
+++ b/src/stickler/structured_object_evaluator/models/comparison_engine.py
@@ -210,7 +210,12 @@ class ComparisonEngine:
         
         Args:
             other: Another instance of the same model to compare with
-            include_confusion_matrix: Whether to include confusion matrix calculations
+            include_confusion_matrix: Whether to include confusion matrix
+                calculations. `overall` gives object verdicts at this level;
+                `aggregate` gives leaf detail for the objects that were
+                comparable, since one below `match_threshold` is a single FD
+                and is not descended into. See
+                https://awslabs.github.io/stickler/Advanced/aggregate-metrics/
             document_non_matches: Whether to document non-matches for analysis
             evaluator_format: Whether to format results for the evaluator
             recall_with_fd: If True, include FD in recall denominator (TP/(TP+FN+FD))

--- a/src/stickler/structured_object_evaluator/models/comparison_engine.py
+++ b/src/stickler/structured_object_evaluator/models/comparison_engine.py
@@ -211,7 +211,9 @@ class ComparisonEngine:
         Args:
             other: Another instance of the same model to compare with
             include_confusion_matrix: Whether to include confusion matrix
-                calculations. `overall` gives object verdicts at this level;
+                calculations. `overall` classifies this node's direct children,
+                which at the root are its own fields, so read a list field's own
+                `overall` for a count of items;
                 `aggregate` gives leaf detail, and for a LIST ITEM that means
                 only the items that were comparable, since an item below the
                 element class's `match_threshold` is a single FD and is not

--- a/src/stickler/structured_object_evaluator/models/comparison_engine.py
+++ b/src/stickler/structured_object_evaluator/models/comparison_engine.py
@@ -212,9 +212,11 @@ class ComparisonEngine:
             other: Another instance of the same model to compare with
             include_confusion_matrix: Whether to include confusion matrix
                 calculations. `overall` gives object verdicts at this level;
-                `aggregate` gives leaf detail for the objects that were
-                comparable, since one below `match_threshold` is a single FD
-                and is not descended into. See
+                `aggregate` gives leaf detail, and for a LIST ITEM that means
+                only the items that were comparable, since an item below the
+                element class's `match_threshold` is a single FD and is not
+                descended into. A single nested `StructuredModel` field is not
+                gated: its leaves are always reported. See
                 https://awslabs.github.io/stickler/Advanced/aggregate-metrics/
             document_non_matches: Whether to document non-matches for analysis
             evaluator_format: Whether to format results for the evaluator

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -1545,7 +1545,15 @@ class StructuredModel(BaseModel):
 
         Args:
             other: Another instance of the same model to compare with
-            include_confusion_matrix: Whether to include confusion matrix calculations
+            include_confusion_matrix: Whether to include confusion matrix
+                calculations. The result carries two rollup nodes answering
+                different questions: `overall` gives object verdicts (was the
+                pairing genuine or spurious), while `aggregate` gives leaf
+                detail for the objects that were comparable. An object below
+                `match_threshold` is one FD and is not descended into, so
+                lowering `match_threshold` is how you get leaf detail for a
+                marginal object. See
+                https://awslabs.github.io/stickler/Advanced/aggregate-metrics/
             document_non_matches: Whether to document non-matches for analysis
             evaluator_format: Whether to format results for the evaluator
             recall_with_fd: If True, include FD in recall denominator (TP/(TP+FN+FD))

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -1547,8 +1547,11 @@ class StructuredModel(BaseModel):
             other: Another instance of the same model to compare with
             include_confusion_matrix: Whether to include confusion matrix
                 calculations. The result carries two rollup nodes answering
-                different questions: `overall` gives object verdicts (was the
-                pairing genuine or spurious), while `aggregate` gives leaf
+                different questions: `overall` classifies this node's direct
+                children (for a list field, whether each pairing was genuine or
+                spurious; at the root, its own fields, so the two units can mix
+                in one count -- read a list field's own `overall` for a count of
+                items), while `aggregate` gives leaf
                 detail for the objects that were comparable. A LIST ITEM below
                 the element class's `match_threshold` is one FD and is not
                 descended into, so lowering `match_threshold` is how you get

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -1549,10 +1549,14 @@ class StructuredModel(BaseModel):
                 calculations. The result carries two rollup nodes answering
                 different questions: `overall` gives object verdicts (was the
                 pairing genuine or spurious), while `aggregate` gives leaf
-                detail for the objects that were comparable. An object below
-                `match_threshold` is one FD and is not descended into, so
-                lowering `match_threshold` is how you get leaf detail for a
-                marginal object. See
+                detail for the objects that were comparable. A LIST ITEM below
+                the element class's `match_threshold` is one FD and is not
+                descended into, so lowering `match_threshold` is how you get
+                leaf detail for a marginal list item. A single nested
+                `StructuredModel` field is not gated this way: its leaves are
+                always reported on `aggregate`, and its `overall` verdict comes
+                from the field's own `threshold`, not from `match_threshold`.
+                See
                 https://awslabs.github.io/stickler/Advanced/aggregate-metrics/
             document_non_matches: Whether to document non-matches for analysis
             evaluator_format: Whether to format results for the evaluator

--- a/tests/auto/test_risk_surface.py
+++ b/tests/auto/test_risk_surface.py
@@ -1094,10 +1094,15 @@ class TestMatchedHasOneDefinition:
         assert overall["tp"] == 1
         assert overall["fd"] == 1
 
-        # So the reliable question is the conjunction of both nodes.
+        # The published clean check, which reads `fp` on BOTH nodes. An earlier
+        # form summed `fd` on `aggregate` and took `fa` from `overall` only,
+        # which reports clean on a value invented where the ground truth is
+        # null; `test_the_clean_check_catches_a_value_invented_on_a_null_leaf`
+        # pins that. Kept in the same shape as the docs so this file is not a
+        # worked example of the retired form.
         clean = (
-            aggregate["fd"] + aggregate["fn"] == 0
-            and overall["fd"] + overall["fn"] + overall["fa"] == 0
+            aggregate["fp"] + aggregate["fn"] == 0
+            and overall["fp"] + overall["fn"] == 0
         )
         assert clean is False
 

--- a/tests/structured_object_evaluator/test_rollup_node_semantics.py
+++ b/tests/structured_object_evaluator/test_rollup_node_semantics.py
@@ -1,0 +1,282 @@
+"""The two confusion-matrix rollup nodes answer two different questions.
+
+`confusion_matrix.overall` gives object verdicts at its own level: was this
+pairing genuine, or spurious. `confusion_matrix.aggregate` gives leaf detail for
+the objects that were comparable.
+
+`match_threshold` is the line between them, and the gating is deliberate. An
+object scoring below it is classified as a single FD, a spurious non-match, and
+is not descended into: reporting the leaves of an object already rejected as a
+whole would be scoring something declared not comparable. A caller who wants
+those leaves counted lowers `match_threshold` so the object qualifies, which
+`test_lowering_match_threshold_exposes_the_leaves` pins.
+
+The two nodes coincide in exactly two situations, both of which have no accepted
+subtree to expand: a model with no nesting, and a subtree rejected outright.
+
+These tests pin the numbers the documentation publishes, so neither can go stale:
+
+    docs/docs/Advanced/aggregate-metrics.md#which-node-answers-which-question
+    docs/docs/Guides/Evaluation/understanding-results.md
+
+Whether aggregates should also count the leaves of below-threshold objects is a
+deliberately deferred question, not a defect. See
+https://github.com/awslabs/stickler/issues/288
+"""
+
+from typing import List, Optional
+
+import pytest
+
+from stickler.comparators.exact import ExactComparator
+from stickler.structured_object_evaluator.models.comparable_field import (
+    ComparableField,
+)
+from stickler.structured_object_evaluator.models.structured_model import (
+    StructuredModel,
+)
+
+FIELDS = ("sku", "desc", "qty", "unit", "tax", "total")
+
+
+class Line(StructuredModel):
+    """Six exact-match leaves, so every leaf comparison is unambiguous."""
+
+    match_threshold = 0.7
+
+    sku: Optional[str] = ComparableField(
+        comparator=ExactComparator(), threshold=1.0, default=None
+    )
+    desc: Optional[str] = ComparableField(
+        comparator=ExactComparator(), threshold=1.0, default=None
+    )
+    qty: Optional[str] = ComparableField(
+        comparator=ExactComparator(), threshold=1.0, default=None
+    )
+    unit: Optional[str] = ComparableField(
+        comparator=ExactComparator(), threshold=1.0, default=None
+    )
+    tax: Optional[str] = ComparableField(
+        comparator=ExactComparator(), threshold=1.0, default=None
+    )
+    total: Optional[str] = ComparableField(
+        comparator=ExactComparator(), threshold=1.0, default=None
+    )
+
+
+class Invoice(StructuredModel):
+    lines: List[Line] = []
+
+
+def _line(index: int, *, wrong: bool = False) -> Line:
+    values = {name: f"{name}{index}" for name in FIELDS}
+    if wrong:
+        values["total"] = "WRONG"
+    return Line(**values)
+
+
+@pytest.fixture
+def one_bad_leaf_of_thirty():
+    """Five line items of six leaves each; one leaf of one item is wrong.
+
+    Every item still pairs above `match_threshold`, which is the whole point:
+    the failure is invisible to anything counting pairings.
+    """
+    ground_truth = Invoice(lines=[_line(i) for i in range(5)])
+    prediction = Invoice(lines=[_line(i, wrong=(i == 2)) for i in range(5)])
+    return ground_truth.compare_with(
+        prediction, include_confusion_matrix=True, add_derived_metrics=True
+    )
+
+
+class TestRejectedObjectsReportNoLeafDetail:
+    """An object below `match_threshold` is one FD and is not descended into.
+
+    This is the intended semantics, not an oversight: the leaves of an object
+    rejected as a whole are not reported. `match_threshold` is therefore the
+    knob controlling how much leaf detail a caller gets.
+    """
+
+    def test_leaf_rows_stop_when_the_object_is_not_comparable(self):
+        good = {name: f"{name}0" for name in FIELDS}
+        ground_truth = Invoice(lines=[Line(**good), Line(**good)])
+
+        rows = []
+        for n_wrong in range(4):
+            bad = {**good}
+            for name in list(FIELDS)[:n_wrong]:
+                bad[name] = "WRONG"
+            cm = ground_truth.compare_with(
+                Invoice(lines=[Line(**good), Line(**bad)]),
+                include_confusion_matrix=True,
+                add_derived_metrics=True,
+            )["confusion_matrix"]
+            aggregate = cm["aggregate"]
+            rows.append((n_wrong, aggregate["tp"] + aggregate["fd"] + aggregate["fn"]))
+
+        # 12 leaves exist in every case, but only comparable objects report
+        # them. The second item drops below match_threshold (0.7) at 2 of 6
+        # wrong, from which point only the first item's 6 leaves are scored.
+        assert rows == [(0, 12), (1, 12), (2, 6), (3, 6)]
+
+    def test_a_rejected_object_reports_itself_and_not_its_leaves(self):
+        good = {name: f"{name}0" for name in FIELDS}
+        bad = {**good, "sku": "WRONG", "desc": "WRONG"}  # 4/6 = 0.6667
+
+        cm = Invoice(lines=[Line(**good)]).compare_with(
+            Invoice(lines=[Line(**bad)]),
+            include_confusion_matrix=True,
+            add_derived_metrics=True,
+        )["confusion_matrix"]
+
+        # The object is the unit of report here, not its six leaves.
+        assert cm["aggregate"]["fd"] == 1
+        assert cm["aggregate"]["tp"] == 0
+        assert cm["overall"]["fd"] == 1
+
+    def test_lowering_match_threshold_exposes_the_leaves(self):
+        """The documented remedy: make the object comparable and leaves follow.
+
+        `match_threshold` decides what counts as the same object, and leaf
+        reporting follows from that. This is the answer for a caller who wants
+        below-threshold detail, rather than a change to what `aggregate` counts.
+        """
+        good = {name: f"{name}0" for name in FIELDS}
+        bad = {**good, "sku": "WRONG", "desc": "WRONG"}  # scores 4/6 = 0.6667
+
+        def counts(match_threshold):
+            line_type = type(
+                "Line",
+                (StructuredModel,),
+                {
+                    "__annotations__": {name: Optional[str] for name in FIELDS},
+                    "match_threshold": match_threshold,
+                    **{
+                        name: ComparableField(
+                            comparator=ExactComparator(), threshold=1.0, default=None
+                        )
+                        for name in FIELDS
+                    },
+                },
+            )
+            doc_type = type(
+                "Doc",
+                (StructuredModel,),
+                {"__annotations__": {"lines": List[line_type]}, "lines": []},
+            )
+            cm = doc_type(lines=[line_type(**good)]).compare_with(
+                doc_type(lines=[line_type(**bad)]),
+                include_confusion_matrix=True,
+                add_derived_metrics=True,
+            )["confusion_matrix"]
+            return cm["aggregate"]["tp"], cm["aggregate"]["fd"]
+
+        # Above the object's score: rejected, so one FD and no leaf rows.
+        assert counts(0.70) == (0, 1)
+
+        # Below it: comparable, so all six leaves are scored and the two bad
+        # ones are reported individually.
+        assert counts(0.66) == (4, 2)
+
+
+class TestRollupNodesCountDifferentThings:
+    def test_overall_counts_item_pairings(self, one_bad_leaf_of_thirty):
+        """Five items paired, so five true positives and nothing wrong."""
+        overall = one_bad_leaf_of_thirty["confusion_matrix"]["overall"]
+
+        assert overall["tp"] == 5
+        assert overall["fd"] == 0
+        assert overall["fn"] == 0
+        assert overall["fp"] == 0
+
+    def test_aggregate_counts_leaf_comparisons(self, one_bad_leaf_of_thirty):
+        """Thirty leaves, one of which failed."""
+        aggregate = one_bad_leaf_of_thirty["confusion_matrix"]["aggregate"]
+
+        assert aggregate["tp"] == 29
+        assert aggregate["fd"] == 1
+        assert aggregate["fn"] == 0
+        assert aggregate["fp"] == 1  # fp == fa + fd
+
+    def test_the_documented_derived_metrics(self, one_bad_leaf_of_thirty):
+        """The exact numbers both doc pages print, side by side."""
+        cm = one_bad_leaf_of_thirty["confusion_matrix"]
+        overall = cm["overall"]["derived"]
+        aggregate = cm["aggregate"]["derived"]
+
+        # `overall` reports a flawless document.
+        assert overall["cm_precision"] == pytest.approx(1.0)
+        assert overall["cm_recall"] == pytest.approx(1.0)
+        assert overall["cm_f1"] == pytest.approx(1.0)
+
+        # `aggregate` sees the bad leaf.
+        assert aggregate["cm_precision"] == pytest.approx(0.9667, abs=1e-4)
+        assert aggregate["cm_recall"] == pytest.approx(1.0)
+        assert aggregate["cm_f1"] == pytest.approx(0.9831, abs=1e-4)
+
+    def test_overall_score_agrees_with_aggregate_and_not_with_overall(
+        self, one_bad_leaf_of_thirty
+    ):
+        """The claim the docs rest on.
+
+        `overall_score` is a weighted mean over the whole tree, so it tracks the
+        leaf view. Reporting `overall.derived` precision beside `overall_score`
+        puts two numbers in the same report that disagree by construction.
+        """
+        cm = one_bad_leaf_of_thirty["confusion_matrix"]
+        score = one_bad_leaf_of_thirty["overall_score"]
+
+        assert score == pytest.approx(0.9667, abs=1e-4)
+        assert score == pytest.approx(cm["aggregate"]["derived"]["cm_precision"])
+        assert score != pytest.approx(cm["overall"]["derived"]["cm_precision"])
+
+    def test_a_complete_failure_check_reads_both_nodes(self):
+        """The two nodes scope different things, so a full check needs both.
+
+        `aggregate.fd + fn == 0` alone answers only "did every leaf of every
+        comparable object land". It says nothing about objects that were not
+        comparable, nor about invented fields, both of which land on `overall`.
+        """
+        good = {name: f"{name}0" for name in FIELDS}
+        two_wrong = {**good, "sku": "WRONG", "desc": "WRONG"}  # 4/6, does not pair
+
+        ground_truth = Invoice(lines=[Line(**good), Line(**good)])
+        prediction = Invoice(lines=[Line(**good), Line(**two_wrong)])
+        cm = ground_truth.compare_with(
+            prediction, include_confusion_matrix=True, add_derived_metrics=True
+        )["confusion_matrix"]
+
+        aggregate, overall = cm["aggregate"], cm["overall"]
+
+        # Every leaf of the one comparable object landed, so the leaf view is
+        # clean. The rejected object contributes no leaf rows.
+        assert aggregate["fd"] + aggregate["fn"] == 0
+
+        # Its rejection is recorded here, which is why a full check reads both.
+        assert overall["fd"] == 1
+        clean = (
+            aggregate["fd"] + aggregate["fn"] == 0
+            and overall["fd"] + overall["fn"] + overall["fa"] == 0
+        )
+        assert clean is False
+
+    def test_the_nodes_converge_when_there_is_no_list(self):
+        """Without a list field there are no pairings, so both count leaves.
+
+        This is why the divergence is easy to miss: it needs a list field to
+        appear at all, and the flat case gives no warning that the two nodes can
+        ever disagree.
+        """
+        ground_truth = _line(0)
+        prediction = _line(0, wrong=True)
+        result = ground_truth.compare_with(
+            prediction, include_confusion_matrix=True, add_derived_metrics=True
+        )
+        cm = result["confusion_matrix"]
+
+        assert cm["overall"]["tp"] == cm["aggregate"]["tp"] == 5
+        assert cm["overall"]["fd"] == cm["aggregate"]["fd"] == 1
+        assert (
+            cm["overall"]["derived"]["cm_precision"]
+            == cm["aggregate"]["derived"]["cm_precision"]
+        )

--- a/tests/structured_object_evaluator/test_rollup_node_semantics.py
+++ b/tests/structured_object_evaluator/test_rollup_node_semantics.py
@@ -11,12 +11,17 @@ whole would be scoring something declared not comparable. A caller who wants
 those leaves counted lowers `match_threshold` so the object qualifies, which
 `test_lowering_match_threshold_exposes_the_leaves` pins.
 
-The two nodes coincide in exactly two situations, both of which have no accepted
-subtree to expand: a model with no nesting, and a subtree rejected outright.
+The two nodes coincide only where there is no accepted subtree to expand at all: a
+model with no nesting, or a document in which *every* subtree was rejected. One
+rejected subtree among several makes them diverge further rather than converge,
+since `aggregate` then reports a flawless precision over the accepted items only,
+which `test_a_rejected_subtree_separates_the_two_numbers` pins.
 
-These tests pin the numbers the documentation publishes, so neither can go stale:
+These tests pin the numbers and the snippet the documentation publishes, so
+neither can go stale:
 
     docs/docs/Advanced/aggregate-metrics.md#which-node-answers-which-question
+    docs/docs/Advanced/threshold-gated-evaluation.md
     docs/docs/Guides/Evaluation/understanding-results.md
 
 Whether aggregates should also count the leaves of below-threshold objects is a
@@ -24,6 +29,7 @@ deliberately deferred question, not a defect. See
 https://github.com/awslabs/stickler/issues/288
 """
 
+from pathlib import Path
 from typing import List, Optional
 
 import pytest
@@ -73,6 +79,64 @@ def _line(index: int, *, wrong: bool = False) -> Line:
     if wrong:
         values["total"] = "WRONG"
     return Line(**values)
+
+
+def _line_type(match_threshold: float) -> type:
+    """A six-leaf line-item model with the given `match_threshold`."""
+    return type(
+        "Line",
+        (StructuredModel,),
+        {
+            "__annotations__": {name: Optional[str] for name in FIELDS},
+            "match_threshold": match_threshold,
+            **{
+                name: ComparableField(
+                    comparator=ExactComparator(), threshold=1.0, default=None
+                )
+                for name in FIELDS
+            },
+        },
+    )
+
+
+def _doc_type(line_type: type) -> type:
+    """A document holding a list of the given line-item model."""
+    return type(
+        "Doc",
+        (StructuredModel,),
+        {"__annotations__": {"lines": List[line_type]}, "lines": []},
+    )
+
+
+_PAGES_PUBLISHING_THE_CLEAN_CHECK = (
+    "docs/docs/Advanced/aggregate-metrics.md",
+    "docs/docs/Advanced/threshold-gated-evaluation.md",
+    "docs/docs/Guides/Evaluation/understanding-results.md",
+)
+
+
+def _documented_clean_check(cm: dict) -> bool:
+    """The "did anything fail" check the doc pages publish, verbatim.
+
+    Defined once so the pages and the tests cannot drift apart. It sums `fp`
+    rather than `fa + fd` because `FP = FA + FD` by construction, so the two are
+    equivalent today and `fp` cannot go stale if a class is ever added.
+
+    Both nodes are read because each is blind to the other's failures: a
+    below-threshold item is one `fd` on `overall` and contributes no leaf rows,
+    while a value invented on a null leaf is `fa` under `aggregate` and leaves
+    `overall` untouched.
+
+    Published in three places, all of which must stay in step with this:
+
+        docs/docs/Advanced/aggregate-metrics.md#asking-whether-anything-failed
+        docs/docs/Advanced/threshold-gated-evaluation.md
+        docs/docs/Guides/Evaluation/understanding-results.md  (twice)
+    """
+    return (
+        cm["aggregate"]["fp"] + cm["aggregate"]["fn"] == 0
+        and cm["overall"]["fp"] + cm["overall"]["fn"] == 0
+    )
 
 
 @pytest.fixture
@@ -145,25 +209,8 @@ class TestRejectedObjectsReportNoLeafDetail:
         bad = {**good, "sku": "WRONG", "desc": "WRONG"}  # scores 4/6 = 0.6667
 
         def counts(match_threshold):
-            line_type = type(
-                "Line",
-                (StructuredModel,),
-                {
-                    "__annotations__": {name: Optional[str] for name in FIELDS},
-                    "match_threshold": match_threshold,
-                    **{
-                        name: ComparableField(
-                            comparator=ExactComparator(), threshold=1.0, default=None
-                        )
-                        for name in FIELDS
-                    },
-                },
-            )
-            doc_type = type(
-                "Doc",
-                (StructuredModel,),
-                {"__annotations__": {"lines": List[line_type]}, "lines": []},
-            )
+            line_type = _line_type(match_threshold)
+            doc_type = _doc_type(line_type)
             cm = doc_type(lines=[line_type(**good)]).compare_with(
                 doc_type(lines=[line_type(**bad)]),
                 include_confusion_matrix=True,
@@ -177,6 +224,48 @@ class TestRejectedObjectsReportNoLeafDetail:
         # Below it: comparable, so all six leaves are scored and the two bad
         # ones are reported individually.
         assert counts(0.66) == (4, 2)
+
+    def test_the_two_documented_threshold_tables(self):
+        """Pins the `match_threshold` tables the two pages print.
+
+        These were the only published figures no test covered, and both had
+        drifted to the numbers of a one-item document while their prose described
+        a two-item and a five-item one. The counts depend on the document, so the
+        document has to be part of the assertion.
+
+            understanding-results.md   two items, second at 4/6
+            aggregate-metrics.md       five items, third at 4/6
+        """
+
+        def counts(match_threshold, items, bad_index):
+            line_type = _line_type(match_threshold)
+            doc_type = _doc_type(line_type)
+            good = {name: f"{name}0" for name in FIELDS}
+            bad = {**good, "sku": "WRONG", "desc": "WRONG"}  # 4/6 = 0.6667
+            cm = doc_type(lines=[line_type(**good) for _ in range(items)]).compare_with(
+                doc_type(
+                    lines=[
+                        line_type(**(bad if i == bad_index else good))
+                        for i in range(items)
+                    ]
+                ),
+                include_confusion_matrix=True,
+                add_derived_metrics=True,
+            )["confusion_matrix"]
+            return (
+                cm["overall"]["tp"],
+                cm["overall"]["fd"],
+                cm["aggregate"]["tp"],
+                cm["aggregate"]["fd"],
+            )
+
+        # understanding-results.md: two items, the second at 4/6.
+        assert counts(0.70, items=2, bad_index=1) == (1, 1, 6, 0)
+        assert counts(0.66, items=2, bad_index=1) == (2, 0, 10, 2)
+
+        # aggregate-metrics.md: five items, the third at 4/6.
+        assert counts(0.70, items=5, bad_index=2) == (4, 1, 24, 0)
+        assert counts(0.66, items=5, bad_index=2) == (5, 0, 28, 2)
 
 
 class TestRollupNodesCountDifferentThings:
@@ -221,7 +310,16 @@ class TestRollupNodesCountDifferentThings:
 
         `overall_score` is a weighted mean over the whole tree, so it tracks the
         leaf view. Reporting `overall.derived` precision beside `overall_score`
-        puts two numbers in the same report that disagree by construction.
+        puts two numbers in the same report that disagree by construction. That
+        inequality is the load-bearing half.
+
+        The equality with `aggregate` precision is narrower than it looks, and is
+        not a general property. A weighted mean of leaf scores equals
+        `tp / (tp + fp)` only while all four of this fixture's conditions hold:
+        every leaf scores exactly 0.0 or 1.0, weights are uniform, there are no
+        FN, and no subtree was rejected. Break the last one and they part
+        company, which `test_a_rejected_subtree_separates_the_two_numbers`
+        pins.
         """
         cm = one_bad_leaf_of_thirty["confusion_matrix"]
         score = one_bad_leaf_of_thirty["overall_score"]
@@ -230,12 +328,42 @@ class TestRollupNodesCountDifferentThings:
         assert score == pytest.approx(cm["aggregate"]["derived"]["cm_precision"])
         assert score != pytest.approx(cm["overall"]["derived"]["cm_precision"])
 
+    def test_a_rejected_subtree_separates_the_two_numbers(self):
+        """The equality above is a property of the fixture, not of the engine.
+
+        With one item of five rejected, `aggregate` sees only the 24 leaves of
+        the four accepted items, all correct, so its precision is a flawless
+        1.0 while `overall_score` carries the rejection.
+        """
+
+        def rejected(index: int) -> Line:
+            """Two of six leaves wrong, so 4/6, below `match_threshold`."""
+            values = {name: f"{name}{index}" for name in FIELDS}
+            values["total"] = "WRONG"
+            values["tax"] = "WRONG"
+            return Line(**values)
+
+        ground_truth = Invoice(lines=[_line(i) for i in range(5)])
+        prediction = Invoice(
+            lines=[rejected(i) if i == 2 else _line(i) for i in range(5)]
+        )
+        result = ground_truth.compare_with(
+            prediction, include_confusion_matrix=True, add_derived_metrics=True
+        )
+        cm = result["confusion_matrix"]
+
+        assert result["overall_score"] == pytest.approx(0.9333, abs=1e-4)
+        assert cm["aggregate"]["derived"]["cm_precision"] == pytest.approx(1.0)
+        assert result["overall_score"] != pytest.approx(
+            cm["aggregate"]["derived"]["cm_precision"]
+        )
+
     def test_a_complete_failure_check_reads_both_nodes(self):
         """The two nodes scope different things, so a full check needs both.
 
-        `aggregate.fd + fn == 0` alone answers only "did every leaf of every
+        `aggregate.fp + fn == 0` alone answers only "did every leaf of every
         comparable object land". It says nothing about objects that were not
-        comparable, nor about invented fields, both of which land on `overall`.
+        comparable, which land on `overall`.
         """
         good = {name: f"{name}0" for name in FIELDS}
         two_wrong = {**good, "sku": "WRONG", "desc": "WRONG"}  # 4/6, does not pair
@@ -250,15 +378,43 @@ class TestRollupNodesCountDifferentThings:
 
         # Every leaf of the one comparable object landed, so the leaf view is
         # clean. The rejected object contributes no leaf rows.
-        assert aggregate["fd"] + aggregate["fn"] == 0
+        assert aggregate["fp"] + aggregate["fn"] == 0
 
         # Its rejection is recorded here, which is why a full check reads both.
         assert overall["fd"] == 1
-        clean = (
-            aggregate["fd"] + aggregate["fn"] == 0
-            and overall["fd"] + overall["fn"] + overall["fa"] == 0
+        assert _documented_clean_check(cm) is False
+
+    def test_the_clean_check_catches_a_value_invented_on_a_null_leaf(self):
+        """The case that makes the published check read `fp`, not `fa + fd`.
+
+        A leaf whose ground truth is null and whose prediction supplies a value
+        is `fa` at that leaf, and it rolls up into `aggregate`. The item still
+        pairs, so the root `overall` stays completely clean. Any check that reads
+        `fa` on `overall` alone therefore reports a hallucinated value as clean,
+        which is the same shape of miss as reading `overall` alone.
+        """
+        good = {name: f"{name}0" for name in FIELDS}
+        ground_truth = Invoice(lines=[Line(**{**good, "total": None})])
+        prediction = Invoice(lines=[Line(**{**good, "total": "INVENTED"})])
+        cm = ground_truth.compare_with(
+            prediction, include_confusion_matrix=True, add_derived_metrics=True
+        )["confusion_matrix"]
+
+        # The hallucination lands on `aggregate`, and nowhere on `overall`.
+        assert cm["aggregate"]["fa"] == 1
+        assert cm["aggregate"]["fp"] == 1
+        assert cm["overall"]["fa"] == 0
+        assert cm["overall"]["fp"] == 0
+
+        assert _documented_clean_check(cm) is False
+
+        # The superseded form, kept here to pin exactly why it was replaced: it
+        # reads `fa` only on `overall`, where this failure never appears.
+        superseded = (
+            cm["aggregate"]["fd"] + cm["aggregate"]["fn"] == 0
+            and cm["overall"]["fd"] + cm["overall"]["fn"] + cm["overall"]["fa"] == 0
         )
-        assert clean is False
+        assert superseded is True
 
     def test_the_nodes_converge_when_there_is_no_list(self):
         """Without a list field there are no pairings, so both count leaves.
@@ -280,3 +436,35 @@ class TestRollupNodesCountDifferentThings:
             cm["overall"]["derived"]["cm_precision"]
             == cm["aggregate"]["derived"]["cm_precision"]
         )
+
+
+class TestTheDocsAndTheEngineCannotDrift:
+    """The published snippet exists in four places; none may drift from this one.
+
+    Both errors this file now guards against reached review because a number or a
+    snippet was written into a page that nothing executed. `_documented_clean_check`
+    is the executable copy, and this walks the pages to confirm they still match it.
+    """
+
+    def test_every_page_publishes_the_current_clean_check(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        expected_lines = (
+            "cm['aggregate']['fp'] + cm['aggregate']['fn'] == 0",
+            "and cm['overall']['fp'] + cm['overall']['fn'] == 0",
+        )
+        superseded = "cm['overall']['fa']"
+
+        for relative in _PAGES_PUBLISHING_THE_CLEAN_CHECK:
+            page = repo_root / relative
+            assert page.exists(), f"{relative} moved; update this list"
+            text = page.read_text()
+
+            assert "clean = (" in text, f"{relative} no longer publishes the check"
+            for line in expected_lines:
+                assert line in text, f"{relative} is missing: {line}"
+
+            # The form that reported a hallucinated value as clean.
+            assert superseded not in text, (
+                f"{relative} still reads `fa` on `overall` alone, which is clean "
+                f"on a value invented against a null ground-truth leaf"
+            )

--- a/tests/structured_object_evaluator/test_rollup_node_semantics.py
+++ b/tests/structured_object_evaluator/test_rollup_node_semantics.py
@@ -142,6 +142,73 @@ _READS_FA_OFF_OVERALL = re.compile(
 )
 
 
+def _authored_prose(repo_root: Path):
+    """Every line this repo authors about the rollup nodes: (path, lineno, text).
+
+    `src/**/*.py` and `docs/**/*.md` are the surfaces a reader sees, and
+    `tests/**/*.py` because a worked example in a test is the next person's copy
+    source. `CHANGELOG.md` is included too, but only its `## [Unreleased]` section:
+    shipped release notes record what was said at the time and are not rewritten,
+    while the open section is authored by the same change as the docs and drifted
+    from them twice. The walk this replaces never reached the changelog at all, and
+    carried an `exempt = {Path("CHANGELOG.md")}` that therefore could not fire --
+    dead code reading as a deliberate exemption.
+
+    This file is skipped of necessity: the guards below spell the banned phrases out.
+    """
+    for path in (
+        sorted(repo_root.glob("src/**/*.py"))
+        + sorted(repo_root.glob("docs/**/*.md"))
+        + sorted(repo_root.glob("tests/**/*.py"))
+    ):
+        if path == Path(__file__).resolve() or ".venv" in path.parts:
+            continue
+        relative = path.relative_to(repo_root)
+        for number, line in enumerate(
+            path.read_text(errors="ignore").splitlines(), start=1
+        ):
+            yield relative, number, line
+
+    lines = (repo_root / "CHANGELOG.md").read_text().splitlines()
+    start = next(
+        (i for i, line in enumerate(lines) if line.startswith("## [Unreleased]")),
+        None,
+    )
+    assert start is not None, "CHANGELOG.md has no `## [Unreleased]` heading to scan"
+    end = next(
+        (
+            i
+            for i, line in enumerate(lines[start + 1 :], start + 1)
+            if line.startswith("## [")
+        ),
+        len(lines),
+    )
+    for number in range(start, end):
+        yield Path("CHANGELOG.md"), number + 1, lines[number]
+
+
+def _documented_unit_label(node: dict) -> str:
+    """Is this node's `aggregate` a count of leaves? The check the pages publish.
+
+    A primitive field has no `fields` key at all. A structured node -- a nested
+    object, or a list -- always has one, and it is empty exactly when there was
+    nothing to descend into: every item was rejected, or the field was null on both
+    sides. `AggregateMetricsCalculator` decides leaf versus parent on precisely that,
+    so this is the condition under which `aggregate` stops being a leaf count.
+
+    The retired form was `node['overall']['tp'] == 0`, which is also true of a
+    primitive field that simply failed -- one leaf, and never anything else -- so it
+    mislabelled exactly the rows a reader scans a ranking for.
+
+    Published in:
+
+        docs/docs/Advanced/aggregate-metrics.md#aggregate-counts-objects-for-an-all-rejected-list
+        docs/docs/Guides/Evaluation/understanding-results.md  (prose and snippet)
+    """
+    childless_structured = "fields" in node and not node["fields"]
+    return "object rows" if childless_structured else "leaves"
+
+
 def _documented_clean_check(cm: dict) -> bool:
     """The "did anything fail" check the doc pages publish, verbatim.
 
@@ -507,8 +574,10 @@ class TestTheDocsAndTheEngineCannotDrift:
 
         Prose is not usually worth a guard, but this one is the whole subject of the
         pages, it is published to the API reference through two docstrings, and every
-        recurrence has been a fresh review finding. Historical CHANGELOG entries for
-        already-shipped releases are exempt: they record what was said at the time.
+        recurrence has been a fresh review finding. The fourth recurrence was in
+        `CHANGELOG.md` under `## [Unreleased]`, which the walk did not reach, so
+        `_authored_prose` now scans that section; shipped release notes stay exempt
+        because they record what was said at the time.
 
         This file is exempt of necessity, since `banned` below spells the phrases
         out. That exemption is doing real work rather than being a formality: the
@@ -518,29 +587,125 @@ class TestTheDocsAndTheEngineCannotDrift:
         """
         repo_root = Path(__file__).resolve().parents[2]
         banned = ("object verdict", "verdicts at", "own direct classification")
-        exempt = {Path("CHANGELOG.md")}
-        offenders = []
-
-        for path in (
-            sorted(repo_root.glob("src/**/*.py"))
-            + sorted(repo_root.glob("docs/**/*.md"))
-            + sorted(repo_root.glob("tests/**/*.py"))
-        ):
-            if path == Path(__file__).resolve():
-                continue
-            if path.relative_to(repo_root) in exempt or ".venv" in path.parts:
-                continue
-            for number, line in enumerate(
-                path.read_text(errors="ignore").splitlines(), start=1
-            ):
-                lowered = line.lower()
-                if any(phrase in lowered for phrase in banned):
-                    offenders.append(f"{path.relative_to(repo_root)}:{number}")
+        offenders = [
+            f"{path}:{number}"
+            for path, number, line in _authored_prose(repo_root)
+            if any(phrase in line.lower() for phrase in banned)
+        ]
 
         assert not offenders, (
             "these describe `overall` as a verdict on the node rather than a "
             "classification of its direct children, which is false at the root "
             f"and in both docstrings published to the API reference: {offenders}"
+        )
+
+    def test_the_changelog_unreleased_section_is_the_part_that_gets_scanned(self):
+        """Both directions on the scanner, because the last exemption was dead code.
+
+        `exempt = {Path("CHANGELOG.md")}` read as a policy and was unreachable: the
+        walk covered `src`, `docs` and `tests` only. So this asserts the open section
+        really is reached, and that a shipped one really is not.
+        """
+        repo_root = Path(__file__).resolve().parents[2]
+        scanned = {
+            (path, number) for path, number, _ in _authored_prose(repo_root)
+        }
+        changelog = (repo_root / "CHANGELOG.md").read_text().splitlines()
+        unreleased = next(
+            i for i, line in enumerate(changelog, start=1) if line == "## [Unreleased]"
+        )
+        shipped = next(
+            i
+            for i, line in enumerate(changelog, start=1)
+            if line.startswith("## [") and i > unreleased
+        )
+
+        assert (Path("CHANGELOG.md"), unreleased) in scanned
+        assert (Path("CHANGELOG.md"), unreleased + 1) in scanned
+        assert (Path("CHANGELOG.md"), shipped) not in scanned
+        assert (Path("CHANGELOG.md"), len(changelog)) not in scanned
+
+    def test_no_file_states_the_retired_all_zero_fallback_mechanism(self):
+        """`aggregate` does not fall back to summing children's `overall`.
+
+        Round four wrote that story into the warning, the `Calculation Logic` step
+        beneath it and the release note, and it is not the mechanism. A rejected item
+        is not descended into, so an all-rejected list has *no* child fields;
+        `AggregateMetricsCalculator` then classes the node as a leaf and copies its
+        own `overall`. Read literally, the retired rule sums over an empty set and
+        predicts `tp=0 fd=0` where the engine reports `fd=2`, so it contradicted the
+        worked output printed beside it.
+
+        `TestAllRejectedAggregateCountsObjects` pins the real behaviour. This guard
+        exists because the observable claim was right, which is what let the wrong
+        causal story survive review.
+        """
+        repo_root = Path(__file__).resolve().parents[2]
+        banned = (
+            "falls back to summing",
+            "recursive leaf sum",
+            "leaf sum is all-zero",
+            "leaf sum comes out all-zero",
+            "unless every one of them is zero",
+            "values are summed instead",
+        )
+        offenders = [
+            f"{path}:{number}"
+            for path, number, line in _authored_prose(repo_root)
+            if any(phrase in line.lower() for phrase in banned)
+        ]
+
+        assert not offenders, (
+            "these state that `aggregate` sums its children's `overall` when the "
+            "leaf sum is all-zero. The engine instead treats a node with no child "
+            f"fields as a leaf and copies its own `overall`: {offenders}"
+        )
+
+    def test_no_page_reads_an_evalresult_attribute_off_a_compare_with_result(self):
+        """`compare_with()` returns a `dict`; only `evaluate()` returns an `EvalResult`.
+
+        The `EvalResult.precision` note was written into a page whose every example
+        is `compare_with()`, and told the reader that "on the first example above
+        `result.precision` is 1.0". Copied, that line raises `AttributeError`.
+
+        Scoped to the identifier `result`, which is what every page binds, and driven
+        by the nearest preceding `result = ` in the file, so a page is judged on the
+        binding actually in scope rather than on whether the entry point is mentioned
+        somewhere nearby -- which is exactly what made the wrong line look fine.
+        """
+        repo_root = Path(__file__).resolve().parents[2]
+        attributes = (
+            "precision",
+            "recall",
+            "f1",
+            "accuracy",
+            "overall_score",
+            "field_scores",
+            "matched",
+            "confusion_matrix",
+        )
+        reads = re.compile(r"(?<![\w.])result\.(" + "|".join(attributes) + r")\b")
+        binds = re.compile(r"(?<![\w.])result\s*=\s*(?P<rhs>.+)")
+        offenders = []
+
+        for page in sorted(repo_root.glob("docs/**/*.md")):
+            binding = None
+            for number, line in enumerate(
+                page.read_text(errors="ignore").splitlines(), start=1
+            ):
+                bound = binds.search(line)
+                if bound:
+                    binding = (number, bound.group("rhs"))
+                if reads.search(line) and binding and "evaluate(" not in binding[1]:
+                    offenders.append(
+                        f"{page.relative_to(repo_root)}:{number} reads an EvalResult "
+                        f"attribute, but `result` was bound at :{binding[0]} by "
+                        f"`{binding[1].strip()}`"
+                    )
+
+        assert not offenders, (
+            "these read an `EvalResult` attribute off something that is not an "
+            f"`EvalResult`, so the published line raises: {offenders}"
         )
 
     def test_no_file_anywhere_publishes_the_superseded_form(self):
@@ -682,13 +847,19 @@ class TestANestedObjectIsNotThresholdGated:
 
 
 class TestAllRejectedAggregateCountsObjects:
-    """`aggregate` stops being a leaf count when every subtree is rejected.
+    """`aggregate` stops being a leaf count when every item of a list is rejected.
 
-    `AggregateMetricsCalculator` falls back to summing children's `overall` when
-    the recursive leaf sum is all-zero, so the unit of the count changes with the
-    data. The page promised "the unit is the leaf" and "primitive field metrics",
-    so dividing an `aggregate` count by a leaf total, or calling its `derived`
-    block leaf-level precision, is wrong on an all-rejected document.
+    The mechanism, which an earlier round of this file got wrong: a rejected item is
+    not descended into, so a list with every item rejected has *no child fields at
+    all*. `AggregateMetricsCalculator` splits leaf from parent on exactly that test
+    (`aggregate_metrics_calculator.py`, `is_leaf_node`), so the node is treated as a
+    leaf and its `aggregate` is a copy of its own `overall` -- one row per rejected
+    item. Nothing sums the children's `overall`; there are no children to sum, and
+    `test_the_rejected_list_node_has_no_children_to_sum` pins that.
+
+    So the unit of the count changes with the data. The page promised "the unit is
+    the leaf" and "primitive field metrics", so dividing an `aggregate` count by a
+    leaf total, or calling its `derived` block leaf-level precision, is wrong here.
     """
 
     @staticmethod
@@ -723,15 +894,44 @@ class TestAllRejectedAggregateCountsObjects:
         cm = self._two_items(rejected=2)
         assert cm["aggregate"]["fd"] == cm["overall"]["fd"] == 2
 
+    def test_the_rejected_list_node_has_no_children_to_sum(self):
+        """The actual mechanism, in both directions.
+
+        A rejected item is not descended into, so the `fields` dict of the list node
+        empties out entirely. That, and not any fallback that sums children's
+        `overall`, is why the node reports object rows: with no children it is a leaf,
+        and a leaf's `aggregate` is a copy of its `overall`. Read the retired rule
+        literally and it sums over an empty set, predicting `tp=0 fd=0` where the
+        engine reports `fd=2`.
+        """
+        partly = self._two_items(rejected=1)["fields"]["items"]
+        wholly = self._two_items(rejected=2)["fields"]["items"]
+
+        assert set(partly["fields"]) == set(FIELDS)  # six leaf children to sum
+        assert wholly["fields"] == {}  # nothing to sum
+
+        # A leaf's `aggregate` is its own `overall`, which is where `fd=2` comes from.
+        metrics = ("tp", "fa", "fd", "fp", "tn", "fn")
+        assert [wholly["aggregate"][m] for m in metrics] == [
+            wholly["overall"][m] for m in metrics
+        ]
+
+        # What the retired rule predicted instead, for the record.
+        summed_child_overall = sum(
+            child["overall"]["fd"] for child in wholly["fields"].values()
+        )
+        assert summed_child_overall == 0
+        assert wholly["aggregate"]["fd"] == 2
+
 
 class _Header(StructuredModel):
     """A document with fields BESIDE the list, which is the ordinary shape.
 
     Every other fixture in this file is a model whose only field is the list, and
     that shape hides two things: `overall` at the root sums the node's direct
-    children, so header leaves and item pairings land in one count; and the
-    `aggregate` object-row fallback can fire for the list while the document as a
-    whole is plainly not all-rejected.
+    children, so header leaves and item pairings land in one count; and the list's
+    `aggregate` can switch to object rows while the document as a whole is plainly
+    not all-rejected.
     """
 
     invoice_id: Optional[str] = ComparableField(
@@ -811,11 +1011,145 @@ class TestCoincidingNodesAreNotEvidenceOfAgreement:
         cm = _header_doc(item_count=2, rejected=2)
         assert cm["overall"]["tp"] > 0
 
-    def test_the_list_fields_own_overall_is_the_signal(self):
-        """`tp == 0` on the list node is the condition that actually holds."""
+    def test_the_list_field_is_where_the_condition_shows(self):
+        """It is the list node, not the root, that lost its children.
+
+        `overall['tp'] == 0` also holds here, and was published as the check for a
+        while, but it is not the condition: a primitive field that merely failed has
+        `tp == 0` too. `_documented_unit_label` is the discriminator.
+        """
         cm = _header_doc(item_count=2, rejected=2)
-        assert cm["fields"]["lines"]["overall"]["tp"] == 0
+        lines = cm["fields"]["lines"]
+
+        assert lines["fields"] == {}
+        assert _documented_unit_label(lines) == "object rows"
+        assert _documented_unit_label(cm) == "leaves"
 
     def test_root_precision_reads_as_a_leaf_rate_and_is_not_one(self):
         cm = _header_doc(item_count=2, rejected=2)
         assert cm["aggregate"]["derived"]["cm_precision"] == pytest.approx(0.6)
+
+
+class TestTheUnitLabelPublishedForRankingSections:
+    """The ranking snippet annotates each section with the unit of its counts.
+
+    Round four added that annotation with `data['overall']['tp'] == 0` as the test,
+    which was inherited from a wrong account of the mechanism. A primitive field that
+    failed has `tp == 0`, so the annotation was wrong on precisely the rows a reader
+    scans a ranking for -- the failing ones -- and it also fired for a list that was
+    null on both sides, where no leaves exist either way.
+
+    `_documented_unit_label` is the corrected test, and these pin it in both
+    directions: it must fire on a node that really lost its children, and stay quiet
+    on every node that did not.
+    """
+
+    @staticmethod
+    def _sections(**kwargs):
+        return _header_doc(**kwargs)["fields"]
+
+    def test_a_failing_primitive_is_still_one_leaf(self):
+        """The row the retired check mislabelled."""
+
+        def item(index):
+            return Line(**{name: f"{name}{index}" for name in FIELDS})
+
+        common = {"invoice_id": "i", "date": "d"}
+        gt = _Header(**common, vendor="v", lines=[item(i) for i in range(5)])
+        pred = _Header(**common, vendor="WRONG", lines=[item(i) for i in range(5)])
+        sections = gt.compare_with(pred, include_confusion_matrix=True)[
+            "confusion_matrix"
+        ]["fields"]
+
+        assert sections["vendor"]["overall"]["tp"] == 0  # what the retired check saw
+        assert "fields" not in sections["vendor"]  # a leaf has no `fields` key
+        assert _documented_unit_label(sections["vendor"]) == "leaves"
+
+    def test_an_all_rejected_list_is_not_a_leaf_count(self):
+        sections = self._sections(item_count=2, rejected=2)
+        assert _documented_unit_label(sections["lines"]) == "object rows"
+
+    def test_a_partly_rejected_list_is_still_a_leaf_count(self):
+        sections = self._sections(item_count=2, rejected=1)
+        assert _documented_unit_label(sections["lines"]) == "leaves"
+
+    def test_a_clean_list_is_a_leaf_count(self):
+        sections = self._sections(item_count=5, rejected=0)
+        assert _documented_unit_label(sections["lines"]) == "leaves"
+
+    def test_a_list_null_on_both_sides_has_no_leaves_either_way(self):
+        """`tn=1` and no children, so it is correctly not called a leaf count."""
+        common = {"invoice_id": "i", "vendor": "v", "date": "d"}
+        cm = _Header(**common, lines=None).compare_with(
+            _Header(**common, lines=None), include_confusion_matrix=True
+        )["confusion_matrix"]
+        lines = cm["fields"]["lines"]
+
+        assert (lines["overall"]["tn"], lines["overall"]["tp"]) == (1, 0)
+        assert lines["fields"] == {}
+        assert _documented_unit_label(lines) == "object rows"
+
+    def test_a_nested_object_is_a_leaf_count(self):
+        """It is never gated, so it always still has its children."""
+
+        class Doc(StructuredModel):
+            contact: Optional[_Contact] = ComparableField(default=None, threshold=0.9)
+
+        cm = Doc(contact=_Contact(a="1", b="2", c="3")).compare_with(
+            Doc(contact=_Contact(a="1", b="2", c="WRONG")),
+            include_confusion_matrix=True,
+        )["confusion_matrix"]
+        contact = cm["fields"]["contact"]
+
+        assert contact["overall"]["fd"] == 1  # rejected at the field's own threshold
+        assert set(contact["fields"]) == {"a", "b", "c"}  # and still expanded
+        assert _documented_unit_label(contact) == "leaves"
+
+    def test_both_pages_publish_the_condition_in_prose(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        expected = "`'fields' in node and not node['fields']`"
+
+        for relative in (
+            "docs/docs/Advanced/aggregate-metrics.md",
+            "docs/docs/Guides/Evaluation/understanding-results.md",
+        ):
+            text = (repo_root / relative).read_text()
+            assert expected in text, (
+                f"{relative} no longer names the childless-node condition; the "
+                f"retired `overall['tp'] == 0` is what it drifted back to last time"
+            )
+
+    def test_the_published_snippet_agrees_with_this_helper(self):
+        """Execute the page's own two lines, rather than matching on their text.
+
+        The annotation reached review wrong because it was written into a page that
+        nothing ran. This lifts `childless = ...` and `unit = ...` straight out of the
+        published snippet and checks them against `_documented_unit_label` on every
+        node shape, so the page cannot say something the tests above do not.
+        """
+        repo_root = Path(__file__).resolve().parents[2]
+        page = (
+            repo_root / "docs/docs/Guides/Evaluation/understanding-results.md"
+        ).read_text()
+        childless_expr = re.search(r"^\s*childless = (.+)$", page, re.M)
+        unit_expr = re.search(r"^\s*unit = (.+)$", page, re.M)
+        assert childless_expr and unit_expr, "the ranking snippet lost its unit label"
+
+        def published_label(node: dict) -> str:
+            childless = eval(childless_expr.group(1), {}, {"data": node})  # noqa: S307
+            return eval(unit_expr.group(1), {}, {"childless": childless})  # noqa: S307
+
+        header = _header_doc(item_count=2, rejected=2)
+        clean = _header_doc(item_count=2, rejected=0)
+        nodes = [
+            header,  # the root, which kept its children
+            header["fields"]["lines"],  # all rejected: no children left
+            header["fields"]["vendor"],  # a matching primitive
+            clean["fields"]["lines"],  # a clean list
+            _header_doc(item_count=2, rejected=1)["fields"]["lines"],
+        ]
+        for node in nodes:
+            assert published_label(node) == _documented_unit_label(node)
+
+        # And the labels are not all the same, so the agreement above means something.
+        assert {published_label(node) for node in nodes} == {"leaves", "object rows"}

--- a/tests/structured_object_evaluator/test_rollup_node_semantics.py
+++ b/tests/structured_object_evaluator/test_rollup_node_semantics.py
@@ -14,16 +14,23 @@ whole would be scoring something declared not comparable. A caller who wants
 those leaves counted lowers `match_threshold` so the object qualifies, which
 `test_lowering_match_threshold_exposes_the_leaves` pins.
 
-The two nodes coincide wherever the node being read has no accepted subtree left
-to expand: a model with no nesting, or one whose every nested subtree was rejected.
-One rejected subtree among several usually makes them diverge further rather than
-converge, since `aggregate` then reports a flawless precision over the accepted
-items only, which `test_a_rejected_subtree_separates_the_two_numbers` pins.
+The two nodes coincide whenever every child contributes the same number of rows to
+each: a model with no nesting, a list whose items were all rejected, and also a
+nested object holding exactly one leaf, where the object is one row and its leaf is
+one row. That last case is an ACCEPTED, EXPANDED subtree, so "they coincide only
+where there is nothing left to expand" is not the rule --
+`test_an_accepted_single_leaf_subtree_also_coincides` pins it. One rejected subtree
+among several usually makes them diverge further rather than converge, since
+`aggregate` then reports a flawless precision over the accepted items only, which
+`test_a_rejected_subtree_separates_the_two_numbers` pins.
 
-Coinciding does not mean nothing was hidden. With header fields beside a list whose
-items were all rejected, both root nodes read the same numbers while leaves exist
-that neither counted -- `TestCoincidingNodesAreNotEvidenceOfAgreement` pins that
-shape, because it falsifies the simpler rule this file used to state.
+Coinciding does not mean nothing was hidden, which is the separate and more useful
+point. With header fields beside a list whose items were all rejected, both root
+nodes read the same numbers while leaves exist that neither counted --
+`TestCoincidingNodesAreNotEvidenceOfAgreement` pins that shape. Note what it does
+NOT show: that shape has no accepted subtree either (the header fields are leaves
+and the list is childless), so it is evidence about hiding, not a counter-example to
+the coincidence rule. Conflating the two is what put a false claim on the page.
 
 These tests pin the numbers and the snippet the documentation publishes, so
 neither can go stale:
@@ -185,6 +192,42 @@ def _authored_prose(repo_root: Path):
     )
     for number in range(start, end):
         yield Path("CHANGELOG.md"), number + 1, lines[number]
+
+
+def _phrase_hits(repo_root: Path, banned) -> list:
+    """Every authored line containing a banned phrase, wraps included.
+
+    Matching per line let a phrase hide in a hard wrap. `CHANGELOG.md` is wrapped
+    at ~80 columns, and a banned phrase was already split across two lines there,
+    so the guards below passed while the claim was present. This joins each file's
+    authored lines, collapses runs of whitespace, and reports the line the match
+    STARTS on, so a wrapped phrase is caught and still located.
+    """
+    per_file = {}
+    for path, number, line in _authored_prose(repo_root):
+        per_file.setdefault(path, []).append((number, line))
+
+    offenders = []
+    for path, numbered in per_file.items():
+        # Character offset -> source line, so a hit can be attributed.
+        joined_parts, starts = [], []
+        cursor = 0
+        for number, line in numbered:
+            text = line.strip()
+            starts.append((cursor, number))
+            joined_parts.append(text)
+            cursor += len(text) + 1
+        joined = " ".join(joined_parts).lower()
+        joined = re.sub(r"\s+", " ", joined)
+        for phrase in banned:
+            start = joined.find(phrase)
+            while start != -1:
+                number = next(
+                    (n for off, n in reversed(starts) if off <= start), numbered[0][0]
+                )
+                offenders.append(f"{path}:{number}")
+                start = joined.find(phrase, start + 1)
+    return sorted(set(offenders))
 
 
 def _documented_unit_label(node: dict) -> str:
@@ -551,7 +594,20 @@ class TestTheDocsAndTheEngineCannotDrift:
         for relative in _PAGES_PUBLISHING_THE_CLEAN_CHECK:
             page = repo_root / relative
             assert page.exists(), f"{relative} moved; update this list"
-            text = page.read_text()
+            # `CHANGELOG.md` is read through the same `[Unreleased]`-only window as
+            # `_authored_prose`, not whole. Reading all of it forbade the retired
+            # form anywhere in the file, including a future shipped note quoting it
+            # as history -- which contradicts the policy that shipped notes record
+            # what was said at the time and are not rewritten. It would also break
+            # on archiving old releases into a separate file.
+            if relative == "CHANGELOG.md":
+                text = "\n".join(
+                    line
+                    for path, _, line in _authored_prose(repo_root)
+                    if path == Path("CHANGELOG.md")
+                )
+            else:
+                text = page.read_text()
 
             assert "clean = (" in text, f"{relative} no longer publishes the check"
             for line in expected_lines:
@@ -598,11 +654,7 @@ class TestTheDocsAndTheEngineCannotDrift:
             "own direct classification",
             "unit is the object",
         )
-        offenders = [
-            f"{path}:{number}"
-            for path, number, line in _authored_prose(repo_root)
-            if any(phrase in line.lower() for phrase in banned)
-        ]
+        offenders = _phrase_hits(repo_root, banned)
 
         assert not offenders, (
             "these describe `overall` as a verdict on the node rather than a "
@@ -618,17 +670,35 @@ class TestTheDocsAndTheEngineCannotDrift:
         really is reached, and that a shipped one really is not.
         """
         repo_root = Path(__file__).resolve().parents[2]
-        scanned = {
-            (path, number) for path, number, _ in _authored_prose(repo_root)
-        }
+        scanned = {(path, number) for path, number, _ in _authored_prose(repo_root)}
         changelog = (repo_root / "CHANGELOG.md").read_text().splitlines()
+        # `startswith`, matching `_authored_prose`. Exact equality here meant the
+        # two disagreed the moment the heading gained a suffix (`## [Unreleased] -
+        # TBD`), and a bare `next()` then died with `StopIteration` rather than
+        # saying what was wrong.
         unreleased = next(
-            i for i, line in enumerate(changelog, start=1) if line == "## [Unreleased]"
+            (
+                i
+                for i, line in enumerate(changelog, start=1)
+                if line.startswith("## [Unreleased]")
+            ),
+            None,
+        )
+        assert unreleased is not None, (
+            "CHANGELOG.md has no `## [Unreleased]` heading; `_authored_prose` scans "
+            "that section, so this test and the walker must find it the same way"
         )
         shipped = next(
-            i
-            for i, line in enumerate(changelog, start=1)
-            if line.startswith("## [") and i > unreleased
+            (
+                i
+                for i, line in enumerate(changelog, start=1)
+                if line.startswith("## [") and i > unreleased
+            ),
+            None,
+        )
+        assert shipped is not None, (
+            "CHANGELOG.md has no shipped release heading after `## [Unreleased]`, so "
+            "the not-scanned half of this test cannot be checked"
         )
 
         assert (Path("CHANGELOG.md"), unreleased) in scanned
@@ -660,11 +730,7 @@ class TestTheDocsAndTheEngineCannotDrift:
             "unless every one of them is zero",
             "values are summed instead",
         )
-        offenders = [
-            f"{path}:{number}"
-            for path, number, line in _authored_prose(repo_root)
-            if any(phrase in line.lower() for phrase in banned)
-        ]
+        offenders = _phrase_hits(repo_root, banned)
 
         assert not offenders, (
             "these state that `aggregate` sums its children's `overall` when the "
@@ -996,10 +1062,16 @@ class TestTheRootMixesHeaderLeavesWithItemPairings:
 class TestCoincidingNodesAreNotEvidenceOfAgreement:
     """The two nodes reading alike does not mean nothing was hidden.
 
-    This file used to state that they coincide only where there is no accepted
-    subtree to expand. With correct header fields beside a list whose items were all
-    rejected, both root nodes read the same numbers while an accepted subtree is
-    present and leaves exist that neither counted.
+    With correct header fields beside a list whose items were all rejected, both
+    root nodes read the same numbers while leaves exist that neither counted.
+
+    What this shape does NOT show is that an accepted subtree can be present while
+    the nodes coincide. It has no accepted subtree: the header fields are primitive
+    leaves with no `fields` key, and the list is childless because every item was
+    rejected. An earlier revision claimed otherwise, and named a test
+    `test_and_an_accepted_subtree_is_present` whose only assertion was
+    `overall['tp'] == 3` -- three matched LEAVES, which is not what the name says.
+    That case is `test_an_accepted_single_leaf_subtree_also_coincides` below.
     """
 
     def test_both_root_nodes_read_alike(self):
@@ -1007,10 +1079,17 @@ class TestCoincidingNodesAreNotEvidenceOfAgreement:
         assert (cm["overall"]["tp"], cm["overall"]["fd"]) == (3, 2)
         assert (cm["aggregate"]["tp"], cm["aggregate"]["fd"]) == (3, 2)
 
-    def test_and_an_accepted_subtree_is_present(self):
-        """The condition the retired rule said had to be absent."""
+    def test_no_accepted_subtree_is_present_here(self):
+        """States the shape honestly, rather than asserting its own name away.
+
+        Three primitive leaves (no `fields` key at all) and one childless list. So
+        this is evidence about hiding, not a counter-example to the coincidence rule.
+        """
         cm = _header_doc(item_count=2, rejected=2)
         assert cm["overall"]["tp"] == 3  # the three header leaves matched
+        headers = ["invoice_id", "vendor", "date"]
+        assert all("fields" not in cm["fields"][name] for name in headers)
+        assert cm["fields"]["lines"]["fields"] == {}
 
     def test_while_leaves_neither_node_counted_exist(self):
         """Two items of six fields is twelve leaves; `aggregate` reports five rows."""
@@ -1164,3 +1243,60 @@ class TestTheUnitLabelPublishedForRankingSections:
 
         # And the labels are not all the same, so the agreement above means something.
         assert {published_label(node) for node in nodes} == {"leaves", "object rows"}
+
+
+class TestAnAcceptedSubtreeCanCoincideToo:
+    """The case that actually falsifies "coincide only where nothing is left to expand".
+
+    A nested object holding exactly ONE leaf: the object is one row on `overall` and
+    its single leaf is one row on `aggregate`, so the two agree while the subtree is
+    accepted AND descended into. The published rule characterised coincidence by the
+    absence of an expandable subtree, and this shape has one.
+    """
+
+    @staticmethod
+    def _one_leaf_doc():
+        Kid = type(
+            "Kid",
+            (StructuredModel,),
+            {
+                "__annotations__": {"a": Optional[str]},
+                "match_threshold": 0.5,
+                "a": ComparableField(
+                    comparator=ExactComparator(), threshold=1.0, default=None
+                ),
+            },
+        )
+        Doc = type(
+            "Doc",
+            (StructuredModel,),
+            {
+                "__annotations__": {"kid": Optional[Kid]},
+                "kid": ComparableField(
+                    comparator=ExactComparator(), threshold=1.0, default=None
+                ),
+            },
+        )
+        return Doc, Kid
+
+    def _cm(self):
+        Doc, Kid = self._one_leaf_doc()
+        return Doc(kid=Kid(a="x")).compare_with(
+            Doc(kid=Kid(a="x")), include_confusion_matrix=True
+        )["confusion_matrix"]
+
+    def test_an_accepted_single_leaf_subtree_also_coincides(self):
+        cm = self._cm()
+        assert (cm["overall"]["tp"], cm["overall"]["fd"]) == (1, 0)
+        assert (cm["aggregate"]["tp"], cm["aggregate"]["fd"]) == (1, 0)
+
+    def test_and_that_subtree_really_was_expanded(self):
+        """Without this the case would be indistinguishable from a childless node."""
+        cm = self._cm()
+        assert sorted(cm["fields"]["kid"]["fields"].keys()) == ["a"]
+
+    def test_and_it_really_was_accepted(self):
+        """A rejected subtree would coincide for the uninteresting reason."""
+        cm = self._cm()
+        assert cm["fields"]["kid"]["overall"]["fd"] == 0
+        assert cm["fields"]["kid"]["overall"]["tp"] == 1

--- a/tests/structured_object_evaluator/test_rollup_node_semantics.py
+++ b/tests/structured_object_evaluator/test_rollup_node_semantics.py
@@ -477,6 +477,53 @@ class TestTheDocsAndTheEngineCannotDrift:
                 f"on a value invented against a null ground-truth leaf"
             )
 
+    def test_no_file_describes_overall_as_an_object_verdict(self):
+        """`overall` classifies a node's DIRECT CHILDREN, not the node itself.
+
+        This phrasing survived three review rounds because each round corrected the
+        sites that were cited and not the claim. It is only true where the node's
+        children happen to be objects: on a list field. At the root the children are
+        the root's own fields, so the count mixes leaves with pairings, which
+        `TestTheRootMixesHeaderLeavesWithItemPairings` pins.
+
+        Prose is not usually worth a guard, but this one is the whole subject of the
+        pages, it is published to the API reference through two docstrings, and every
+        recurrence has been a fresh review finding. Historical CHANGELOG entries for
+        already-shipped releases are exempt: they record what was said at the time.
+
+        This file is exempt of necessity, since `banned` below spells the phrases
+        out. That exemption is doing real work rather than being a formality: the
+        module docstring says a list field's `overall` "reads as an object verdict",
+        which is the one context where the phrase is accurate. Read that as the
+        boundary this guard cannot police, not as an oversight.
+        """
+        repo_root = Path(__file__).resolve().parents[2]
+        banned = ("object verdict", "verdicts at", "own direct classification")
+        exempt = {Path("CHANGELOG.md")}
+        offenders = []
+
+        for path in (
+            sorted(repo_root.glob("src/**/*.py"))
+            + sorted(repo_root.glob("docs/**/*.md"))
+            + sorted(repo_root.glob("tests/**/*.py"))
+        ):
+            if path == Path(__file__).resolve():
+                continue
+            if path.relative_to(repo_root) in exempt or ".venv" in path.parts:
+                continue
+            for number, line in enumerate(
+                path.read_text(errors="ignore").splitlines(), start=1
+            ):
+                lowered = line.lower()
+                if any(phrase in lowered for phrase in banned):
+                    offenders.append(f"{path.relative_to(repo_root)}:{number}")
+
+        assert not offenders, (
+            "these describe `overall` as a verdict on the node rather than a "
+            "classification of its direct children, which is false at the root "
+            f"and in both docstrings published to the API reference: {offenders}"
+        )
+
     def test_no_file_anywhere_publishes_the_superseded_form(self):
         """The page walk above cannot see a copy that is not a page.
 

--- a/tests/structured_object_evaluator/test_rollup_node_semantics.py
+++ b/tests/structured_object_evaluator/test_rollup_node_semantics.py
@@ -1,8 +1,11 @@
 """The two confusion-matrix rollup nodes answer two different questions.
 
-`confusion_matrix.overall` gives object verdicts at its own level: was this
-pairing genuine, or spurious. `confusion_matrix.aggregate` gives leaf detail for
-the objects that were comparable.
+`confusion_matrix.overall` classifies a node's direct children. On a list field
+those children are the item pairings, so it reads as an object verdict: was this
+pairing genuine, or spurious. At the root they are the root's own fields, so the
+two units can mix in one count, which `TestTheRootMixesHeaderLeavesWithItemPairings`
+pins. `confusion_matrix.aggregate` gives leaf detail for the objects that were
+comparable.
 
 `match_threshold` is the line between them, and the gating is deliberate. An
 object scoring below it is classified as a single FD, a spurious non-match, and

--- a/tests/structured_object_evaluator/test_rollup_node_semantics.py
+++ b/tests/structured_object_evaluator/test_rollup_node_semantics.py
@@ -468,3 +468,158 @@ class TestTheDocsAndTheEngineCannotDrift:
                 f"{relative} still reads `fa` on `overall` alone, which is clean "
                 f"on a value invented against a null ground-truth leaf"
             )
+
+    def test_no_file_anywhere_publishes_the_superseded_form(self):
+        """The page walk above cannot see a copy that is not a page.
+
+        One survived in `tests/auto/test_risk_surface.py`, under a comment
+        calling it "the reliable question", so the form this file retires was
+        still in the repo as a worked example for the next person to copy. The
+        page walk missed it because it matches on the docs' quoting style and
+        that copy used different variable names. This one is quoting-agnostic:
+        it finds every `clean = (` in the tree and checks the block under it.
+        """
+        repo_root = Path(__file__).resolve().parents[2]
+        offenders = []
+
+        for path in sorted(repo_root.glob("**/*.py")) + sorted(
+            repo_root.glob("docs/**/*.md")
+        ):
+            if path == Path(__file__).resolve() or ".venv" in path.parts:
+                continue
+            lines = path.read_text(errors="ignore").splitlines()
+            for number, line in enumerate(lines):
+                if "clean = (" not in line:
+                    continue
+                block = "\n".join(lines[number : number + 8])
+                # `fa` read from `overall` inside the check is the retired form:
+                # a value invented on a null ground-truth leaf is `fa` on
+                # `aggregate` and leaves `overall` clean, so the check passes on
+                # a hallucination. Sum `fp` on both nodes instead.
+                if '"fa"' in block or "'fa'" in block:
+                    if "overall" in block:
+                        offenders.append(f"{path.relative_to(repo_root)}:{number + 1}")
+
+        assert not offenders, (
+            "these publish a clean check reading `fa` on `overall`, which "
+            f"reports clean on a hallucinated value: {offenders}"
+        )
+
+
+class _Contact(StructuredModel):
+    """A nested object, deliberately not a list element."""
+
+    match_threshold = 0.7
+
+    a: Optional[str] = ComparableField(
+        comparator=ExactComparator(), threshold=1.0, default=None
+    )
+    b: Optional[str] = ComparableField(
+        comparator=ExactComparator(), threshold=1.0, default=None
+    )
+    c: Optional[str] = ComparableField(
+        comparator=ExactComparator(), threshold=1.0, default=None
+    )
+
+
+class TestANestedObjectIsNotThresholdGated:
+    """The gating is a property of list pairing, not of objects.
+
+    The pages said "an object below `match_threshold` is one FD and is not
+    descended into" without qualification. That is true for a
+    `List[StructuredModel]` item, which `StructuredListComparator` pairs and then
+    accepts or rejects. A single nested `StructuredModel` field goes through
+    `FieldComparator`, which has no such stage.
+
+    Two consequences a reader with a nested-object schema needs, and neither was
+    stated: the leaves are always reported, and `match_threshold` is not the knob.
+    The published remedy -- "lower `match_threshold` to get leaf detail for a
+    marginal object" -- was a no-op for this shape.
+    """
+
+    @staticmethod
+    def _compare(field_threshold=None):
+        extra = {} if field_threshold is None else {"threshold": field_threshold}
+
+        class Doc(StructuredModel):
+            contact: Optional[_Contact] = ComparableField(default=None, **extra)
+            name: Optional[str] = ComparableField(
+                comparator=ExactComparator(), threshold=1.0, default=None
+            )
+
+        return Doc(contact=_Contact(a="1", b="2", c="3"), name="n").compare_with(
+            Doc(contact=_Contact(a="1", b="2", c="WRONG"), name="n"),
+            include_confusion_matrix=True,
+        )["confusion_matrix"]
+
+    def test_the_failing_leaf_is_reported_even_when_the_object_is_rejected(self):
+        """`aggregate` shows these leaves; the docs said it hid them."""
+        cm = self._compare(field_threshold=0.9)
+        assert (cm["overall"]["tp"], cm["overall"]["fd"]) == (1, 1)
+        assert (cm["aggregate"]["tp"], cm["aggregate"]["fd"]) == (3, 1)
+
+    def test_the_leaves_are_reported_when_it_is_accepted_too(self):
+        """Same `aggregate` either way, which is the point: nothing is excluded."""
+        cm = self._compare(field_threshold=0.5)
+        assert (cm["overall"]["tp"], cm["overall"]["fd"]) == (2, 0)
+        assert (cm["aggregate"]["tp"], cm["aggregate"]["fd"]) == (3, 1)
+
+    def test_the_field_threshold_is_what_decides_the_verdict(self):
+        boundary = {t: self._compare(field_threshold=t)["overall"] for t in (0.9, 0.5)}
+        assert boundary[0.9]["fd"] == 1
+        assert boundary[0.5]["fd"] == 0
+
+    @pytest.mark.parametrize("match_threshold", (0.9, 0.7, 0.5, 0.1))
+    def test_match_threshold_is_inert_for_this_shape(self, match_threshold):
+        """The retired remedy, pinned as a no-op so it cannot be re-published."""
+        original = _Contact.match_threshold
+        try:
+            _Contact.match_threshold = match_threshold
+            cm = self._compare()
+        finally:
+            _Contact.match_threshold = original
+        assert (cm["overall"]["tp"], cm["overall"]["fd"]) == (2, 0)
+        assert (cm["aggregate"]["tp"], cm["aggregate"]["fd"]) == (3, 1)
+
+
+class TestAllRejectedAggregateCountsObjects:
+    """`aggregate` stops being a leaf count when every subtree is rejected.
+
+    `AggregateMetricsCalculator` falls back to summing children's `overall` when
+    the recursive leaf sum is all-zero, so the unit of the count changes with the
+    data. The page promised "the unit is the leaf" and "primitive field metrics",
+    so dividing an `aggregate` count by a leaf total, or calling its `derived`
+    block leaf-level precision, is wrong on an all-rejected document.
+    """
+
+    @staticmethod
+    def _two_items(rejected: int):
+        def item(index: int, wrong: bool) -> Line:
+            values = {name: f"{name}{index}" for name in FIELDS}
+            if wrong:
+                values["tax"] = "WRONG"
+                values["total"] = "WRONG"
+            return Line(**values)
+
+        class Doc(StructuredModel):
+            items: Optional[List[Line]] = ComparableField(default=None)
+
+        gt = [item(i, False) for i in range(2)]
+        pred = [item(i, i < rejected) for i in range(2)]
+        return Doc(items=gt).compare_with(
+            Doc(items=pred), include_confusion_matrix=True
+        )["confusion_matrix"]
+
+    def test_one_rejected_still_counts_leaves(self):
+        aggregate = self._two_items(rejected=1)["aggregate"]
+        assert (aggregate["tp"], aggregate["fd"]) == (6, 0)
+
+    def test_both_rejected_counts_objects_instead(self):
+        """Twelve leaves exist; `aggregate` reports two rows."""
+        cm = self._two_items(rejected=2)
+        assert (cm["aggregate"]["tp"], cm["aggregate"]["fd"]) == (0, 2)
+        assert (cm["overall"]["tp"], cm["overall"]["fd"]) == (0, 2)
+
+    def test_so_the_two_nodes_agree_only_because_the_unit_changed(self):
+        cm = self._two_items(rejected=2)
+        assert cm["aggregate"]["fd"] == cm["overall"]["fd"] == 2

--- a/tests/structured_object_evaluator/test_rollup_node_semantics.py
+++ b/tests/structured_object_evaluator/test_rollup_node_semantics.py
@@ -586,7 +586,18 @@ class TestTheDocsAndTheEngineCannotDrift:
         boundary this guard cannot police, not as an oversight.
         """
         repo_root = Path(__file__).resolve().parents[2]
-        banned = ("object verdict", "verdicts at", "own direct classification")
+        # "the unit is the object" is here because it is the form that actually
+        # recurred: the phrase-based guard caught `object verdict` and friends
+        # while `aggregate-metrics.md` went on saying "The unit is the object" for
+        # another review round, on the page every cross-link targets. Banning the
+        # concept in one spelling and not the other is how a guard passes while
+        # the claim survives.
+        banned = (
+            "object verdict",
+            "verdicts at",
+            "own direct classification",
+            "unit is the object",
+        )
         offenders = [
             f"{path}:{number}"
             for path, number, line in _authored_prose(repo_root)

--- a/tests/structured_object_evaluator/test_rollup_node_semantics.py
+++ b/tests/structured_object_evaluator/test_rollup_node_semantics.py
@@ -11,11 +11,16 @@ whole would be scoring something declared not comparable. A caller who wants
 those leaves counted lowers `match_threshold` so the object qualifies, which
 `test_lowering_match_threshold_exposes_the_leaves` pins.
 
-The two nodes coincide only where there is no accepted subtree to expand at all: a
-model with no nesting, or a document in which *every* subtree was rejected. One
-rejected subtree among several makes them diverge further rather than converge,
-since `aggregate` then reports a flawless precision over the accepted items only,
-which `test_a_rejected_subtree_separates_the_two_numbers` pins.
+The two nodes coincide wherever the node being read has no accepted subtree left
+to expand: a model with no nesting, or one whose every nested subtree was rejected.
+One rejected subtree among several usually makes them diverge further rather than
+converge, since `aggregate` then reports a flawless precision over the accepted
+items only, which `test_a_rejected_subtree_separates_the_two_numbers` pins.
+
+Coinciding does not mean nothing was hidden. With header fields beside a list whose
+items were all rejected, both root nodes read the same numbers while leaves exist
+that neither counted -- `TestCoincidingNodesAreNotEvidenceOfAgreement` pins that
+shape, because it falsifies the simpler rule this file used to state.
 
 These tests pin the numbers and the snippet the documentation publishes, so
 neither can go stale:
@@ -491,7 +496,19 @@ class TestTheDocsAndTheEngineCannotDrift:
             for number, line in enumerate(lines):
                 if "clean = (" not in line:
                     continue
-                block = "\n".join(lines[number : number + 8])
+                # Only the assignment itself. A fixed window read past the
+                # closing paren, so an ordinary `assert overall["fa"] == 0`
+                # written after a corrected block would fail this test, in
+                # another file, for a reason unrelated to the change being
+                # made. Stop when the parentheses balance.
+                block_lines = []
+                depth = 0
+                for candidate in lines[number:]:
+                    block_lines.append(candidate)
+                    depth += candidate.count("(") - candidate.count(")")
+                    if depth <= 0:
+                        break
+                block = "\n".join(block_lines)
                 # `fa` read from `overall` inside the check is the retired form:
                 # a value invented on a null ground-truth leaf is `fa` on
                 # `aggregate` and leaves `overall` clean, so the check passes on
@@ -623,3 +640,100 @@ class TestAllRejectedAggregateCountsObjects:
     def test_so_the_two_nodes_agree_only_because_the_unit_changed(self):
         cm = self._two_items(rejected=2)
         assert cm["aggregate"]["fd"] == cm["overall"]["fd"] == 2
+
+
+class _Header(StructuredModel):
+    """A document with fields BESIDE the list, which is the ordinary shape.
+
+    Every other fixture in this file is a model whose only field is the list, and
+    that shape hides two things: `overall` at the root sums the node's direct
+    children, so header leaves and item pairings land in one count; and the
+    `aggregate` object-row fallback can fire for the list while the document as a
+    whole is plainly not all-rejected.
+    """
+
+    invoice_id: Optional[str] = ComparableField(
+        comparator=ExactComparator(), threshold=1.0, default=None
+    )
+    vendor: Optional[str] = ComparableField(
+        comparator=ExactComparator(), threshold=1.0, default=None
+    )
+    date: Optional[str] = ComparableField(
+        comparator=ExactComparator(), threshold=1.0, default=None
+    )
+    lines: Optional[List[Line]] = ComparableField(default=None)
+
+
+def _header_doc(item_count: int, rejected: int):
+    def item(index: int, wrong: bool) -> Line:
+        values = {name: f"{name}{index}" for name in FIELDS}
+        if wrong:
+            values["tax"] = "WRONG"
+            values["total"] = "WRONG"
+        return Line(**values)
+
+    common = {"invoice_id": "i", "vendor": "v", "date": "d"}
+    gt = _Header(**common, lines=[item(i, False) for i in range(item_count)])
+    pred = _Header(**common, lines=[item(i, i < rejected) for i in range(item_count)])
+    return gt.compare_with(pred, include_confusion_matrix=True)["confusion_matrix"]
+
+
+class TestTheRootMixesHeaderLeavesWithItemPairings:
+    """`overall` at the root is not a count of list items.
+
+    The published lookup row said "How many list items did the model find? ->
+    `overall`", which is true only of a model whose sole field is the list. Add the
+    header fields a real invoice has and the root count silently becomes the sum of
+    two different units.
+    """
+
+    def test_the_root_count_is_leaves_plus_pairings(self):
+        cm = _header_doc(item_count=5, rejected=0)
+        assert cm["overall"]["tp"] == 8  # 3 header leaves + 5 item pairings
+
+    def test_the_list_field_is_the_node_that_counts_items(self):
+        cm = _header_doc(item_count=5, rejected=0)
+        assert cm["fields"]["lines"]["overall"]["tp"] == 5
+
+    def test_so_the_two_disagree_and_only_one_answers_the_question(self):
+        cm = _header_doc(item_count=5, rejected=0)
+        assert cm["overall"]["tp"] != cm["fields"]["lines"]["overall"]["tp"]
+
+
+class TestCoincidingNodesAreNotEvidenceOfAgreement:
+    """The two nodes reading alike does not mean nothing was hidden.
+
+    This file used to state that they coincide only where there is no accepted
+    subtree to expand. With correct header fields beside a list whose items were all
+    rejected, both root nodes read the same numbers while an accepted subtree is
+    present and leaves exist that neither counted.
+    """
+
+    def test_both_root_nodes_read_alike(self):
+        cm = _header_doc(item_count=2, rejected=2)
+        assert (cm["overall"]["tp"], cm["overall"]["fd"]) == (3, 2)
+        assert (cm["aggregate"]["tp"], cm["aggregate"]["fd"]) == (3, 2)
+
+    def test_and_an_accepted_subtree_is_present(self):
+        """The condition the retired rule said had to be absent."""
+        cm = _header_doc(item_count=2, rejected=2)
+        assert cm["overall"]["tp"] == 3  # the three header leaves matched
+
+    def test_while_leaves_neither_node_counted_exist(self):
+        """Two items of six fields is twelve leaves; `aggregate` reports five rows."""
+        cm = _header_doc(item_count=2, rejected=2)
+        assert cm["aggregate"]["tp"] + cm["aggregate"]["fd"] == 5
+
+    def test_the_document_is_not_all_rejected(self):
+        """So a reader checking the document-level condition is not protected."""
+        cm = _header_doc(item_count=2, rejected=2)
+        assert cm["overall"]["tp"] > 0
+
+    def test_the_list_fields_own_overall_is_the_signal(self):
+        """`tp == 0` on the list node is the condition that actually holds."""
+        cm = _header_doc(item_count=2, rejected=2)
+        assert cm["fields"]["lines"]["overall"]["tp"] == 0
+
+    def test_root_precision_reads_as_a_leaf_rate_and_is_not_one(self):
+        cm = _header_doc(item_count=2, rejected=2)
+        assert cm["aggregate"]["derived"]["cm_precision"] == pytest.approx(0.6)

--- a/tests/structured_object_evaluator/test_rollup_node_semantics.py
+++ b/tests/structured_object_evaluator/test_rollup_node_semantics.py
@@ -37,6 +37,7 @@ deliberately deferred question, not a defect. See
 https://github.com/awslabs/stickler/issues/288
 """
 
+import re
 from pathlib import Path
 from typing import List, Optional
 
@@ -120,6 +121,24 @@ _PAGES_PUBLISHING_THE_CLEAN_CHECK = (
     "docs/docs/Advanced/aggregate-metrics.md",
     "docs/docs/Advanced/threshold-gated-evaluation.md",
     "docs/docs/Guides/Evaluation/understanding-results.md",
+    # Correct today, and nothing was stopping it drifting: the page walk named
+    # only the three doc pages and the repo walk covers `*.py` plus
+    # `docs/**/*.md`, so the release note the snippet ships in was unguarded.
+    "CHANGELOG.md",
+)
+
+# Third-party code is not ours to lint, and a contributor's environment is not
+# always `.venv`. Restricting the walk to the trees we author is both the fix for
+# that and a large speed-up over globbing the repo.
+_TREES_WE_AUTHOR = ("src", "tests", "docs", "examples")
+
+# `overall` and `fa` in ONE subscript chain, in either quoting style, with an
+# optional node variable in front (`cm['overall']['fa']`, `overall["fa"]`).
+# Deliberately not "both words appear in the block": reading `fa` off `aggregate`
+# alongside `fp` off `overall` is correct and must not be flagged.
+_READS_FA_OFF_OVERALL = re.compile(
+    r"""\[\s*['"]overall['"]\s*\]\s*\[\s*['"]fa['"]\s*\]"""
+    r"""|\boverall\s*\[\s*['"]fa['"]\s*\]"""
 )
 
 
@@ -533,14 +552,23 @@ class TestTheDocsAndTheEngineCannotDrift:
         page walk missed it because it matches on the docs' quoting style and
         that copy used different variable names. This one is quoting-agnostic:
         it finds every `clean = (` in the tree and checks the block under it.
+
+        Scoped to the trees we author rather than the whole repo. Globbing
+        `**/*.py` and skipping only `.venv` failed with third-party paths for
+        anyone whose environment is `venv/`, `env/` or `.tox/`, reporting them
+        under a message about stickler's clean check.
         """
         repo_root = Path(__file__).resolve().parents[2]
         offenders = []
 
-        for path in sorted(repo_root.glob("**/*.py")) + sorted(
-            repo_root.glob("docs/**/*.md")
-        ):
-            if path == Path(__file__).resolve() or ".venv" in path.parts:
+        candidates = [
+            path
+            for tree in _TREES_WE_AUTHOR
+            for pattern in ("**/*.py", "**/*.md")
+            for path in repo_root.glob(f"{tree}/{pattern}")
+        ]
+        for path in sorted(set(candidates)):
+            if path == Path(__file__).resolve():
                 continue
             lines = path.read_text(errors="ignore").splitlines()
             for number, line in enumerate(lines):
@@ -559,13 +587,17 @@ class TestTheDocsAndTheEngineCannotDrift:
                     if depth <= 0:
                         break
                 block = "\n".join(block_lines)
-                # `fa` read from `overall` inside the check is the retired form:
-                # a value invented on a null ground-truth leaf is `fa` on
-                # `aggregate` and leaves `overall` clean, so the check passes on
-                # a hallucination. Sum `fp` on both nodes instead.
-                if '"fa"' in block or "'fa'" in block:
-                    if "overall" in block:
-                        offenders.append(f"{path.relative_to(repo_root)}:{number + 1}")
+                # The retired form reads `fa` OFF `overall`, in one subscript
+                # chain: a value invented on a null ground-truth leaf is `fa` on
+                # `aggregate` and leaves `overall` clean, so such a check passes
+                # on a hallucination. Sum `fp` on both nodes instead.
+                #
+                # Matched as one chain rather than as "both words appear
+                # somewhere in the block", which condemned a correct check that
+                # happens to read `fa` off the OTHER node -- for example
+                # `cm['overall']['fp'] == 0 and cm['aggregate']['fa'] == 0`.
+                if _READS_FA_OFF_OVERALL.search(block):
+                    offenders.append(f"{path.relative_to(repo_root)}:{number + 1}")
 
         assert not offenders, (
             "these publish a clean check reading `fa` on `overall`, which "

--- a/tests/structured_object_evaluator/test_rollup_node_semantics.py
+++ b/tests/structured_object_evaluator/test_rollup_node_semantics.py
@@ -230,26 +230,34 @@ def _phrase_hits(repo_root: Path, banned) -> list:
     return sorted(set(offenders))
 
 
-def _documented_unit_label(node: dict) -> str:
+def _documented_unit_label(node: dict, *, is_object_list: bool) -> str:
     """Is this node's `aggregate` a count of leaves? The check the pages publish.
 
-    A primitive field has no `fields` key at all. A structured node -- a nested
-    object, or a list -- always has one, and it is empty exactly when there was
-    nothing to descend into: every item was rejected, or the field was null on both
-    sides. `AggregateMetricsCalculator` decides leaf versus parent on precisely that,
-    so this is the condition under which `aggregate` stops being a leaf count.
+    The unit CANNOT be derived from the confusion matrix. Measured:
 
-    The retired form was `node['overall']['tp'] == 0`, which is also true of a
-    primitive field that simply failed -- one leaf, and never anything else -- so it
-    mislabelled exactly the rows a reader scans a ranking for.
+        prims      (List[str], one element wrong)   fields={}  aggregate tp=1 fd=1
+        items_bad  (List[Model], item rejected)     fields={}  aggregate tp=0 fd=1
+
+    The first is two element comparisons, which are leaves; the second is one
+    rejected object. Both are childless structured nodes with non-zero counts, so
+    `"fields" in node and not node["fields"]` -- the form this replaces -- called the
+    primitive list's leaf counts "object rows". It also mislabelled a scalar that was
+    null on both sides, which carries `fields == {}` as well.
+
+    The earlier form before that, `node["overall"]["tp"] == 0`, was wrong in the
+    other direction: true of a primitive field that simply failed.
+
+    So the caller has to supply what only the schema knows -- whether the field is a
+    `List[StructuredModel]` -- and `overall["tp"] == 0` then means every item was
+    rejected.
 
     Published in:
 
         docs/docs/Advanced/aggregate-metrics.md#aggregate-counts-objects-for-an-all-rejected-list
         docs/docs/Guides/Evaluation/understanding-results.md  (prose and snippet)
     """
-    childless_structured = "fields" in node and not node["fields"]
-    return "object rows" if childless_structured else "leaves"
+    counts_objects = is_object_list and node["overall"]["tp"] == 0
+    return "object rows" if counts_objects else "leaves"
 
 
 def _documented_clean_check(cm: dict) -> bool:
@@ -1023,7 +1031,15 @@ class _Header(StructuredModel):
     lines: Optional[List[Line]] = ComparableField(default=None)
 
 
-def _header_doc(item_count: int, rejected: int):
+def _header_doc(item_count: int, rejected: int, vendor_wrong: bool = False):
+    """Three header leaves beside a list of `item_count` items, `rejected` of them bad.
+
+    `vendor_wrong` breaks one HEADER field. Needed because a correct header leaf has
+    `overall['tp'] == 1`, so a document built without it cannot tell the published
+    unit condition from the retired `overall['tp'] == 0` one -- the failing primitive
+    is the only node where those two disagree.
+    """
+
     def item(index: int, wrong: bool) -> Line:
         values = {name: f"{name}{index}" for name in FIELDS}
         if wrong:
@@ -1031,10 +1047,33 @@ def _header_doc(item_count: int, rejected: int):
             values["total"] = "WRONG"
         return Line(**values)
 
-    common = {"invoice_id": "i", "vendor": "v", "date": "d"}
-    gt = _Header(**common, lines=[item(i, False) for i in range(item_count)])
-    pred = _Header(**common, lines=[item(i, i < rejected) for i in range(item_count)])
+    common = {"invoice_id": "i", "date": "d"}
+    gt = _Header(
+        **common, vendor="v", lines=[item(i, False) for i in range(item_count)]
+    )
+    pred = _Header(
+        **common,
+        vendor="WRONG" if vendor_wrong else "v",
+        lines=[item(i, i < rejected) for i in range(item_count)],
+    )
     return gt.compare_with(pred, include_confusion_matrix=True)["confusion_matrix"]
+
+
+def _primitive_list_doc():
+    """A `List[str]` with one of two elements wrong.
+
+    Childless with non-zero `aggregate` counts, exactly like an all-rejected object
+    list, and yet its rows are element comparisons, which are leaves. The pair of
+    shapes the published unit condition has to tell apart without help from the
+    matrix, because the matrix cannot tell them apart.
+    """
+
+    class Doc(StructuredModel):
+        tags: Optional[List[str]] = ComparableField(default=None)
+
+    return Doc(tags=["a", "b"]).compare_with(
+        Doc(tags=["a", "Z"]), include_confusion_matrix=True
+    )["confusion_matrix"]
 
 
 class TestTheRootMixesHeaderLeavesWithItemPairings:
@@ -1106,14 +1145,17 @@ class TestCoincidingNodesAreNotEvidenceOfAgreement:
 
         `overall['tp'] == 0` also holds here, and was published as the check for a
         while, but it is not the condition: a primitive field that merely failed has
-        `tp == 0` too. `_documented_unit_label` is the discriminator.
+        `tp == 0` too. `_documented_unit_label` is the discriminator, and it needs
+        the schema's answer for the field, which is why `is_object_list` is passed
+        explicitly on both calls -- `lines` is a `List[StructuredModel]`, the root
+        document is not a list at all.
         """
         cm = _header_doc(item_count=2, rejected=2)
         lines = cm["fields"]["lines"]
 
         assert lines["fields"] == {}
-        assert _documented_unit_label(lines) == "object rows"
-        assert _documented_unit_label(cm) == "leaves"
+        assert _documented_unit_label(lines, is_object_list=True) == "object rows"
+        assert _documented_unit_label(cm, is_object_list=False) == "leaves"
 
     def test_root_precision_reads_as_a_leaf_rate_and_is_not_one(self):
         cm = _header_doc(item_count=2, rejected=2)
@@ -1123,15 +1165,20 @@ class TestCoincidingNodesAreNotEvidenceOfAgreement:
 class TestTheUnitLabelPublishedForRankingSections:
     """The ranking snippet annotates each section with the unit of its counts.
 
-    Round four added that annotation with `data['overall']['tp'] == 0` as the test,
-    which was inherited from a wrong account of the mechanism. A primitive field that
-    failed has `tp == 0`, so the annotation was wrong on precisely the rows a reader
-    scans a ranking for -- the failing ones -- and it also fired for a list that was
-    null on both sides, where no leaves exist either way.
+    Two earlier forms of that annotation were wrong in opposite directions:
 
-    `_documented_unit_label` is the corrected test, and these pin it in both
-    directions: it must fire on a node that really lost its children, and stay quiet
-    on every node that did not.
+        node["overall"]["tp"] == 0            also true of a FAILING PRIMITIVE
+        "fields" in node and not node["fields"]   also true of a PRIMITIVE LIST
+
+    The second is the subtler one and is why the annotation now needs the schema. A
+    `List[str]` with one element wrong and a `List[Model]` with its only item
+    rejected are indistinguishable in the confusion matrix -- both `fields == {}`
+    with non-zero counts -- yet the first is element comparisons, which are leaves,
+    and the second is one row per rejected object. A scalar null on both sides also
+    carries `fields == {}`.
+
+    So `_documented_unit_label` takes `is_object_list` from the caller, which is what
+    only the model knows, and these pin it in both directions.
     """
 
     @staticmethod
@@ -1139,7 +1186,7 @@ class TestTheUnitLabelPublishedForRankingSections:
         return _header_doc(**kwargs)["fields"]
 
     def test_a_failing_primitive_is_still_one_leaf(self):
-        """The row the retired check mislabelled."""
+        """The row the first retired check mislabelled."""
 
         def item(index):
             return Line(**{name: f"{name}{index}" for name in FIELDS})
@@ -1151,24 +1198,79 @@ class TestTheUnitLabelPublishedForRankingSections:
             "confusion_matrix"
         ]["fields"]
 
-        assert sections["vendor"]["overall"]["tp"] == 0  # what the retired check saw
+        assert sections["vendor"]["overall"]["tp"] == 0  # what the first check saw
         assert "fields" not in sections["vendor"]  # a leaf has no `fields` key
-        assert _documented_unit_label(sections["vendor"]) == "leaves"
+        assert (
+            _documented_unit_label(sections["vendor"], is_object_list=False) == "leaves"
+        )
+
+    def test_a_primitive_list_is_a_leaf_count(self):
+        """The row the second retired check mislabelled.
+
+        Two elements, one wrong: `aggregate tp=1 fd=1` really is two ELEMENT
+        comparisons, and an element of a primitive list is a leaf. The node is
+        childless all the same, so a check keyed on that called it object rows.
+        """
+
+        class Doc(StructuredModel):
+            tags: Optional[List[str]] = ComparableField(default=None)
+
+        cm = Doc(tags=["a", "b"]).compare_with(
+            Doc(tags=["a", "Z"]), include_confusion_matrix=True
+        )["confusion_matrix"]
+        tags = cm["fields"]["tags"]
+
+        assert tags["fields"] == {}  # childless, like an all-rejected object list
+        assert (tags["aggregate"]["tp"], tags["aggregate"]["fd"]) == (1, 1)
+        assert _documented_unit_label(tags, is_object_list=False) == "leaves"
+
+    def test_the_two_shapes_are_indistinguishable_in_the_matrix(self):
+        """Why the schema has to supply the answer, stated as an assertion.
+
+        If these two ever became distinguishable, the annotation could be derived
+        again and this whole parameter could go.
+        """
+
+        class Doc(StructuredModel):
+            tags: Optional[List[str]] = ComparableField(default=None)
+            rows: Optional[List[Line]] = ComparableField(default=None)
+
+        wrong = Line(**{**{n: f"{n}0" for n in FIELDS}, "tax": "X", "total": "X"})
+        cm = Doc(
+            tags=["a", "b"], rows=[Line(**{n: f"{n}0" for n in FIELDS})]
+        ).compare_with(
+            Doc(tags=["a", "Z"], rows=[wrong]), include_confusion_matrix=True
+        )["confusion_matrix"]
+
+        tags, rows = cm["fields"]["tags"], cm["fields"]["rows"]
+        assert tags["fields"] == rows["fields"] == {}
+        assert tags["aggregate"]["tp"] + tags["aggregate"]["fd"] > 0
+        assert rows["aggregate"]["tp"] + rows["aggregate"]["fd"] > 0
+        # Same shape, different unit. Only the annotation tells them apart.
+        assert _documented_unit_label(tags, is_object_list=False) == "leaves"
+        assert _documented_unit_label(rows, is_object_list=True) == "object rows"
 
     def test_an_all_rejected_list_is_not_a_leaf_count(self):
         sections = self._sections(item_count=2, rejected=2)
-        assert _documented_unit_label(sections["lines"]) == "object rows"
+        assert _documented_unit_label(sections["lines"], is_object_list=True) == (
+            "object rows"
+        )
 
     def test_a_partly_rejected_list_is_still_a_leaf_count(self):
         sections = self._sections(item_count=2, rejected=1)
-        assert _documented_unit_label(sections["lines"]) == "leaves"
+        assert (
+            _documented_unit_label(sections["lines"], is_object_list=True) == "leaves"
+        )
 
     def test_a_clean_list_is_a_leaf_count(self):
         sections = self._sections(item_count=5, rejected=0)
-        assert _documented_unit_label(sections["lines"]) == "leaves"
+        assert (
+            _documented_unit_label(sections["lines"], is_object_list=True) == "leaves"
+        )
 
-    def test_a_list_null_on_both_sides_has_no_leaves_either_way(self):
-        """`tn=1` and no children, so it is correctly not called a leaf count."""
+    def test_a_list_null_on_both_sides_reports_no_rows_at_all(self):
+        """`tn=1` and no children. Calling it either unit is vacuous, but it must
+        not be reported as a leaf rate, since there are no leaves."""
         common = {"invoice_id": "i", "vendor": "v", "date": "d"}
         cm = _Header(**common, lines=None).compare_with(
             _Header(**common, lines=None), include_confusion_matrix=True
@@ -1177,7 +1279,8 @@ class TestTheUnitLabelPublishedForRankingSections:
 
         assert (lines["overall"]["tn"], lines["overall"]["tp"]) == (1, 0)
         assert lines["fields"] == {}
-        assert _documented_unit_label(lines) == "object rows"
+        assert lines["aggregate"]["tp"] + lines["aggregate"]["fd"] == 0
+        assert _documented_unit_label(lines, is_object_list=True) == "object rows"
 
     def test_a_nested_object_is_a_leaf_count(self):
         """It is never gated, so it always still has its children."""
@@ -1193,56 +1296,94 @@ class TestTheUnitLabelPublishedForRankingSections:
 
         assert contact["overall"]["fd"] == 1  # rejected at the field's own threshold
         assert set(contact["fields"]) == {"a", "b", "c"}  # and still expanded
-        assert _documented_unit_label(contact) == "leaves"
+        assert _documented_unit_label(contact, is_object_list=False) == "leaves"
 
-    def test_both_pages_publish_the_condition_in_prose(self):
+    def test_both_pages_say_the_unit_cannot_be_derived_from_the_matrix(self):
+        """Both claims, matched on their full phrases rather than on substrings.
+
+        An earlier version of this guard tested for `"cannot be"`, which
+        `aggregate-metrics.md` also contains in an unrelated sentence about the
+        all-zero fallback, so deleting the actual claim left the guard passing.
+        Whitespace is collapsed first so a reflow across a line break still matches.
+        """
         repo_root = Path(__file__).resolve().parents[2]
-        expected = "`'fields' in node and not node['fields']`"
-
+        required = (
+            "cannot be derived from the confusion matrix",
+            "list of primitives",
+        )
         for relative in (
             "docs/docs/Advanced/aggregate-metrics.md",
             "docs/docs/Guides/Evaluation/understanding-results.md",
         ):
-            text = (repo_root / relative).read_text()
-            assert expected in text, (
-                f"{relative} no longer names the childless-node condition; the "
-                f"retired `overall['tp'] == 0` is what it drifted back to last time"
-            )
+            page = repo_root / relative
+            assert page.exists(), page
+            text = " ".join(page.read_text().split()).lower()
+            for phrase in required:
+                assert phrase in text, (
+                    f"{relative} no longer says '{phrase}'. The unit cannot be read "
+                    f"off the matrix, and both derived conditions published before "
+                    f"this were wrong, in opposite directions."
+                )
 
     def test_the_published_snippet_agrees_with_this_helper(self):
-        """Execute the page's own two lines, rather than matching on their text.
+        """Execute the page's own lines rather than matching on their text.
 
-        The annotation reached review wrong because it was written into a page that
-        nothing ran. This lifts `childless = ...` and `unit = ...` straight out of the
-        published snippet and checks them against `_documented_unit_label` on every
-        node shape, so the page cannot say something the tests above do not.
+        Both wrong annotations reached review because they were written into a page
+        that nothing ran. This lifts the published condition out of the snippet and
+        checks it against `_documented_unit_label` on every node shape.
         """
         repo_root = Path(__file__).resolve().parents[2]
         page = (
             repo_root / "docs/docs/Guides/Evaluation/understanding-results.md"
         ).read_text()
-        childless_expr = re.search(r"^\s*childless = (.+)$", page, re.M)
-        unit_expr = re.search(r"^\s*unit = (.+)$", page, re.M)
-        assert childless_expr and unit_expr, "the ranking snippet lost its unit label"
+        cond = re.search(r"^\s*counts_objects = (.+)$", page, re.M)
+        unit = re.search(r"^\s*unit = (.+)$", page, re.M)
+        assert cond and unit, "the ranking snippet lost its unit label"
 
-        def published_label(node: dict) -> str:
-            childless = eval(childless_expr.group(1), {}, {"data": node})  # noqa: S307
-            return eval(unit_expr.group(1), {}, {"childless": childless})  # noqa: S307
+        def published_label(node: dict, section: str, object_lists: set) -> str:
+            counts_objects = eval(  # noqa: S307
+                cond.group(1),
+                {},
+                {"data": node, "section": section, "OBJECT_LISTS": object_lists},
+            )
+            return eval(unit.group(1), {}, {"counts_objects": counts_objects})  # noqa: S307
 
         header = _header_doc(item_count=2, rejected=2)
         clean = _header_doc(item_count=2, rejected=0)
-        nodes = [
-            header,  # the root, which kept its children
-            header["fields"]["lines"],  # all rejected: no children left
-            header["fields"]["vendor"],  # a matching primitive
-            clean["fields"]["lines"],  # a clean list
-            _header_doc(item_count=2, rejected=1)["fields"]["lines"],
+        partial = _header_doc(item_count=2, rejected=1)
+        # A header field that FAILED. This is the discriminating case: it is the only
+        # node where the published condition and the retired `overall['tp'] == 0`
+        # form disagree, so without it the snippet could drop `section in
+        # OBJECT_LISTS` and every assertion here would still pass. Verified: with
+        # that guard removed, this case is what fails.
+        failed_leaf = _header_doc(item_count=2, rejected=0, vendor_wrong=True)
+        # A list of PRIMITIVES that is childless with non-zero counts, which is the
+        # shape the other retired form (`'fields' in data and not data['fields']`)
+        # mislabelled.
+        primitive_list = _primitive_list_doc()
+        cases = [
+            (header["fields"]["lines"], "lines", {"lines"}),
+            (clean["fields"]["lines"], "lines", {"lines"}),
+            (partial["fields"]["lines"], "lines", {"lines"}),
+            (header["fields"]["vendor"], "vendor", {"lines"}),
+            (failed_leaf["fields"]["vendor"], "vendor", {"lines"}),
+            (primitive_list["fields"]["tags"], "tags", {"lines"}),
+            (header, "root", {"lines"}),
         ]
-        for node in nodes:
-            assert published_label(node) == _documented_unit_label(node)
+        assert failed_leaf["fields"]["vendor"]["overall"]["tp"] == 0, (
+            "the discriminating case must actually have tp == 0, or it discriminates "
+            "nothing"
+        )
+        assert primitive_list["fields"]["tags"]["fields"] == {}, (
+            "the primitive-list case must actually be childless"
+        )
+        for node, section, object_lists in cases:
+            assert published_label(node, section, object_lists) == (
+                _documented_unit_label(node, is_object_list=section in object_lists)
+            ), section
 
-        # And the labels are not all the same, so the agreement above means something.
-        assert {published_label(node) for node in nodes} == {"leaves", "object rows"}
+        labels = {published_label(n, s, o) for n, s, o in cases}
+        assert labels == {"leaves", "object rows"}
 
 
 class TestAnAcceptedSubtreeCanCoincideToo:


### PR DESCRIPTION
Closes the documentation half of #288.

## The problem

`confusion_matrix.overall` and `confusion_matrix.aggregate` were described only mechanically:

> **`overall`** reflects this node's own direct classification.
> **`aggregate`** sums all primitive-field classifications beneath this node.

Both accurate, and no help. Nothing said which to read for which question, or that they diverge on any model with nesting. So consumers picked by guessing, and the AWS Solutions Library IDP Accelerator picked `overall`, which scores 100% on any document whose line items merely paired ([their #625](https://github.com/aws-solutions-library-samples/accelerated-intelligent-document-processing-on-aws/issues/625), surfacing as a parent field showing a tick while its own drilldown showed a cross).

## What the nodes actually are

They are the two stages of the evaluation:

- **`overall` is detection.** Unit is the object. Did we find the right things?
- **`aggregate` is extraction.** Unit is the leaf. Among objects established to be the same object, were the values right?

`match_threshold` is the handoff, and it is really the definition of "the same object". Above it, grading the fields is meaningful. Below it, grading them would be scoring the fields of a *different* object, so such an object is one FD and is not descended into.

Five line items of six fields each, one field wrong. The item scores 5/6 and is comparable:

```
overall_score   0.9667

cm['overall']     tp=5   fd=0   P=1.0000  R=1.0000  F1=1.0000
cm['aggregate']   tp=29  fd=1   P=0.9667  R=1.0000  F1=0.9831
```

Five objects found, none spurious. Thirty leaves, one wrong. Both numbers correct for their own question.

Drop the same item to 4/6 and it is no longer the same object:

```
cm['overall']     tp=0   fd=1
cm['aggregate']   tp=0   fd=1
```

The nodes now agree, because there is no accepted subtree to expand. They coincide in exactly two situations: a flat model, and a subtree rejected outright.

## Grounding this in mAP rather than arguing it

This is the same match-then-score structure as mean Average Precision, which **this repo already implements** for bounding boxes. `docs/docs/Advanced/bbox-map-metrics.md:191` already states the same rule for IoU:

> A below-threshold detection counts as both a false positive and a false negative (the prediction is in the wrong place, and the ground-truth box is left unmatched).

So the rule is not new and not specific to objects; the objects path was simply the one without an explanation. Both new sections cross-link to `bbox-map-metrics.md#iou-thresholds` instead of re-arguing it. Nobody expects an unmatched detection to contribute per-attribute errors, and the reasoning is identical.

## Getting leaf detail for a marginal object

The knob is `match_threshold` itself, which the docs now say and a test pins:

```
match_threshold   comparable?   aggregate
0.70              no            tp=0 fd=1
0.66              yes           tp=4 fd=2
```

## What changed

| file | change |
|---|---|
| `docs/docs/Guides/Evaluation/understanding-results.md` | rewrote the `overall` vs `aggregate` section: both examples, the remedy table, a which-node-for-which-question table, the two-node failure check |
| `docs/docs/Advanced/aggregate-metrics.md` | new "Which node answers which question" section under the existing mechanical note |
| `docs/docs/Advanced/classification-logic.md` | one paragraph noting the derived metrics are per node, so the node choice changes the precision you report |
| `compare_with()` docstrings | `structured_model.py` and `comparison_engine.py`, both published to the API reference |
| `tests/structured_object_evaluator/test_rollup_node_semantics.py` | new, 9 tests |

## Tests

The new file pins the numbers this PR publishes, so the pages cannot go stale, plus the behaviour they describe:

- the worked example's counts and all three derived metrics on both nodes
- that `overall_score` tracks `aggregate` and not `overall` (the claim the docs rest on)
- that a rejected object reports itself and not its leaves, and that leaf rows stop as soon as an object drops below the threshold
- that lowering `match_threshold` exposes those leaves, which is the documented remedy
- the flat-model case where the nodes converge, which is why this is easy to miss

## Not in scope

`EvalResult.precision`, `.recall`, `.f1` and `.accuracy` read `overall.derived`, so they are the object-level metrics. On the example above `result.precision` is `1.0` beside an `overall_score` of `0.9667` on the same object. That is two correct answers to two different questions, and it is documented here rather than changed.

What #288 still leaves open for 1.0 is **naming**. `overall` reads as "everything" when it means "one level, one unit". `by_object` / `by_field` or `detection` / `extraction` would carry the distinction that the current names actively hide. Renaming is breaking, so it is a 1.0 decision and not this PR.

Whether aggregates should also count the leaves of below-threshold objects is a separately deferred question, and is deliberately not treated here as a defect.

## Verification

- `1975 passed, 2 skipped`
- `ruff check` clean
- `mkdocs build --strict` adds no new warnings (it already fails on 9 pre-existing griffe and autorefs findings in untouched files, count identical to `dev`)
- both new cross-links verified to resolve against the `#iou-thresholds` anchor in the built site

## Merge order

Please land #290 first. Both branches edit `understanding-results.md` in adjacent sections, so git should merge them cleanly, but I would rather reread the merged page as a whole than trust the diff. I will rebase this onto `dev` once #290 is in.
