### PR TITLE
Fix/233 score source parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,58 @@ Each release links to full notes on the
 
 ## [Unreleased]
 
+### Fixed
+
+- `overall_score` and the confusion matrix no longer disagree about a field that
+  is absent on both sides. The two read different scores for the same object
+  pair: `overall_score` takes the threshold-corrected score, while object
+  classification against `match_threshold` takes the raw pairwise similarity.
+  The raw path tested absence with a bare `is None`, so it scored `[]` against
+  `None` on a list field, `""` against `None` on a string field, and two empty
+  lists against each other all as `0.0` -- while `ComparisonDispatcher` scored
+  every one of those as a true negative worth `1.0`.
+
+  The result was a pair reported as `overall_score == 1.0` and `fd == 1` at once:
+  a perfect match that is also a false discovery. Two **identical** objects were
+  enough to trigger it. Any `List[Model]` whose element model declares an
+  optional list or string field reaches this whenever that field is left absent
+  on both sides, which for a document-extraction schema is the common case, not
+  an edge one -- and the contradiction is invisible unless you read both numbers
+  together, so it silently deflated precision on object-level metrics.
+
+  Both readers now define absence the same way the dispatcher does, per field
+  kind: `None` and `[]` for a list field, `None` and `""` for everything else.
+  This is the rule the docs already
+  [documented](https://awslabs.github.io/stickler/Advanced/classification-logic/)
+  ([#233](https://github.com/awslabs/stickler/issues/233))
+
+- A field annotated `list`, `list | None`, or `Optional[list]` is now recognized
+  as a list field. `_is_list_field` tested `get_origin(...) is list`, which
+  matches only a *parameterized* spelling, so the three unparameterized ones
+  answered `False` while `List`, `list[str] | None`, and `Optional[List[str]]`
+  answered `True`. `list | None` is the incongruous case: it is a PEP 604
+  optional list, and `list[str] | None` was already handled.
+
+  An unrecognized spelling skips list null handling and falls into the primitive
+  null check, where `[]` is not "effectively null". Such a field scored `1.0`
+  when empty on both sides but recorded **no classification evidence at all** --
+  no TN, no TP, no row. Because the score was right, the missing count was easy
+  to miss; it understated `tn` and every metric derived from it. Comparing a
+  six-field model against itself with every field `[]` reported `tn == 3` where
+  the docs call for `6`.
+
+  Recognition is now spelling-independent within a union: bare and parameterized
+  members answer alike. Only the null and empty cases move -- a populated list
+  reached `PrimitiveListComparator` before and still does, and no raw score
+  changes.
+
+  Two spellings are still not list fields, both deliberately. `Any` holding a
+  list is not one, because inferring list-ness from a runtime value rather than
+  an annotation is a larger change than this. Neither is
+  `Optional[Annotated[list, ...]]`: pydantic strips `Annotated` when it wraps the
+  whole annotation but preserves it as a union member, and unwrapping it should
+  be made consistent across the other annotation readers rather than here alone
+
 ### Changed
 
 - Confidence AUROC and document-splitting statistics now use NumPy
@@ -16,6 +68,34 @@ Each release links to full notes on the
   `scikit-learn` is no longer a core dependency, and the `docsplit` extra now
   adds only pandas; SciPy remains isolated to the `semantic` extra
   ([#216](https://github.com/awslabs/stickler/issues/216)).
+
+- Object-level TP/FD counts move for schemas with fields that are absent on both
+  sides. An absent-on-both field now contributes a full `1.0` to the raw object
+  similarity that `HungarianHelper` classifies against `match_threshold`, so a
+  pair that disagrees on every value a user actually supplied can clear the
+  threshold on the strength of its absent fields alone. An object with two
+  empty-on-both lists and one wrong string scores `2/3`; with five, `5/6`. Pairs
+  that previously classified as FD can now classify as TP, and **precision can
+  rise** as a function of how many absent optional fields a schema declares.
+
+  This extends existing semantics rather than introducing them. A field left
+  `None` already behaved exactly this way -- only the `[]` and `""` spellings
+  were scored differently, which is precisely the inconsistency
+  [#233](https://github.com/awslabs/stickler/issues/233) is about. Making them
+  agree necessarily means `[]` and `""` adopt what `None` already did.
+
+  Field-level counts do not move: an absent-on-both field is still a TN rather
+  than a TP, and a field the prediction gets wrong is still reported as an FD in
+  both the field breakdown and the aggregate. Only the *object-level*
+  classification of the enclosing pair changes. Anyone diffing evaluation
+  reports across this upgrade should expect object-level precision to shift for
+  affected schemas.
+
+  Absence is not leniency: `""` did not become a wildcard. An absent value
+  against a populated one still scores `0.0`, as the dispatcher already scored
+  it. A custom comparator that scored `""` against a populated value above `0.0`
+  is now short-circuited to `0.0` on the raw path, matching what `compare_with`
+  already reported for that pair.
 
 ## [0.7.0] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,50 @@ Each release links to full notes on the
   together, so it silently deflated precision on object-level metrics.
 
   Both readers now define absence the same way the dispatcher does, per field
-  kind: `None` and `[]` for a list field, `None` and `""` for everything else.
-  This is the rule the docs already
+  kind: `None` and `[]` for a list field, `None`, `""` and `{}` for everything
+  else. This is the rule the docs already
   [documented](https://awslabs.github.io/stickler/Advanced/classification-logic/)
   ([#233](https://github.com/awslabs/stickler/issues/233))
+
+- An empty dict is now read as absent, the third case that documented rule
+  names. `NullHelper.is_effectively_null_for_primitives` covered `None` and `""`
+  but not `{}`, so the #233 contradiction survived for a `Dict` field in the
+  opposite direction: two **identical** objects each holding `{}` classified as
+  a false discovery instead of a match, and `{}` against `None` recorded an FN
+  while `None` against `{}` recorded an FA, where the rule calls for a TN in all
+  three.
+
+  A populated dict field was worse than misclassified, it was unscoreable. No
+  comparator accepts a dict -- `LevenshteinComparator` raises `TypeError`
+  pointing at `StructuredModel` instead -- so `{}` against `{"k": "v"}` fell
+  through to the comparator and *raised*, taking out Hungarian matching for any
+  `List[Model]` whose element model had a populated dict field. That pair is now
+  an ordinary false alarm.
+
+  Two **populated** dicts still reach the comparator and still raise. Giving
+  dicts a comparator is a separate change; this one only closes the absence
+  cases.
+
+- A field annotated `Optional[Annotated[List[str], ...]]` is now recognized as a
+  list field. Pydantic strips `Annotated` when it wraps a whole annotation, so
+  `Annotated[Optional[List[str]], ...]` always worked, but it leaves the wrapper
+  on a union arm -- and `get_origin` reports `Annotated` there rather than the
+  type inside. `Annotated[List[str], ...] | None` normalises to exactly that
+  spelling, so both PEP 604 and subscript forms were affected.
+
+  This is the annotation a `Field(description=...)` produces, which makes it
+  common in extraction schemas rather than exotic. The cost landed three
+  different ways on one field, all silent: `[]` against `[]` recorded **no
+  counter at all** and the field vanished from the confusion matrix, `[]`
+  against `None` recorded an FN, and `None` against `[]` recorded an FA -- while
+  a sibling `Optional[List[str]]` recorded a TN for all three.
+
+  Union arms are unwrapped through a new shared
+  `optional_annotation.unwrap_annotated`, alongside the existing helpers for
+  destructuring a union, rather than a fourth hand-rolled check. Routing is
+  unaffected: `List[Model]` on this spelling already reached
+  `StructuredListComparator` through the dispatcher's runtime type check, so
+  only the null and empty cases move.
 
 - A field annotated `list`, `list | None`, or `Optional[list]` is now recognized
   as a list field. `_is_list_field` tested `get_origin(...) is list`, which
@@ -54,12 +94,27 @@ Each release links to full notes on the
   reached `PrimitiveListComparator` before and still does, and no raw score
   changes.
 
-  Two spellings are still not list fields, both deliberately. `Any` holding a
-  list is not one, because inferring list-ness from a runtime value rather than
-  an annotation is a larger change than this. Neither is
-  `Optional[Annotated[list, ...]]`: pydantic strips `Annotated` when it wraps the
-  whole annotation but preserves it as a union member, and unwrapping it should
-  be made consistent across the other annotation readers rather than here alone
+  One spelling is still not a list field, deliberately: `Any` holding a list.
+  Inferring list-ness from a runtime value rather than an annotation is a
+  different question from reading a spelling correctly, and every caller here
+  has only the annotation.
+
+### Performance
+
+- Restored the fast path in `ComparisonHelper.compare_field_raw`. Reading a
+  field's absence rule requires knowing whether the field is a list, and
+  `_is_list_field` re-reads `model_fields` and destructures the annotation on
+  every call. The bare `is None` check it replaced short-circuited before doing
+  any of that, so consulting the annotation unconditionally cost about 23% on a
+  60x60 Hungarian cost matrix of 20-field models -- 72,000 calls for one list
+  comparison (0.531s to 0.651s; measured best-of-three).
+
+  The lookup is now guarded by a cheap value test that is the union of both
+  `NullHelper` rules, so anything either one calls absent still reaches the full
+  check and no outcome changes, while the common case of both sides being
+  populated skips the annotation entirely (0.537s, within noise of the original).
+  A test pins the superset property so adding a case to either rule without
+  widening the guard fails loudly rather than silently skipping the check.
 
 ### Changed
 
@@ -79,10 +134,15 @@ Each release links to full notes on the
   rise** as a function of how many absent optional fields a schema declares.
 
   This extends existing semantics rather than introducing them. A field left
-  `None` already behaved exactly this way -- only the `[]` and `""` spellings
-  were scored differently, which is precisely the inconsistency
+  `None` already behaved exactly this way -- only the `[]`, `""` and `{}`
+  spellings were scored differently, which is precisely the inconsistency
   [#233](https://github.com/awslabs/stickler/issues/233) is about. Making them
-  agree necessarily means `[]` and `""` adopt what `None` already did.
+  agree necessarily means those three adopt what `None` already did. The same
+  applies to a field whose annotation was not recognized as a list
+  (`Optional[list]`, `Optional[Annotated[List[str], ...]]` and the other
+  spellings above): it now gets list absence semantics, so an empty-on-both
+  field of that kind starts contributing `1.0` where it previously contributed
+  `0.0` or nothing.
 
   Field-level counts do not move: an absent-on-both field is still a TN rather
   than a TP, and a field the prediction gets wrong is still reported as an FD in
@@ -91,11 +151,18 @@ Each release links to full notes on the
   reports across this upgrade should expect object-level precision to shift for
   affected schemas.
 
-  Absence is not leniency: `""` did not become a wildcard. An absent value
-  against a populated one still scores `0.0`, as the dispatcher already scored
-  it. A custom comparator that scored `""` against a populated value above `0.0`
-  is now short-circuited to `0.0` on the raw path, matching what `compare_with`
-  already reported for that pair.
+  Absence is not leniency: `""` and `{}` did not become wildcards. An absent
+  value against a populated one still scores `0.0`, as the dispatcher already
+  scored it. A custom comparator that scored `""` against a populated value
+  above `0.0` is now short-circuited to `0.0` on the raw path, matching what
+  `compare_with` already reported for that pair.
+
+  What is *not* changed here: how a below-threshold pair is treated. Those are
+  still atomic false discoveries with no field breakdown, per
+  [threshold-gated evaluation](https://awslabs.github.io/stickler/Advanced/threshold-gated-evaluation/).
+  Whether an absent-on-both field should count toward the similarity that gets
+  gated at all is a separate question about the metric itself, not about the
+  spelling inconsistency this fixes, and it is left alone.
 
 ## [0.7.0] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,21 @@ Each release links to full notes on the
   different question from reading a spelling correctly, and every caller here
   has only the annotation.
 
+- Raw object similarity used by Hungarian matching no longer treats a true
+  negative as evidence that two objects match. Fields absent on both sides are
+  excluded from the weighted-average numerator and denominator. If every field
+  is absent, the score is defined as `1.0`, preserving the #233 fix; otherwise,
+  empty optional fields can no longer hide a missed value or make an empty
+  candidate tie one that extracted real content.
+
+- Threshold-gated recursion now applies consistently to nested metrics,
+  `non_matches`, and `field_comparisons` for `List[StructuredModel]`. An
+  assigned pair below the element model's `match_threshold` produces one atomic
+  FD, while unmatched GT and prediction objects produce one atomic FN and FA.
+  None of these objects contributes leaf-level metrics or report entries.
+  Lower the element model's `match_threshold` to inspect leaf comparisons for
+  weaker pairs.
+
 ### Performance
 
 - Restored the fast path in `ComparisonHelper.compare_field_raw`. Reading a
@@ -123,46 +138,6 @@ Each release links to full notes on the
   `scikit-learn` is no longer a core dependency, and the `docsplit` extra now
   adds only pandas; SciPy remains isolated to the `semantic` extra
   ([#216](https://github.com/awslabs/stickler/issues/216)).
-
-- Object-level TP/FD counts move for schemas with fields that are absent on both
-  sides. An absent-on-both field now contributes a full `1.0` to the raw object
-  similarity that `HungarianHelper` classifies against `match_threshold`, so a
-  pair that disagrees on every value a user actually supplied can clear the
-  threshold on the strength of its absent fields alone. An object with two
-  empty-on-both lists and one wrong string scores `2/3`; with five, `5/6`. Pairs
-  that previously classified as FD can now classify as TP, and **precision can
-  rise** as a function of how many absent optional fields a schema declares.
-
-  This extends existing semantics rather than introducing them. A field left
-  `None` already behaved exactly this way -- only the `[]`, `""` and `{}`
-  spellings were scored differently, which is precisely the inconsistency
-  [#233](https://github.com/awslabs/stickler/issues/233) is about. Making them
-  agree necessarily means those three adopt what `None` already did. The same
-  applies to a field whose annotation was not recognized as a list
-  (`Optional[list]`, `Optional[Annotated[List[str], ...]]` and the other
-  spellings above): it now gets list absence semantics, so an empty-on-both
-  field of that kind starts contributing `1.0` where it previously contributed
-  `0.0` or nothing.
-
-  Field-level counts do not move: an absent-on-both field is still a TN rather
-  than a TP, and a field the prediction gets wrong is still reported as an FD in
-  both the field breakdown and the aggregate. Only the *object-level*
-  classification of the enclosing pair changes. Anyone diffing evaluation
-  reports across this upgrade should expect object-level precision to shift for
-  affected schemas.
-
-  Absence is not leniency: `""` and `{}` did not become wildcards. An absent
-  value against a populated one still scores `0.0`, as the dispatcher already
-  scored it. A custom comparator that scored `""` against a populated value
-  above `0.0` is now short-circuited to `0.0` on the raw path, matching what
-  `compare_with` already reported for that pair.
-
-  What is *not* changed here: how a below-threshold pair is treated. Those are
-  still atomic false discoveries with no field breakdown, per
-  [threshold-gated evaluation](https://awslabs.github.io/stickler/Advanced/threshold-gated-evaluation/).
-  Whether an absent-on-both field should count toward the similarity that gets
-  gated at all is a separate question about the metric itself, not about the
-  spelling inconsistency this fixes, and it is left alone.
 
 ## [0.7.0] - 2026-08-18
 

--- a/docs/docs/Advanced/classification-logic.md
+++ b/docs/docs/Advanced/classification-logic.md
@@ -107,6 +107,8 @@ From the base counts:
 
 **Null vs. empty equivalence** -- Empty strings (`""`), empty lists (`[]`), and empty objects (`{}`) are treated as null. Comparing any of these with `null` yields TN.
 
+**TN in object matching** -- A TN is absence of evidence, not evidence of a match. Fields absent on both sides are excluded from the weighted object similarity used by Hungarian matching. If every field is absent, the similarity is defined as `1.0`.
+
 **Threshold boundary** -- A similarity score exactly equal to the threshold counts as a match (TP).
 
 **List order** -- Order does not matter. The Hungarian algorithm finds the optimal pairing regardless of element position.

--- a/docs/docs/Advanced/hungarian-matching.md
+++ b/docs/docs/Advanced/hungarian-matching.md
@@ -18,7 +18,7 @@ The algorithm has three phases:
 
 ### 1. Pairwise Similarity
 
-For each (GT[i], Pred[j]) pair, Stickler calls `GT[i].compare_with(Pred[j])` to obtain an overall similarity score. The result is an N x M cost matrix.
+For each (GT[i], Pred[j]) pair, Stickler calls `GT[i].compare(Pred[j])` to obtain a raw weighted similarity score. Fields absent on both sides are excluded because a true negative is not match evidence. If every field is absent, the score is `1.0`. The result is an N x M cost matrix.
 
 ### 2. Hungarian Assignment
 

--- a/docs/docs/Advanced/threshold-gated-evaluation.md
+++ b/docs/docs/Advanced/threshold-gated-evaluation.md
@@ -18,6 +18,12 @@ When comparing `List[StructuredModel]` fields, Stickler only performs detailed n
 
 This keeps metrics focused on meaningful comparisons and avoids generating misleading field-level statistics for object pairs that are fundamentally different.
 
+The gate applies to nested confusion-matrix metrics, `non_matches`, and
+`field_comparisons`. A rejected or unmatched object produces one object-level
+entry in those reports, not one entry per leaf. To inspect leaves for weaker
+pairs, lower the list element model's `match_threshold` to a small positive
+value; this intentionally broadens which pairs count as the same object.
+
 ## Algorithm Flow
 
 ### 1. Hungarian Matching
@@ -138,7 +144,10 @@ No nested analysis for either.
 }
 ```
 
-Field-level metrics appear only for the single TP pair. The `non_matches` list documents every FD, FN, and FA for diagnostic purposes.
+Field-level metrics appear only for the single TP pair. The `non_matches` list
+documents each FD, FN, and FA once at object level; `field_comparisons` uses the
+same boundary. Neither report expands a rejected or unmatched object into
+leaves.
 
 ## Delegation Pattern
 
@@ -164,6 +173,8 @@ Scores percolate upward from leaf fields to the top-level result using weighted 
 4. The overall similarity is `total_weighted_score / total_weight`.
 
 The `all_fields_matched` flag is `True` only when every field's raw similarity meets its individual threshold.
+
+For the raw object similarity used by Hungarian matching, fields absent on both sides are omitted from both totals. They remain TNs in the confusion matrix, but do not help a pair clear `match_threshold`. If no fields remain, the similarity is defined as `1.0`, because nothing disagreed.
 
 ## Edge Cases
 

--- a/src/stickler/structured_object_evaluator/models/README.md
+++ b/src/stickler/structured_object_evaluator/models/README.md
@@ -14,6 +14,11 @@ its `from_json()` ingestion and `compare_with()` comparison pipeline.
   (`ComparableField`), per-field comparator/threshold/weight metadata.
 - `model_factory.py`, `field_converter.py`, `json_schema_field_converter.py`,
   `type_resolver.py`, `configuration_helper.py` — building models from JSON / schema.
+- `optional_annotation.py` — the single source for destructuring a type
+  annotation: union arms in every spelling (`Optional[T]`, `Union[T, None]`,
+  `T | None`) and `Annotated` unwrapping. Ask through it rather than rebuilding
+  the checks; `get_origin` answers differently per spelling and each hand-rolled
+  copy has gotten one wrong.
 
 **Comparison pipeline**
 - `comparison_engine.py` — `ComparisonEngine`, the orchestrator behind

--- a/src/stickler/structured_object_evaluator/models/comparison_helper.py
+++ b/src/stickler/structured_object_evaluator/models/comparison_helper.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List
 from stickler.comparators.base import BaseComparator
 
 from .hungarian_helper import HungarianHelper
+from .null_helper import NullHelper
 from .threshold_helper import ThresholdHelper
 
 
@@ -166,7 +167,15 @@ class ComparisonHelper:
         # CRITICAL FIX: Use threshold-applied scores for consistency with individual comparison
         # This ensures list comparison matches the same scoring logic as individual comparison
         if not matched_pairs:
-            overall_score = 0.0
+            # Two empty lists agree perfectly: there is nothing to find and
+            # nothing was found. Scoring that 0.0 made an object whose only
+            # field is an empty list compare as a total mismatch against an
+            # identical object, which then classified as a false discovery even
+            # though `compare_with` reported a perfect match. The dispatcher
+            # already treats both-empty as a true negative with score 1.0; this
+            # keeps the raw path in agreement with it.
+            # See https://github.com/awslabs/stickler/issues/233
+            overall_score = 1.0 if not gt_list and not pred_list else 0.0
         else:
             # Apply threshold to each similarity score (same logic as individual comparison)
             threshold_applied_similarities = []
@@ -225,6 +234,18 @@ class ComparisonHelper:
 
         # Get field value from self
         self_value = getattr(structured_model_instance, field_name)
+
+        # For list fields, None and [] both mean "no items" and so agree with
+        # each other. The dispatcher already scores a both-null list field as a
+        # true negative worth 1.0; without the same rule here the generic None
+        # check below scores `[]` against `None` as 0.0, and the object lands
+        # under `match_threshold` while `compare_with` calls it a perfect match.
+        # See https://github.com/awslabs/stickler/issues/233
+        if structured_model_instance._is_list_field(field_name):
+            self_is_null = NullHelper.is_effectively_null_for_lists(self_value)
+            other_is_null = NullHelper.is_effectively_null_for_lists(other_value)
+            if self_is_null or other_is_null:
+                return 1.0 if self_is_null and other_is_null else 0.0
 
         # Handle None values
         if self_value is None or other_value is None:

--- a/src/stickler/structured_object_evaluator/models/comparison_helper.py
+++ b/src/stickler/structured_object_evaluator/models/comparison_helper.py
@@ -13,6 +13,24 @@ from .null_helper import NullHelper
 from .threshold_helper import ThresholdHelper
 
 
+def _maybe_absent(val: Any) -> bool:
+    """Whether ``val`` could be absent under *either* of ``NullHelper``'s rules.
+
+    A cheap over-approximation, used only to decide whether it is worth reading
+    a field's annotation to find out which rule applies. It must stay a
+    superset of both :meth:`NullHelper.is_effectively_null_for_lists` and
+    :meth:`NullHelper.is_effectively_null_for_primitives`: returning ``False``
+    for something either one calls absent would silently skip the true-negative
+    and false-negative handling in
+    :meth:`ComparisonHelper.compare_field_raw`. Returning ``True`` too often
+    only costs the lookup it was meant to avoid.
+
+    ``test_maybe_absent_is_a_superset_of_both_null_rules`` pins that property so
+    adding a case to either predicate without widening this one fails loudly.
+    """
+    return val is None or (isinstance(val, (str, list, dict)) and len(val) == 0)
+
+
 class ComparisonHelper:
     """Helper class for StructuredModel field comparison operations."""
 
@@ -249,19 +267,31 @@ class ComparisonHelper:
         #
         # What counts as absent is per-kind, exactly as the dispatcher defines
         # it: for a list field `None` and `[]` both mean "no items"; for
-        # everything else `None` and `""` both mean "no value". Both predicates
-        # treat `None` as absent, which is why this subsumes the bare `is None`
-        # check that used to stand here.
+        # everything else `None`, `""` and `{}` all mean "no value". Both
+        # predicates treat `None` as absent, which is why this subsumes the bare
+        # `is None` check that used to stand here.
         # See https://github.com/awslabs/stickler/issues/233
-        if structured_model_instance._is_list_field(field_name):
-            is_absent = NullHelper.is_effectively_null_for_lists
-        else:
-            is_absent = NullHelper.is_effectively_null_for_primitives
+        #
+        # `_maybe_absent` guards the annotation lookup rather than duplicating
+        # it. This function runs once per field per pairwise comparison, which
+        # is every cell of a Hungarian cost matrix -- 60x60 objects of 20 fields
+        # is 72,000 calls -- and `_is_list_field` re-reads `model_fields` and
+        # destructures the annotation on each one. The bare `is None` check this
+        # replaced short-circuited before doing any of that, so consulting the
+        # annotation unconditionally cost ~23% on that shape. The guard is the
+        # union of the two predicates below, so anything either one would call
+        # absent still reaches it and the outcome is unchanged; both sides being
+        # populated, the overwhelmingly common case, now skips the lookup.
+        if _maybe_absent(self_value) or _maybe_absent(other_value):
+            if structured_model_instance._is_list_field(field_name):
+                is_absent = NullHelper.is_effectively_null_for_lists
+            else:
+                is_absent = NullHelper.is_effectively_null_for_primitives
 
-        self_is_null = is_absent(self_value)
-        other_is_null = is_absent(other_value)
-        if self_is_null or other_is_null:
-            return 1.0 if self_is_null and other_is_null else 0.0
+            self_is_null = is_absent(self_value)
+            other_is_null = is_absent(other_value)
+            if self_is_null or other_is_null:
+                return 1.0 if self_is_null and other_is_null else 0.0
 
         # Handle lists with special processing
         if isinstance(self_value, list) and isinstance(other_value, list):

--- a/src/stickler/structured_object_evaluator/models/comparison_helper.py
+++ b/src/stickler/structured_object_evaluator/models/comparison_helper.py
@@ -37,8 +37,12 @@ class ComparisonHelper:
             - fp: Total false positives (fd + fa)
             - overall_score: Similarity score for backward compatibility
         """
-        # Empty lists are handled early on immediately.
-   
+        # Empty lists reach here and fall through to `unordered_list_metrics`,
+        # which scores two of them 1.0. `ComparisonDispatcher` short-circuits an
+        # absent list field before this function is called, but only for fields
+        # `_is_list_field` recognizes -- a list held in an `Any`-annotated field
+        # arrives here empty.
+
         # Use HungarianHelper for Hungarian matching operations
         hungarian_helper = HungarianHelper()
         from .structured_model import StructuredModel
@@ -235,21 +239,29 @@ class ComparisonHelper:
         # Get field value from self
         self_value = getattr(structured_model_instance, field_name)
 
-        # For list fields, None and [] both mean "no items" and so agree with
-        # each other. The dispatcher already scores a both-null list field as a
-        # true negative worth 1.0; without the same rule here the generic None
-        # check below scores `[]` against `None` as 0.0, and the object lands
-        # under `match_threshold` while `compare_with` calls it a perfect match.
+        # Read absence the same way `ComparisonDispatcher` does. It scores a
+        # field absent on both sides as a true negative worth 1.0 and a field
+        # absent on exactly one side as FN/FA worth 0.0 (STEP 3 for list fields,
+        # STEP 4 for everything else). Without the same rule here the two score
+        # readers disagree: `compare_with` reports a perfect match while the raw
+        # similarity lands under `match_threshold`, so the same pair is a perfect
+        # match and a false discovery at once.
+        #
+        # What counts as absent is per-kind, exactly as the dispatcher defines
+        # it: for a list field `None` and `[]` both mean "no items"; for
+        # everything else `None` and `""` both mean "no value". Both predicates
+        # treat `None` as absent, which is why this subsumes the bare `is None`
+        # check that used to stand here.
         # See https://github.com/awslabs/stickler/issues/233
         if structured_model_instance._is_list_field(field_name):
-            self_is_null = NullHelper.is_effectively_null_for_lists(self_value)
-            other_is_null = NullHelper.is_effectively_null_for_lists(other_value)
-            if self_is_null or other_is_null:
-                return 1.0 if self_is_null and other_is_null else 0.0
+            is_absent = NullHelper.is_effectively_null_for_lists
+        else:
+            is_absent = NullHelper.is_effectively_null_for_primitives
 
-        # Handle None values
-        if self_value is None or other_value is None:
-            return 1.0 if self_value == other_value else 0.0
+        self_is_null = is_absent(self_value)
+        other_is_null = is_absent(other_value)
+        if self_is_null or other_is_null:
+            return 1.0 if self_is_null and other_is_null else 0.0
 
         # Handle lists with special processing
         if isinstance(self_value, list) and isinstance(other_value, list):

--- a/src/stickler/structured_object_evaluator/models/field_comparison_helper.py
+++ b/src/stickler/structured_object_evaluator/models/field_comparison_helper.py
@@ -110,8 +110,13 @@ class FieldComparisonHelper(ComparisonHelperBase):
         """
         from .structured_model import StructuredModel
         
-        # Check if both objects are structured models
-        if (isinstance(gt_object, StructuredModel) and isinstance(pred_object, StructuredModel)):
+        # Only threshold-passing structured pairs represent the same object and
+        # may expose leaf comparisons.
+        if (
+            is_match
+            and isinstance(gt_object, StructuredModel)
+            and isinstance(pred_object, StructuredModel)
+        ):
             # Perform field-by-field comparison to get detailed field comparisons
             comparison_result = gt_object.compare_with(
                 pred_object, 
@@ -165,7 +170,8 @@ class FieldComparisonHelper(ComparisonHelperBase):
             return field_comparisons
         
         else:
-            # For primitive objects or single object comparisons, create a single entry
+            # Primitive items and threshold-rejected or unmatched structured
+            # objects remain atomic.
             expected_key = f"{field_name}[{gt_index}]" if gt_index is not None else f"{field_name}[]"
             actual_key = f"{field_name}[{pred_index}]" if pred_index is not None else None
             

--- a/src/stickler/structured_object_evaluator/models/non_matches_helper.py
+++ b/src/stickler/structured_object_evaluator/models/non_matches_helper.py
@@ -151,10 +151,17 @@ class NonMatchesHelper(ComparisonHelperBase):
         Returns:
             List of non-match entries
         """
-        # Only return entries for non-matches
+        from .structured_model import StructuredModel
+
         if is_match:
+            if isinstance(gt_object, StructuredModel) and isinstance(
+                pred_object, StructuredModel
+            ):
+                return self._extract_field_level_non_matches(
+                    field_name, gt_object, pred_object, gt_index
+                )
             return []
-            
+
         # Determine non-match type based on available objects
         if gt_object is None:
             non_match_type = "FA"
@@ -166,10 +173,17 @@ class NonMatchesHelper(ComparisonHelperBase):
             # Both objects exist but similarity is below threshold
             non_match_type = "FD"
             object_index = gt_index
-            
-        return self._extract_field_level_non_matches(
-            field_name, gt_object, pred_object, object_index, non_match_type, similarity_score
-        )
+
+        return [
+            self.create_non_match_entry(
+                field_name,
+                gt_object,
+                pred_object,
+                non_match_type,
+                object_index,
+                similarity_score,
+            )
+        ]
     
     def _extract_field_level_non_matches(
         self, 
@@ -177,53 +191,42 @@ class NonMatchesHelper(ComparisonHelperBase):
         gt_object: Any, 
         pred_object: Any, 
         object_index: int,
-        non_match_type: str,
-        similarity_score: float = None
     ) -> List[Dict[str, Any]]:
-        """Extract field-level non-matches from structured model objects.
+        """Extract field-level non-matches from a threshold-passing object pair.
         
         Args:
             field_name: Name of the parent list field
             gt_object: Ground truth structured model
             pred_object: Prediction structured model  
             object_index: Index in the list
-            non_match_type: Type of non-match ("FD", "FN", "FA")
-            similarity_score: Overall similarity score
             
         Returns:
             List of field-level non-match entries
         """
-        from .structured_model import StructuredModel
-        # Check if both objects are structured models
-        if (isinstance(gt_object, StructuredModel) and isinstance(pred_object, StructuredModel)):
-            # Perform field-by-field comparison
-            comparison_result = gt_object.compare_with(
-                pred_object, 
-                document_non_matches=True,
-                include_confusion_matrix=False
+        comparison_result = gt_object.compare_with(
+            pred_object,
+            document_non_matches=True,
+            include_confusion_matrix=False,
+        )
+
+        field_non_matches = []
+
+        for non_match in comparison_result.get("non_matches", []):
+            indexed_field_path = (
+                f"{field_name}[{object_index}].{non_match['field_path']}"
             )
-            
-            field_non_matches = []
-            
-            for non_match in comparison_result.get("non_matches", []):
-                indexed_field_path = f"{field_name}[{object_index}].{non_match['field_path']}"
-                
-                field_entry = {
-                    "field_path": indexed_field_path,
-                    "non_match_type": non_match["non_match_type"],
-                    "ground_truth_value": non_match["ground_truth_value"],
-                    "prediction_value": non_match["prediction_value"],
-                    "reason": non_match.get("reason", "field mismatch"),
-                }
-                
-                if "similarity_score" in non_match:
-                    field_entry["similarity_score"] = non_match["similarity_score"]
-                    
-                field_non_matches.append(field_entry)
-                
-            return field_non_matches
-        
-        else:
-            return [self.create_non_match_entry(
-                field_name, gt_object, pred_object, non_match_type, object_index, similarity_score
-            )]
+
+            field_entry = {
+                "field_path": indexed_field_path,
+                "non_match_type": non_match["non_match_type"],
+                "ground_truth_value": non_match["ground_truth_value"],
+                "prediction_value": non_match["prediction_value"],
+                "reason": non_match.get("reason", "field mismatch"),
+            }
+
+            if "similarity_score" in non_match:
+                field_entry["similarity_score"] = non_match["similarity_score"]
+
+            field_non_matches.append(field_entry)
+
+        return field_non_matches

--- a/src/stickler/structured_object_evaluator/models/null_helper.py
+++ b/src/stickler/structured_object_evaluator/models/null_helper.py
@@ -36,14 +36,30 @@ class NullHelper:
 
     @staticmethod
     def is_effectively_null_for_primitives(val: Any) -> bool:
-        """Check if a primitive value is effectively null.
+        """Check if a non-list value is effectively null.
 
-        Treats empty strings and None as equivalent for string fields.
+        Treats ``None``, an empty string and an empty dict as equivalent, which
+        is the rule the docs state: "Empty strings (``""``), empty lists
+        (``[]``), and empty objects (``{}``) are treated as null." Empty lists
+        are the one case this does *not* answer, because list-ness is decided
+        from the annotation rather than the value -- see
+        :meth:`is_effectively_null_for_lists`, which ``ComparisonDispatcher``
+        reaches first for any field ``_is_list_field`` recognises.
+
+        ``{}`` was missing here, and its absence was visible in the metrics
+        rather than benign: two **identical** objects each holding ``{}`` in a
+        dict field classified as a false discovery, the same contradiction
+        #233 reports for lists. It was also unreachable to score, because no
+        comparator accepts a dict -- ``LevenshteinComparator`` raises
+        ``TypeError`` -- so a populated dict field made the pair uncomparable
+        instead of merely mismatched. Reading ``{}`` as absent gives the three
+        empty/null combinations a true negative and turns the fourth
+        (``{}`` against populated) into a false alarm rather than a crash.
 
         Args:
             val: Value to check
 
         Returns:
-            True if the value is None or an empty string, False otherwise
+            True if the value is None, an empty string or an empty dict
         """
-        return val is None or (isinstance(val, str) and val == "")
+        return val is None or (isinstance(val, (str, dict)) and len(val) == 0)

--- a/src/stickler/structured_object_evaluator/models/optional_annotation.py
+++ b/src/stickler/structured_object_evaluator/models/optional_annotation.py
@@ -35,13 +35,49 @@ supported range, and it is the spelling modern tooling emits.
 """
 
 import types
-from typing import Any, Tuple, Union, get_args, get_origin
+from typing import Annotated, Any, Tuple, Union, get_args, get_origin
 
-__all__ = ["is_union", "union_args", "is_optional_union", "unwrap_optional"]
+__all__ = [
+    "is_union",
+    "union_args",
+    "is_optional_union",
+    "unwrap_optional",
+    "unwrap_annotated",
+]
 
 # Both origins a union annotation can report. `types.UnionType` is what the
 # `|` operator produces; `typing.Union` is what the subscript form produces.
 _UNION_ORIGINS = (Union, types.UnionType)
+
+
+def unwrap_annotated(annotation: Any) -> Any:
+    """Strip ``Annotated[T, ...]`` down to ``T``, leaving anything else alone.
+
+    Pydantic strips ``Annotated`` when it wraps a whole annotation, so
+    ``Annotated[List[str], "m"]`` arrives at these readers already unwrapped. It
+    does **not** strip it inside a union, so ``Optional[Annotated[List[str],
+    "m"]]`` keeps the wrapper on the arm -- and ``Annotated[List[str], "m"] |
+    None`` normalises to exactly that. Any reader that destructures a union arm
+    has to unwrap it itself or the arm answers for ``Annotated`` rather than for
+    the type inside.
+
+    ``get_origin`` reports ``Annotated`` here rather than the wrapped type, so
+    an origin test alone reads the wrapper. ``get_args(...)[0]`` is the wrapped
+    type and the remaining args are the metadata.
+
+    Applies once, not repeatedly: ``typing`` flattens nested ``Annotated``, so
+    ``Annotated[Annotated[T, "a"], "b"]`` is stored as ``Annotated[T, "a", "b"]``.
+
+    Args:
+        annotation: Type annotation to unwrap.
+
+    Returns:
+        The wrapped type when ``annotation`` is ``Annotated``, otherwise
+        ``annotation`` unchanged.
+    """
+    if get_origin(annotation) is Annotated:
+        return get_args(annotation)[0]
+    return annotation
 
 
 def is_union(annotation: Any) -> bool:

--- a/src/stickler/structured_object_evaluator/models/primitive_list_comparator.py
+++ b/src/stickler/structured_object_evaluator/models/primitive_list_comparator.py
@@ -90,7 +90,10 @@ class PrimitiveListComparator:
         weight = info.weight
         threshold = info.threshold
 
-        # All code paths already check if the lists are empty
+        # Empty lists are not filtered out before this point. `ComparisonDispatcher`
+        # short-circuits an absent list field, but only for fields
+        # `_is_list_field` recognizes -- a list held in an `Any`-annotated field
+        # arrives here empty and is scored by `_compare_unordered_lists`.
 
         # For primitive lists, use the comparison logic from _compare_unordered_lists
         # which properly handles the threshold-based matching

--- a/src/stickler/structured_object_evaluator/models/structured_list_comparator.py
+++ b/src/stickler/structured_object_evaluator/models/structured_list_comparator.py
@@ -2,13 +2,9 @@
 Dedicated class for handling Hungarian matching of List[StructuredModel] fields.
 
 This class extracts the Hungarian matching logic from StructuredModel to improve
-code organization and maintainability. The extraction preserves existing behavior
-exactly, including current bugs that will be fixed in subsequent phases.
-
-Current Behavior Preserved (including bugs):
-- Uses parent field threshold instead of object match_threshold (bug)
-- Generates nested metrics for all matched pairs regardless of threshold (bug)
-- Object-level counting discrepancies in some scenarios (bug)
+code organization and maintainability. Object assignment and recursive field
+evaluation are separate: only assigned pairs that meet the element model's
+``match_threshold`` are evaluated field by field.
 """
 
 from typing import TYPE_CHECKING, Any, Dict, List
@@ -41,9 +37,6 @@ class StructuredListComparator:
     ) -> dict:
         """Enhanced structural list comparison that returns both metrics AND scores.
 
-        CRITICAL: This is the main entry point extracted from StructuredModel.
-        Maintains identical behavior including current bugs for Phase 2 compatibility.
-
         Args:
             gt_list: Ground truth list of StructuredModel objects
             pred_list: Predicted list of StructuredModel objects
@@ -72,8 +65,8 @@ class StructuredListComparator:
         (
             object_level_metrics,
             matched_pairs,
-            matched_gt_indices,
-            matched_pred_indices,
+            _matched_gt_indices,
+            _matched_pred_indices,
         ) = self._calculate_object_level_metrics(gt_list, pred_list, match_threshold)
 
         # Calculate raw similarity score using extracted method
@@ -91,8 +84,6 @@ class StructuredListComparator:
             gt_list,
             pred_list,
             matched_pairs,
-            matched_gt_indices,
-            matched_pred_indices,
             match_threshold,
         )
 
@@ -221,8 +212,6 @@ class StructuredListComparator:
         gt_list: List["StructuredModel"],
         pred_list: List["StructuredModel"],
         matched_pairs: List,
-        matched_gt_indices: set,
-        matched_pred_indices: set,
         match_threshold: float,
     ) -> Dict[str, Dict[str, Any]]:
         """Calculate field-level details for nested structure with threshold-gated recursion.
@@ -236,8 +225,6 @@ class StructuredListComparator:
             gt_list: Ground truth list
             pred_list: Predicted list
             matched_pairs: List of (gt_idx, pred_idx, similarity) tuples
-            matched_gt_indices: Set of matched GT indices
-            matched_pred_indices: Set of matched pred indices
             match_threshold: Match threshold for threshold-gating (NOW PROPERLY USED!)
 
         Returns:
@@ -261,13 +248,7 @@ class StructuredListComparator:
                 if similarity >= match_threshold
             ]
 
-            # Only generate field details if we have good matched pairs OR unmatched objects
-            has_good_matches = len(good_matched_pairs) > 0
-            has_unmatched = (len(matched_gt_indices) < len(gt_list)) or (
-                len(matched_pred_indices) < len(pred_list)
-            )
-
-            if has_good_matches or has_unmatched:
+            if good_matched_pairs:
                 for sub_field_name in model_class.model_fields:
                     if sub_field_name == "extra_fields":
                         continue
@@ -285,9 +266,6 @@ class StructuredListComparator:
                             gt_list,
                             pred_list,
                             good_matched_pairs,
-                            matched_gt_indices,
-                            matched_pred_indices,
-                            match_threshold,
                         )
                     else:
                         # Handle primitive fields with simple aggregation - ONLY for good matches
@@ -296,8 +274,6 @@ class StructuredListComparator:
                             gt_list,
                             pred_list,
                             good_matched_pairs,
-                            matched_gt_indices,
-                            matched_pred_indices,
                         )
 
         return field_details
@@ -308,9 +284,6 @@ class StructuredListComparator:
         gt_list: List["StructuredModel"],
         pred_list: List["StructuredModel"],
         matched_pairs: List,
-        matched_gt_indices: set,
-        matched_pred_indices: set,
-        match_threshold: float,
     ) -> Dict[str, Any]:
         """Handle hierarchical List[StructuredModel] fields with TRUE recursive aggregation.
 
@@ -479,8 +452,6 @@ class StructuredListComparator:
         gt_list: List["StructuredModel"],
         pred_list: List["StructuredModel"],
         matched_pairs: List,
-        matched_gt_indices: set,
-        matched_pred_indices: set,
     ) -> Dict[str, Any]:
         """Handle non-hierarchical fields with aggregation across matched pairs.
 
@@ -521,25 +492,6 @@ class StructuredListComparator:
 
             aggregated_result = self._recursive_aggregate_metrics(pair_results)
 
-            # Handle unmatched objects — count each list element as FN or FA
-            for gt_idx, gt_item in enumerate(gt_list):
-                if gt_idx not in matched_gt_indices and gt_item is not None:
-                    gt_sub_value = getattr(gt_item, sub_field_name)
-                    if isinstance(gt_sub_value, list) and gt_sub_value:
-                        aggregated_result["overall"]["fn"] += len(gt_sub_value)
-                    elif gt_sub_value is not None:
-                        aggregated_result["overall"]["fn"] += 1
-
-            for pred_idx, pred_item in enumerate(pred_list):
-                if pred_idx not in matched_pred_indices and pred_item is not None:
-                    pred_sub_value = getattr(pred_item, sub_field_name)
-                    if isinstance(pred_sub_value, list) and pred_sub_value:
-                        aggregated_result["overall"]["fa"] += len(pred_sub_value)
-                        aggregated_result["overall"]["fp"] += len(pred_sub_value)
-                    elif pred_sub_value is not None:
-                        aggregated_result["overall"]["fa"] += 1
-                        aggregated_result["overall"]["fp"] += 1
-
             self._add_derived_metrics_recursively(aggregated_result)
             return aggregated_result
 
@@ -562,20 +514,6 @@ class StructuredListComparator:
 
                 for metric in ["tp", "fa", "fd", "fp", "tn", "fn"]:
                     sub_field_metrics[metric] += field_classification.get(metric, 0)
-
-        # Handle unmatched objects for primitive fields
-        for gt_idx, gt_item in enumerate(gt_list):
-            if gt_idx not in matched_gt_indices and gt_item is not None:
-                gt_sub_value = getattr(gt_item, sub_field_name)
-                if gt_sub_value is not None:
-                    sub_field_metrics["fn"] += 1
-
-        for pred_idx, pred_item in enumerate(pred_list):
-            if pred_idx not in matched_pred_indices and pred_item is not None:
-                pred_sub_value = getattr(pred_item, sub_field_name)
-                if pred_sub_value is not None:
-                    sub_field_metrics["fa"] += 1
-                    sub_field_metrics["fp"] += 1
 
         return {"overall": sub_field_metrics}
 

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -165,6 +165,53 @@ def _strip_extra_fields_property(schema_obj: Dict[str, Any]) -> None:
         schema_obj["required"] = [r for r in required if r != _EXTRA_FIELDS_KEY]
 
 
+def _annotation_is_list(annotation: Any) -> bool:
+    """Check whether a type annotation denotes a list, parameterized or not.
+
+    Every spelling of a list annotation has to answer the same way, because the
+    answer decides whether a field gets list null semantics (``None`` and ``[]``
+    both meaning "no items") or primitive ones. A spelling that reads as
+    non-list records no TN when both sides are empty, so it silently drops
+    classification evidence rather than failing loudly.
+
+    Two traps make that easy to get wrong, and both are handled here:
+
+    - ``get_origin`` returns ``list`` only for a *parameterized* spelling, so
+      bare ``list`` needs an identity test alongside it. Without one, ``list``
+      and ``list | None`` read as non-list while ``list[str]`` and
+      ``list[str] | None`` read as lists. ``typing.List`` needs no special case
+      -- ``get_origin`` already normalizes it to ``list``.
+    - A PEP 604 union (``list | None``) reports ``types.UnionType`` as its
+      origin, not ``typing.Union``, so its arms are reached through
+      :func:`optional_annotation.union_args` -- the package's single source for
+      destructuring a union in every spelling -- rather than a hand-rolled
+      origin check.
+
+    Union members are recursed with the same two rules rather than a bare ``is
+    list``, so a bare and a parameterized member inside one union answer alike.
+    Depth needs no special handling: ``typing`` flattens nested unions, so
+    ``Optional[list[str] | None]`` is stored as ``Optional[list[str]]``.
+
+    One spelling is deliberately *not* covered: ``Optional[Annotated[list,
+    ...]]``. Pydantic strips ``Annotated`` when it wraps the whole annotation
+    (so ``Annotated[list, "m"]`` and ``Annotated[Optional[List[str]], "m"]`` both
+    arrive here already unwrapped) but preserves it as a union member, and this
+    does not unwrap it. Doing so should be consistent with the other annotation
+    readers -- ``_is_structured_field_type`` and the HTML report's threshold
+    extraction -- rather than fixed here alone.
+    """
+    if annotation is list:
+        return True
+
+    if get_origin(annotation) is list:
+        return True
+
+    # Any union arm being a list is enough, in every spelling. `union_args`
+    # is the package's single source for a union's non-None arms and returns
+    # `()` for a non-union, so this also bottoms out the recursion.
+    return any(_annotation_is_list(arg) for arg in union_args(annotation))
+
+
 class StructuredModel(BaseModel):
     """Base class for models with structured comparison capabilities.
 
@@ -936,23 +983,7 @@ class StructuredModel(BaseModel):
             return False
 
         field_type = field_info.annotation
-
-        # Use get_origin rather than reading `__origin__` directly: a PEP 604
-        # union (`list[T] | None`) has no `__origin__` attribute at all, so the
-        # old `hasattr` guard skipped it entirely and such a field was not
-        # recognised as a list.
-        origin = get_origin(field_type)
-        if origin is list or origin is List:
-            return True
-
-        # Optional[List[...]] case, in every spelling. Any arm being a list is
-        # enough, so a wider union like `Optional[List[str]] | Any` still counts.
-        for arg in union_args(field_type):
-            arg_origin = get_origin(arg)
-            if arg_origin is list or arg_origin is List:
-                return True
-
-        return False
+        return _annotation_is_list(field_type)
 
     def _handle_list_field_dispatch(
         self, gt_val: Any, pred_val: Any, weight: float

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -29,7 +29,7 @@ from .configuration_helper import ConfigurationHelper
 from .evaluator_format_helper import EvaluatorFormatHelper
 from .hungarian_helper import HungarianHelper
 from .metrics_helper import MetricsHelper
-from .optional_annotation import union_args, unwrap_optional
+from .optional_annotation import union_args, unwrap_annotated, unwrap_optional
 from .rich_value_helper import RichValueHelper
 from .threshold_helper import THRESHOLD_DOCS_URL
 from .threshold_helper import model_identity as _model_identity
@@ -174,7 +174,7 @@ def _annotation_is_list(annotation: Any) -> bool:
     non-list records no TN when both sides are empty, so it silently drops
     classification evidence rather than failing loudly.
 
-    Two traps make that easy to get wrong, and both are handled here:
+    Three traps make that easy to get wrong, and all three are handled here:
 
     - ``get_origin`` returns ``list`` only for a *parameterized* spelling, so
       bare ``list`` needs an identity test alongside it. Without one, ``list``
@@ -186,20 +186,27 @@ def _annotation_is_list(annotation: Any) -> bool:
       :func:`optional_annotation.union_args` -- the package's single source for
       destructuring a union in every spelling -- rather than a hand-rolled
       origin check.
+    - ``Annotated`` survives inside a union, where pydantic does not strip it,
+      and ``get_origin`` reports ``Annotated`` rather than the type inside. So
+      ``Optional[Annotated[List[str], ...]]`` -- the spelling a
+      ``Field(description=...)`` produces, and what ``Annotated[List[str], ...]
+      | None`` normalises to -- read as non-list. Arms are unwrapped through
+      :func:`optional_annotation.unwrap_annotated` before being tested.
 
-    Union members are recursed with the same two rules rather than a bare ``is
+    Union members are recursed with the same rules rather than a bare ``is
     list``, so a bare and a parameterized member inside one union answer alike.
     Depth needs no special handling: ``typing`` flattens nested unions, so
     ``Optional[list[str] | None]`` is stored as ``Optional[list[str]]``.
 
-    One spelling is deliberately *not* covered: ``Optional[Annotated[list,
-    ...]]``. Pydantic strips ``Annotated`` when it wraps the whole annotation
-    (so ``Annotated[list, "m"]`` and ``Annotated[Optional[List[str]], "m"]`` both
-    arrive here already unwrapped) but preserves it as a union member, and this
-    does not unwrap it. Doing so should be consistent with the other annotation
-    readers -- ``_is_structured_field_type`` and the HTML report's threshold
-    extraction -- rather than fixed here alone.
+    One spelling is still deliberately *not* covered: ``Any`` holding a list at
+    runtime. Inferring list-ness from a value rather than an annotation is a
+    different question from reading a spelling correctly, and every caller here
+    has only the annotation.
     """
+    # `Annotated` first: everything below asks about the type inside it, and a
+    # wrapper reaching the `get_origin` test would answer for the wrapper.
+    annotation = unwrap_annotated(annotation)
+
     if annotation is list:
         return True
 

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -24,11 +24,12 @@ from stickler.comparators.base import BaseComparator
 from stickler.utils.deprecation import warn_once
 
 from .comparable_field import ComparableField
-from .comparison_helper import ComparisonHelper
+from .comparison_helper import ComparisonHelper, _maybe_absent
 from .configuration_helper import ConfigurationHelper
 from .evaluator_format_helper import EvaluatorFormatHelper
 from .hungarian_helper import HungarianHelper
 from .metrics_helper import MetricsHelper
+from .null_helper import NullHelper
 from .optional_annotation import union_args, unwrap_annotated, unwrap_optional
 from .rich_value_helper import RichValueHelper
 from .threshold_helper import THRESHOLD_DOCS_URL
@@ -1342,15 +1343,29 @@ class StructuredModel(BaseModel):
             if field_name == "extra_fields":
                 continue
             if hasattr(other, field_name):
+                self_value = getattr(self, field_name)
+                other_value = getattr(other, field_name)
+
+                # A true negative is absence of evidence, not evidence that two
+                # objects match. Omit absent-on-both fields from the weighted
+                # average that Hungarian matching uses. The cheap guard preserves
+                # the populated-value fast path in pairwise cost matrices.
+                if _maybe_absent(self_value) and _maybe_absent(other_value):
+                    is_absent = (
+                        NullHelper.is_effectively_null_for_lists
+                        if self._is_list_field(field_name)
+                        else NullHelper.is_effectively_null_for_primitives
+                    )
+                    if is_absent(self_value) and is_absent(other_value):
+                        continue
+
                 # Get field configuration
                 info = self.__class__._get_comparison_info(field_name)
                 # Use weight from ComparableField object
                 weight = info.weight
 
                 # Compare field values WITHOUT applying thresholds
-                field_score = self.compare_field_raw(
-                    field_name, getattr(other, field_name)
-                )
+                field_score = self.compare_field_raw(field_name, other_value)
 
                 # Update total score
                 total_score += field_score * weight
@@ -1359,8 +1374,10 @@ class StructuredModel(BaseModel):
         # Calculate overall score
         if total_weight > 0:
             return total_score / total_weight
-        else:
-            return 0.0
+
+        # Every compared field was absent on both sides. Nothing disagreed, so
+        # identical empty objects remain a perfect match (#233).
+        return 1.0
 
     def compare_with(
         self,

--- a/tests/structured_object_evaluator/test_confidence_metrics.py
+++ b/tests/structured_object_evaluator/test_confidence_metrics.py
@@ -49,6 +49,7 @@ class Product(StructuredModel):
     name: str = ComparableField(comparator=LevenshteinComparator(), threshold=0.8)
     price: float = ComparableField(comparator=NumericComparator(), threshold=0.5)
     sku: str = ComparableField(comparator=ExactComparator(), threshold=1.0)
+    match_threshold = 0.6  # Keep 2-of-3 products open for leaf confidence checks.
 
 
 class Address(StructuredModel):

--- a/tests/structured_object_evaluator/test_field_comparison_collection.py
+++ b/tests/structured_object_evaluator/test_field_comparison_collection.py
@@ -95,6 +95,12 @@ class Invoice(StructuredModel):
         comparator=NumericComparator(absolute_tolerance=0.02), threshold=1.0, weight=2.0)
 
 
+class LineItemCollection(StructuredModel):
+    """Minimal wrapper for testing list-object threshold gating."""
+
+    line_items: List[LineItem] = ComparableField(weight=1.0)
+
+
 class PrimitiveListModel(StructuredModel):
     """Model with primitive list fields."""
     
@@ -314,8 +320,8 @@ class TestFieldComparisonCollection:
         # Should be matched with line_items[0] due to reordering
         assert widget_b_comp["actual_key"] == "line_items[0].product"
 
-    def test_list_field_comparisons_partial_matches(self):
-        """Test list field comparisons with partial matches and non-matches."""
+    def test_below_threshold_list_field_comparisons_are_atomic(self):
+        """Below-threshold list objects produce object-level comparisons."""
         invoice1 = Invoice(
             invoice_id="INV-001",
             customer=Person(
@@ -348,25 +354,40 @@ class TestFieldComparisonCollection:
         result = invoice1.compare_with(invoice2, document_field_comparisons=True)
         field_comparisons = result["field_comparisons"]
         
-        # Find list item comparisons
-        list_comparisons = [fc for fc in field_comparisons if fc["expected_key"].startswith("line_items[")]
-        
-        # Should have some matches and some non-matches
-        matches = [fc for fc in list_comparisons if fc["match"]]
-        non_matches = [fc for fc in list_comparisons if not fc["match"]]
-        
-        assert len(matches) > 0
-        assert len(non_matches) > 0
-        
-        # Check for partial product match
-        product_comparisons = [fc for fc in list_comparisons if fc["expected_key"].endswith(".product")]
-        widget_a_comparison = next((fc for fc in product_comparisons if fc["expected_value"] == "Widget A"), None)
-        
-        if widget_a_comparison:
-            # Should be matched with "Widget Alpha" and be a partial match
-            assert widget_a_comparison["actual_value"] == "Widget Alpha"
-            assert widget_a_comparison["match"] is False  # Should be below 0.8 threshold
-            assert widget_a_comparison["score"] == 0.0
+        list_comparisons = [
+            fc
+            for fc in field_comparisons
+            if fc["expected_key"].startswith("line_items[")
+        ]
+
+        assert len(list_comparisons) == 2
+        assert {fc["expected_key"] for fc in list_comparisons} == {
+            "line_items[0]",
+            "line_items[1]",
+        }
+        assert all(fc["match"] is False for fc in list_comparisons)
+        assert all(fc["score"] < LineItem.match_threshold for fc in list_comparisons)
+        assert all(isinstance(fc["expected_value"], dict) for fc in list_comparisons)
+
+    def test_lower_match_threshold_enables_list_leaf_comparisons(self, monkeypatch):
+        """Lowering the element PET exposes comparisons for that object pair."""
+        monkeypatch.setattr(LineItem, "match_threshold", 0.4)
+        gt = LineItemCollection(
+            line_items=[LineItem(product="Widget A", quantity=2, price=10.0)]
+        )
+        pred = LineItemCollection(
+            line_items=[LineItem(product="Widget Alpha", quantity=2, price=10.5)]
+        )
+
+        field_comparisons = gt.compare_with(
+            pred, document_field_comparisons=True
+        )["field_comparisons"]
+
+        assert {fc["expected_key"] for fc in field_comparisons} == {
+            "line_items[0].product",
+            "line_items[0].quantity",
+            "line_items[0].price",
+        }
 
     def test_primitive_list_field_comparisons(self):
         """Test field comparisons with primitive list fields."""

--- a/tests/structured_object_evaluator/test_non_match_documentation.py
+++ b/tests/structured_object_evaluator/test_non_match_documentation.py
@@ -142,12 +142,10 @@ def test_non_match_documentation_disabled():
 # Result-shape parity across list length (#224)
 # ---------------------------------------------------------------------------
 #
-# A below-threshold pair in a List[StructuredModel] must be documented the
-# same way whether the list holds one item or several. Before #224 the 1-vs-1
+# A below-threshold pair in a List[StructuredModel] must be documented as one
+# atomic FD whether the list holds one item or several. Before #224 the 1-vs-1
 # case was the odd one out: the fast path dropped the pair, so it surfaced as
-# an object-level FN plus an object-level FA instead of field-level false
-# discoveries. These pin the shape at n=1 against n=2 so the two cannot drift
-# apart again.
+# an FN plus an FA. These pin the shape at n=1 against n=2.
 
 
 class _Line(StructuredModel):
@@ -169,34 +167,47 @@ def _wholly_wrong(n: int):
 
 
 @pytest.mark.parametrize("n", [1, 2, 3])
-def test_below_threshold_pairs_are_field_level_false_discoveries(n):
-    """Every sub-field of every below-threshold pair is documented as an FD."""
+def test_below_threshold_pairs_are_atomic_false_discoveries(n):
+    """Each below-threshold pair is documented as one object-level FD."""
     gt, pred = _wholly_wrong(n)
 
     non_matches = gt.compare_with(pred, document_non_matches=True)["non_matches"]
 
-    # One record per sub-field per pair -- not one per object.
-    assert len(non_matches) == 2 * n
+    assert len(non_matches) == n
     assert all(
         nm["non_match_type"] == NonMatchType.FALSE_DISCOVERY for nm in non_matches
     ), "an assigned pair below threshold is a false discovery, not FN + FA"
 
-    # Paths address the field, not the object: `lines[0].sku`, not `lines[0]`.
     assert {nm["field_path"] for nm in non_matches} == {
-        f"lines[{i}].{field}" for i in range(n) for field in ("sku", "desc")
+        f"lines[{i}]" for i in range(n)
     }
 
-    # Scalars, not the whole object dict.
     assert all(
-        isinstance(nm["ground_truth_value"], str) for nm in non_matches
-    ), "field-level records carry the field value"
+        set(nm["ground_truth_value"]) == {"sku", "desc"} for nm in non_matches
+    ), "atomic records carry the whole object"
+    assert all(nm["similarity"] < _Line.match_threshold for nm in non_matches)
+
+
+def test_threshold_passing_pair_reports_leaf_non_matches(monkeypatch):
+    """A pair admitted by PET still documents its incorrect leaves."""
+    monkeypatch.setattr(_Line, "match_threshold", 0.5)
+    gt = _Invoice(lines=[_Line(sku="A0", desc="Widget")])
+    pred = _Invoice(lines=[_Line(sku="A0", desc="Gadget")])
+
+    non_matches = gt.compare_with(pred, document_non_matches=True)["non_matches"]
+
+    assert len(non_matches) == 1
+    assert non_matches[0]["field_path"] == "lines[0].desc"
+    assert non_matches[0]["non_match_type"] == NonMatchType.FALSE_DISCOVERY
+    assert non_matches[0]["ground_truth_value"] == "Widget"
+    assert non_matches[0]["prediction_value"] == "Gadget"
 
 
 def test_non_match_shape_is_independent_of_list_length():
     """The per-pair record shape at n=1 matches n=2 exactly.
 
-    This is the #224 property: classification must not depend on how many
-    items happen to be in the list.
+    This is the #224 property: atomic classification must not depend on list
+    length.
     """
     keys_by_n = {}
     for n in (1, 2):

--- a/tests/structured_object_evaluator/test_optional_annotation.py
+++ b/tests/structured_object_evaluator/test_optional_annotation.py
@@ -4,12 +4,15 @@ Every spelling of "may be None" must be recognised, and a genuine multi-arm
 union must not be mistaken for one.
 """
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Annotated, Any, Dict, List, Optional, Union
+
+from pydantic import Field
 
 from stickler.structured_object_evaluator.models.optional_annotation import (
     is_optional_union,
     is_union,
     union_args,
+    unwrap_annotated,
     unwrap_optional,
 )
 
@@ -131,3 +134,44 @@ class TestUnwrapOptional:
     def test_the_two_spellings_unwrap_identically(self):
         assert unwrap_optional(Optional[_A]) == unwrap_optional(_A | None)
         assert unwrap_optional(Optional[List[_A]])[1] == unwrap_optional(list[_A] | None)[1]
+
+
+class TestUnwrapAnnotated:
+    def test_strips_the_wrapper_down_to_the_wrapped_type(self):
+        assert unwrap_annotated(Annotated[str, "m"]) is str
+        assert unwrap_annotated(Annotated[List[str], "m"]) == List[str]
+        assert unwrap_annotated(Annotated[list, "m"]) is list
+
+    def test_keeps_multiple_metadata_entries_out_of_the_result(self):
+        assert unwrap_annotated(Annotated[int, "a", "b", "c"]) is int
+
+    def test_unwraps_a_pydantic_field_as_metadata(self):
+        """The spelling a `Field(description=...)` produces."""
+        assert unwrap_annotated(Annotated[List[str], Field(description="d")]) == List[str]
+
+    def test_returns_anything_else_unchanged(self):
+        assert unwrap_annotated(str) is str
+        assert unwrap_annotated(List[str]) == List[str]
+        assert unwrap_annotated(Optional[str]) == Optional[str]
+        assert unwrap_annotated(list) is list
+
+    def test_does_not_reach_inside_a_union(self):
+        """A union is not `Annotated`; destructuring it is `union_args`' job.
+
+        `Optional[Annotated[T, ...]]` therefore comes back untouched -- the
+        wrapper is on the *arm*, so a caller has to unwrap after descending.
+        """
+        wrapped = Optional[Annotated[List[str], "m"]]
+        assert unwrap_annotated(wrapped) == wrapped
+
+    def test_composes_with_union_args_to_reach_the_inner_type(self):
+        """How the readers actually use it: descend, then unwrap."""
+        arms = union_args(Optional[Annotated[List[str], "m"]])
+        assert [unwrap_annotated(arm) for arm in arms] == [List[str]]
+
+    def test_nested_annotated_is_flattened_by_typing_so_one_pass_suffices(self):
+        assert unwrap_annotated(Annotated[Annotated[str, "a"], "b"]) is str
+
+    def test_pep604_annotated_optional_normalises_to_the_subscript_form(self):
+        """`Annotated[T, ...] | None` and `Optional[Annotated[T, ...]]` are one type."""
+        assert (Annotated[List[str], "m"] | None) == Optional[Annotated[List[str], "m"]]

--- a/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
+++ b/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
@@ -17,6 +17,9 @@ from stickler.comparators.levenshtein import LevenshteinComparator
 from stickler.structured_object_evaluator.models.comparable_field import (
     ComparableField,
 )
+from stickler.structured_object_evaluator.models.comparison_helper import (
+    ComparisonHelper,
+)
 from stickler.structured_object_evaluator.models.structured_model import (
     StructuredModel,
 )
@@ -32,6 +35,15 @@ class LineItemsInfo(StructuredModel):
 
 class Invoice(StructuredModel):
     LineItems: Optional[List[LineItemsInfo]] | Any = ComparableField(weight=1.0)
+
+
+class Pep604LineItemsInfo(StructuredModel):
+    LineItemDays: list[str] | None = ComparableField(weight=1.0)
+    match_threshold = 1.0
+
+
+class Pep604Invoice(StructuredModel):
+    LineItems: list[Pep604LineItemsInfo] = ComparableField(weight=1.0)
 
 
 # ---------------------------------------------------------------------------
@@ -258,6 +270,22 @@ def test_empty_simple_list_within_structured_list():
     assert obj_metrics["tp"] + obj_metrics["fd"] + obj_metrics["tn"] == 1
 
 
+def test_raw_empty_lists_score_as_perfect_match():
+    """The raw unordered-list path agrees that two empty lists match."""
+    result = ComparisonHelper.compare_unordered_lists(
+        [], [], ExactComparator(), threshold=1.0
+    )
+
+    assert result == {
+        "tp": 0,
+        "fd": 0,
+        "fa": 0,
+        "fn": 0,
+        "fp": 0,
+        "overall_score": 1.0,
+    }
+
+
 @pytest.mark.parametrize("n_items", [1, 2, 3])
 def test_empty_simple_lists_are_true_positives_at_any_length(n_items):
     """Identical empty-list objects are TPs at n=1 and n>1 alike.
@@ -311,6 +339,25 @@ def test_absent_simple_list_agrees_across_score_readers(gt_days, pred_days):
     assert result["overall_score"] == 1.0
     assert obj_metrics["fd"] == 0
     assert obj_metrics["tp"] == 1
+
+
+@pytest.mark.parametrize("gt_days,pred_days", [([], None), (None, [])])
+def test_pep604_optional_absent_list_agrees_across_score_readers(gt_days, pred_days):
+    """PEP 604 optional lists use the same absent-list semantics."""
+    gt = Pep604Invoice(LineItems=[Pep604LineItemsInfo(LineItemDays=gt_days)])
+    pred = Pep604Invoice(LineItems=[Pep604LineItemsInfo(LineItemDays=pred_days)])
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    cm = result["confusion_matrix"]
+    object_metrics = _overall(cm, "LineItems")
+    field_metrics = _overall(cm, "LineItems", "LineItemDays")
+
+    assert result["overall_score"] == 1.0
+    assert object_metrics["tp"] == 1
+    assert object_metrics["fd"] == 0
+    assert field_metrics["tn"] == 1
+    assert field_metrics["fn"] == 0
+    assert field_metrics["fa"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
+++ b/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
@@ -23,6 +23,8 @@ from stickler.structured_object_evaluator.models.comparison_helper import (
     ComparisonHelper,
     _maybe_absent,
 )
+from stickler.structured_object_evaluator.models.hungarian_helper import HungarianHelper
+from stickler.structured_object_evaluator.models.non_match_field import NonMatchType
 from stickler.structured_object_evaluator.models.null_helper import NullHelper
 from stickler.structured_object_evaluator.models.structured_model import (
     StructuredModel,
@@ -138,12 +140,7 @@ class DictContainer(StructuredModel):
 
 
 class PartiallyWrongItem(StructuredModel):
-    """Two absent-on-both list fields and one field the prediction gets wrong.
-
-    ``match_threshold`` is low enough that the two agreeing empty fields alone
-    carry the pair over it — see
-    ``test_absent_list_fields_lift_a_disagreeing_pair_to_a_true_positive``.
-    """
+    """Two absent-on-both list fields and one populated field."""
 
     a: Optional[List[str]] = ComparableField(weight=1.0)
     b: Optional[List[str]] = ComparableField(weight=1.0)
@@ -153,6 +150,38 @@ class PartiallyWrongItem(StructuredModel):
 
 class PartiallyWrongContainer(StructuredModel):
     items: List[PartiallyWrongItem] = ComparableField(weight=1.0)
+
+
+class MissedValueItem(StructuredModel):
+    """One real value and five fields that may be true negatives."""
+
+    a: Optional[str] = ComparableField(
+        comparator=ExactComparator(), threshold=1.0, weight=1.0
+    )
+    b: list = ComparableField(weight=1.0)
+    c: list = ComparableField(weight=1.0)
+    d: list = ComparableField(weight=1.0)
+    e: list = ComparableField(weight=1.0)
+    f: list = ComparableField(weight=1.0)
+    match_threshold = 0.8
+
+
+class MissedValueContainer(StructuredModel):
+    items: List[MissedValueItem] = ComparableField(weight=1.0)
+
+
+class CompetingCandidateItem(StructuredModel):
+    """Two fields that distinguish an empty from a useful candidate."""
+
+    a: Optional[str] = ComparableField(
+        comparator=ExactComparator(), threshold=1.0, weight=1.0
+    )
+    b: list = ComparableField(weight=1.0)
+    match_threshold = 0.7
+
+
+class CompetingCandidateContainer(StructuredModel):
+    items: List[CompetingCandidateItem] = ComparableField(weight=1.0)
 
 
 # ---------------------------------------------------------------------------
@@ -864,70 +893,132 @@ def test_absent_string_against_populated_is_not_leniently_matched(gt_note, pred_
 
 
 # ---------------------------------------------------------------------------
-# Tests — object matching counts absent-on-both fields toward the threshold
+# Tests — true negatives are not evidence for object matching
 # ---------------------------------------------------------------------------
 
+def test_all_absent_fields_define_empty_denominator_as_a_match():
+    """An empty denominator is 1.0, preserving the original #233 fix."""
+    gt = LineItemsInfo(LineItemDays=[])
+    pred = LineItemsInfo(LineItemDays=None)
+
+    assert gt.compare(pred) == 1.0
+
+
 @pytest.mark.parametrize("absent", [[], None], ids=["empty-list", "none"])
-def test_absent_list_fields_lift_a_disagreeing_pair_to_a_true_positive(absent):
-    """Absent-on-both fields count toward ``match_threshold``. Deliberate.
-
-    This is the metric consequence of the #233 fix, pinned because it is not
-    self-evidently desirable. ``HungarianHelper`` classifies an object pair by
-    its raw similarity, and an absent-on-both field now contributes a full
-    ``1.0`` to that average. So a pair that disagrees on *every* value a user
-    actually supplied can still clear ``match_threshold`` on the strength of its
-    absent fields: here two of three fields are absent on both sides, the third
-    disagrees outright, and the pair scores ``2/3`` and classifies as TP. Before
-    the fix the ``[]`` spelling scored ``0.0`` and classified as FD.
-
-    Parameterized over both spellings of absent because that is the argument for
-    the flip: ``None`` already behaved this way, so the fix extends existing
-    semantics to ``[]`` rather than inventing a rule. The two ids must stay
-    equal — if they ever diverge, the parity #233 is about has reopened.
-
-    The inflation this permits is real and worth stating: precision rises with
-    the number of absent optional fields a schema declares. The field-level
-    counts are what keep the report honest — ``c`` is still reported as a false
-    discovery, and the aggregate still carries ``fd == 1``. Only the
-    *object-level* classification moves.
-    """
+def test_absent_list_fields_do_not_lift_a_disagreeing_pair(absent):
+    """True negatives are excluded from object similarity in either spelling."""
     gt_item = PartiallyWrongItem(a=absent, b=absent, c="alpha")
     pred_item = PartiallyWrongItem(a=absent, b=absent, c="zzzzz")
 
-    # Two of three fields agree (vacuously), the third does not.
-    assert gt_item.compare(pred_item) == pytest.approx(2 / 3)
+    assert gt_item.compare(pred_item) == 0.0
 
     result = PartiallyWrongContainer(items=[gt_item]).compare_with(
         PartiallyWrongContainer(items=[pred_item]), include_confusion_matrix=True
     )
     cm = result["confusion_matrix"]
 
-    # 2/3 clears match_threshold=0.5, so the pair is an object-level TP.
-    assert _overall(cm, "items")["tp"] == 1
-    assert _overall(cm, "items")["fd"] == 0
+    assert _overall(cm, "items")["tp"] == 0
+    assert _overall(cm, "items")["fd"] == 1
+    assert cm["fields"]["items"]["overall"]["derived"]["cm_f1"] == 0.0
+    assert cm["fields"]["items"].get("fields", {}) == {}
 
-    # The disagreement is not swallowed: the field that is wrong is still wrong,
-    # the vacuously-agreeing fields are true negatives rather than true
-    # positives, and the aggregate still reports the false discovery.
-    assert _overall(cm, "items", "c")["fd"] == 1
-    assert _overall(cm, "items", "a")["tn"] == 1
-    assert _overall(cm, "items", "b")["tn"] == 1
-    assert cm["aggregate"]["fd"] == 1
-    assert cm["aggregate"]["tp"] == 0
+
+def test_prediction_that_extracts_nothing_is_not_a_perfect_match():
+    """Five true negatives cannot hide the only missed value."""
+    gt_item = MissedValueItem(
+        a="VALUE", b=[], c=[], d=[], e=[], f=[]
+    )
+    pred_item = MissedValueItem(
+        a=None, b=[], c=[], d=[], e=[], f=[]
+    )
+
+    assert gt_item.compare(pred_item) == 0.0
+
+    result = MissedValueContainer(items=[gt_item]).compare_with(
+        MissedValueContainer(items=[pred_item]), include_confusion_matrix=True
+    )
+    object_metrics = _overall(result["confusion_matrix"], "items")
+
+    assert object_metrics["tp"] == 0
+    assert object_metrics["fd"] == 1
+    assert (
+        result["confusion_matrix"]["fields"]["items"]["overall"]["derived"]["cm_f1"]
+        == 0.0
+    )
+
+
+def test_hungarian_prefers_content_agreement_over_an_empty_candidate():
+    """Assignment prefers content, while PET still rejects a weak pair."""
+    gt_item = CompetingCandidateItem(a="x", b=[])
+    empty_candidate = CompetingCandidateItem(a=None, b=[])
+    correct_candidate = CompetingCandidateItem(a="x", b=["z"])
+
+    assert gt_item.compare(empty_candidate) == 0.0
+    assert gt_item.compare(correct_candidate) == pytest.approx(0.5)
+
+    matching = HungarianHelper().get_complete_matching_info(
+        [gt_item], [empty_candidate, correct_candidate]
+    )
+    assert matching["assignments"] == [(0, 1)]
+    assert matching["matched_pairs"][0][2] == pytest.approx(0.5)
+    assert matching["unmatched_pred_indices"] == [0]
+
+    result = CompetingCandidateContainer(items=[gt_item]).compare_with(
+        CompetingCandidateContainer(items=[empty_candidate, correct_candidate]),
+        include_confusion_matrix=True,
+        document_non_matches=True,
+        document_field_comparisons=True,
+    )
+    object_metrics = _overall(result["confusion_matrix"], "items")
+    fd_entry = next(
+        non_match
+        for non_match in result["non_matches"]
+        if non_match["non_match_type"] == NonMatchType.FALSE_DISCOVERY
+    )
+    fa_entry = next(
+        non_match
+        for non_match in result["non_matches"]
+        if non_match["non_match_type"] == NonMatchType.FALSE_ALARM
+    )
+    item_comparisons = [
+        comparison
+        for comparison in result["field_comparisons"]
+        if comparison["expected_key"].startswith("items[")
+    ]
+
+    assert result["overall_score"] == pytest.approx(0.25)
+    assert object_metrics["tp"] == 0
+    assert object_metrics["fd"] == 1
+    assert object_metrics["fa"] == 1
+    assert result["confusion_matrix"]["fields"]["items"]["fields"] == {}
+
+    assert fd_entry["field_path"] == "items[0]"
+    assert fd_entry["ground_truth_value"] == gt_item.model_dump()
+    assert fd_entry["prediction_value"] == correct_candidate.model_dump()
+    assert fd_entry["similarity"] == pytest.approx(0.5)
+    assert fa_entry["field_path"] == "items[0]"
+    assert fa_entry["ground_truth_value"] is None
+    assert fa_entry["prediction_value"] == empty_candidate.model_dump()
+
+    assert len(item_comparisons) == 2
+    assert all("." not in comparison["expected_key"] for comparison in item_comparisons)
+    assigned_comparison = next(
+        comparison
+        for comparison in item_comparisons
+        if comparison["actual_value"] == correct_candidate.model_dump()
+    )
+    assert assigned_comparison["expected_key"] == "items[0]"
+    assert assigned_comparison["actual_key"] == "items[1]"
+    assert assigned_comparison["match"] is False
+    assert assigned_comparison["score"] == pytest.approx(0.5)
 
 
 # ---------------------------------------------------------------------------
-# Tests — unmatched structured objects with simple list fields
-# Exercises the unmatched-object path for simple lists (PR #83 feedback)
+# Tests — unmatched structured objects remain atomic
 # ---------------------------------------------------------------------------
 
-def test_unmatched_gt_object_simple_list_contributes_fn():
-    """When GT has more structured items than pred, the unmatched GT item's
-    simple list elements should contribute FN at the field level.
-
-    GT: 2 TaskItems, Pred: 1 TaskItem (matching the first).
-    The unmatched GT item has tags=["X", "Y", "Z"] → should add 3 FN.
-    """
+def test_unmatched_gt_object_does_not_contribute_leaf_fn():
+    """An unmatched GT object is one object-level FN, not leaf-level FNs."""
     gt = TaskList(tasks=[
         TaskItem(tags=["A", "B"], priority="high"),
         TaskItem(tags=["X", "Y", "Z"], priority="low"),
@@ -937,25 +1028,19 @@ def test_unmatched_gt_object_simple_list_contributes_fn():
     ])
 
     result = gt.compare_with(pred, include_confusion_matrix=True)
+    task_metrics = _overall(result["confusion_matrix"], "tasks")
     tags_metrics = _overall(result["confusion_matrix"], "tasks", "tags")
     priority_metrics = _overall(result["confusion_matrix"], "tasks", "priority")
 
-    # Matched pair: tags TP=2, priority TP=1
-    # Unmatched GT: priority gets FN=1 (primitive path handles this)
-    #               tags should get FN=3 (one per list element)
+    assert task_metrics["fn"] == 1
     assert tags_metrics["tp"] == 2
-    assert tags_metrics["fn"] == 3
+    assert tags_metrics["fn"] == 0
     assert priority_metrics["tp"] == 1
-    assert priority_metrics["fn"] == 1
+    assert priority_metrics["fn"] == 0
 
 
-def test_unmatched_pred_object_simple_list_contributes_fa():
-    """When pred has more structured items than GT, the unmatched pred item's
-    simple list elements should contribute FA/FP at the field level.
-
-    GT: 1 TaskItem, Pred: 2 TaskItems (first matches GT).
-    The unmatched pred item has tags=["X", "Y", "Z"] → should add 3 FA.
-    """
+def test_unmatched_pred_object_does_not_contribute_leaf_fa():
+    """An unmatched prediction is one object-level FA, not leaf-level FAs."""
     gt = TaskList(tasks=[
         TaskItem(tags=["A", "B"], priority="high"),
     ])
@@ -965,13 +1050,12 @@ def test_unmatched_pred_object_simple_list_contributes_fa():
     ])
 
     result = gt.compare_with(pred, include_confusion_matrix=True)
+    task_metrics = _overall(result["confusion_matrix"], "tasks")
     tags_metrics = _overall(result["confusion_matrix"], "tasks", "tags")
     priority_metrics = _overall(result["confusion_matrix"], "tasks", "priority")
 
-    # Matched pair: tags TP=2, priority TP=1
-    # Unmatched pred: priority gets FA=1, FP=1 (primitive path handles this)
-    #                 tags should get FA=3, FP=3 (one per list element)
+    assert task_metrics["fa"] == 1
     assert tags_metrics["tp"] == 2
-    assert tags_metrics["fa"] == 3
+    assert tags_metrics["fa"] == 0
     assert priority_metrics["tp"] == 1
-    assert priority_metrics["fa"] == 1
+    assert priority_metrics["fa"] == 0

--- a/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
+++ b/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
@@ -10,6 +10,8 @@ See: https://github.com/awslabs/stickler/issues/33
 
 from typing import Any, List, Optional
 
+import pytest
+
 from stickler.comparators.exact import ExactComparator
 from stickler.comparators.levenshtein import LevenshteinComparator
 from stickler.structured_object_evaluator.models.comparable_field import (
@@ -223,19 +225,17 @@ def test_simple_list_alongside_primitive_field():
 
 
 def test_empty_simple_list_within_structured_list():
-    """Empty simple lists on both sides — the pair is assigned, not unmatched.
+    """Empty simple lists on both sides — the pair is a TP, not a false discovery.
 
-    This asserts only the #224 property: an assigned pair is not reported as
-    FN + FA. It deliberately does *not* pin how the pair is classified.
+    Regression test for GitHub issue #233.
 
-    An object whose only field is an empty list gets list-path similarity 0.0
-    even though the two objects are identical, which is a separate pre-existing
-    bug. That leaves the result internally contradictory here -- the comparison
-    reports ``overall_score == 1.0`` (a perfect match) while the pair scores
-    below ``match_threshold`` and so classifies as FD. Pinning ``fd == 1``
-    would cement that contradiction into the suite and have to be undone when
-    the similarity bug is fixed, at which point this pair should become a TP or
-    a list-level TN.
+    The two objects are identical, so ``overall_score`` is 1.0. The confusion
+    matrix used to read a different score for the same pair: an object whose
+    only field was an empty list scored 0.0 on the list path, landing below
+    ``match_threshold`` and classifying as FD. The same pair was therefore a
+    perfect match and a false discovery at once.
+
+    Also retains the #224 property: an assigned pair is not reported as FN + FA.
     """
     gt = Invoice(LineItems=[LineItemsInfo(LineItemDays=[])])
     pred = Invoice(LineItems=[LineItemsInfo(LineItemDays=[])])
@@ -243,12 +243,74 @@ def test_empty_simple_list_within_structured_list():
     result = gt.compare_with(pred, include_confusion_matrix=True)
     obj_metrics = _overall(result["confusion_matrix"], "LineItems")
 
+    # Identical objects are a perfect match.
+    assert result["overall_score"] == 1.0
+
+    # The pair is a true positive, and specifically not a false discovery.
+    assert obj_metrics["tp"] == 1
+    assert obj_metrics["fd"] == 0
+
     # The #224 property: the pair is assigned, so neither side is orphaned.
     assert obj_metrics["fn"] == 0
     assert obj_metrics["fa"] == 0
 
-    # Whichever way the pair is classified, it is counted exactly once.
+    # The pair is counted exactly once.
     assert obj_metrics["tp"] + obj_metrics["fd"] + obj_metrics["tn"] == 1
+
+
+@pytest.mark.parametrize("n_items", [1, 2, 3])
+def test_empty_simple_lists_are_true_positives_at_any_length(n_items):
+    """Identical empty-list objects are TPs at n=1 and n>1 alike.
+
+    Regression test for GitHub issue #233, which recorded the contradiction at
+    both lengths: ``overall_score=1.0`` with ``fd=1`` at n=1 and ``fd=2`` at
+    n=2. Parameterized because the 1-vs-1 case reaches Hungarian matching
+    differently from the multi-item case.
+    """
+    items = [LineItemsInfo(LineItemDays=[]) for _ in range(n_items)]
+    gt = Invoice(LineItems=list(items))
+    pred = Invoice(LineItems=list(items))
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    obj_metrics = _overall(result["confusion_matrix"], "LineItems")
+
+    assert result["overall_score"] == 1.0
+    assert obj_metrics["tp"] == n_items
+    assert obj_metrics["fd"] == 0
+    assert obj_metrics["fn"] == 0
+    assert obj_metrics["fa"] == 0
+
+
+@pytest.mark.parametrize(
+    "gt_days,pred_days",
+    [
+        ([], []),
+        (None, None),
+        ([], None),
+        (None, []),
+    ],
+)
+def test_absent_simple_list_agrees_across_score_readers(gt_days, pred_days):
+    """``overall_score`` and the confusion matrix agree on an absent list field.
+
+    Regression test for GitHub issue #233.
+
+    For a list field, ``None`` and ``[]`` both mean "no items", so every
+    combination of the two is a perfect match. ``overall_score`` read that from
+    the threshold-corrected score while the confusion matrix read the raw
+    similarity, and the raw path scored ``[]`` against ``None`` as 0.0 — so the
+    pair reported 1.0 and FD together. Both readers must now agree.
+    """
+    gt = Invoice(LineItems=[LineItemsInfo(LineItemDays=gt_days)])
+    pred = Invoice(LineItems=[LineItemsInfo(LineItemDays=pred_days)])
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    obj_metrics = _overall(result["confusion_matrix"], "LineItems")
+
+    # A perfect score cannot coexist with a false discovery.
+    assert result["overall_score"] == 1.0
+    assert obj_metrics["fd"] == 0
+    assert obj_metrics["tp"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
+++ b/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
@@ -8,9 +8,10 @@ not treated as atomic primitive values.
 See: https://github.com/awslabs/stickler/issues/33
 """
 
-from typing import Any, List, Optional
+from typing import Annotated, Any, Dict, List, Optional
 
 import pytest
+from pydantic import Field
 
 from stickler.comparators.base import BaseComparator
 from stickler.comparators.exact import ExactComparator
@@ -20,7 +21,9 @@ from stickler.structured_object_evaluator.models.comparable_field import (
 )
 from stickler.structured_object_evaluator.models.comparison_helper import (
     ComparisonHelper,
+    _maybe_absent,
 )
+from stickler.structured_object_evaluator.models.null_helper import NullHelper
 from stickler.structured_object_evaluator.models.structured_model import (
     StructuredModel,
 )
@@ -50,9 +53,18 @@ class Pep604Invoice(StructuredModel):
 class EveryListSpelling(StructuredModel):
     """Every spelling of a list annotation. All must be recognized alike.
 
-    ``get_origin`` returns ``list`` only for a *parameterized* spelling, so the
-    three unparameterized ones here used to read as non-list -- including
-    ``list | None``, a PEP 604 optional list. See ``_annotation_is_list``.
+    Two families used to read as non-list:
+
+    - The unparameterized ones, because ``get_origin`` returns ``list`` only for
+      a *parameterized* spelling -- including ``list | None``, a PEP 604
+      optional list.
+    - The ``Annotated`` ones, because pydantic strips ``Annotated`` only when it
+      wraps the whole annotation, and ``get_origin`` reports ``Annotated``
+      rather than the type inside. ``annotated_whole`` is the spelling pydantic
+      does strip, so it always worked; it is here to hold that contrast in
+      place.
+
+    See ``_annotation_is_list`` and ``optional_annotation.unwrap_annotated``.
     """
 
     bare: list = ComparableField(weight=1.0)
@@ -61,6 +73,15 @@ class EveryListSpelling(StructuredModel):
     bare_typing: List = ComparableField(weight=1.0)
     param_pep604_optional: list[str] | None = ComparableField(weight=1.0)
     param_optional: Optional[List[str]] = ComparableField(weight=1.0)
+    annotated_whole: Annotated[Optional[List[str]], "meta"] = ComparableField(weight=1.0)
+    annotated_optional: Optional[Annotated[List[str], "meta"]] = ComparableField(
+        weight=1.0
+    )
+    annotated_pep604: Annotated[List[str], "meta"] | None = ComparableField(weight=1.0)
+    annotated_bare: Annotated[list, "meta"] | None = ComparableField(weight=1.0)
+    annotated_field: Optional[Annotated[List[str], Field(description="d")]] = (
+        ComparableField(weight=1.0)
+    )
 
 
 LIST_SPELLINGS = (
@@ -70,6 +91,21 @@ LIST_SPELLINGS = (
     "bare_typing",
     "param_pep604_optional",
     "param_optional",
+    "annotated_whole",
+    "annotated_optional",
+    "annotated_pep604",
+    "annotated_bare",
+    "annotated_field",
+)
+
+# The spellings that carry an `Annotated` wrapper on the *union arm*, which is
+# where pydantic leaves it in place. `annotated_whole` is excluded: pydantic
+# strips a wrapper around the whole annotation, so it never had the problem.
+ANNOTATED_ARM_SPELLINGS = (
+    "annotated_optional",
+    "annotated_pep604",
+    "annotated_bare",
+    "annotated_field",
 )
 
 
@@ -88,6 +124,17 @@ class NoteLeaf(StructuredModel):
 
 class NoteContainer(StructuredModel):
     items: List[NoteLeaf] = ComparableField(weight=1.0)
+
+
+class DictLeaf(StructuredModel):
+    """A dict field, the third kind of "empty" the documented rule names."""
+
+    meta: Optional[Dict[str, str]] = ComparableField(weight=1.0)
+    match_threshold = 1.0
+
+
+class DictContainer(StructuredModel):
+    items: List[DictLeaf] = ComparableField(weight=1.0)
 
 
 class PartiallyWrongItem(StructuredModel):
@@ -538,6 +585,51 @@ def test_every_list_spelling_records_a_true_negative_when_empty_on_both_sides():
     assert cm["aggregate"]["tn"] == len(LIST_SPELLINGS)
 
 
+@pytest.mark.parametrize("field_name", ANNOTATED_ARM_SPELLINGS)
+@pytest.mark.parametrize(
+    "gt_val,pred_val",
+    [([], []), ([], None), (None, [])],
+)
+def test_annotated_arm_matches_the_plain_optional_list(field_name, gt_val, pred_val):
+    """An ``Annotated`` wrapper on a union arm must not change the metrics.
+
+    Pydantic strips ``Annotated`` when it wraps the whole annotation but leaves
+    it on a union arm, and ``get_origin`` reports ``Annotated`` rather than the
+    wrapped type. So ``Optional[Annotated[List[str], ...]]`` read as non-list
+    while its sibling ``Optional[List[str]]`` read as a list -- and
+    ``Annotated[List[str], ...] | None`` normalises to exactly that spelling.
+
+    The cost showed up in three different ways on the same field, all of them
+    silent: ``[]`` against ``[]`` recorded *no counter at all* (the field
+    vanished from the confusion matrix), ``[]`` against ``None`` recorded an FN,
+    and ``None`` against ``[]`` recorded an FA. The plain spelling records a TN
+    for all three.
+
+    ``Field(description=...)`` produces this annotation, so it is the common
+    spelling in an extraction schema rather than an exotic one.
+    """
+    gt = EveryListSpelling(**{field_name: gt_val})
+    pred = EveryListSpelling(**{field_name: pred_val})
+    plain_gt = EveryListSpelling(**{"param_optional": gt_val})
+    plain_pred = EveryListSpelling(**{"param_optional": pred_val})
+
+    assert gt._is_list_field(field_name) is True
+
+    annotated = _overall(
+        gt.compare_with(pred, include_confusion_matrix=True)["confusion_matrix"],
+        field_name,
+    )
+    plain = _overall(
+        plain_gt.compare_with(plain_pred, include_confusion_matrix=True)[
+            "confusion_matrix"
+        ],
+        "param_optional",
+    )
+
+    assert annotated == plain, f"{field_name} disagrees with Optional[List[str]]"
+    assert annotated["tn"] == 1
+
+
 def test_an_any_annotated_field_is_not_a_list_field():
     """``Any`` holding a list is still not a list *field*, by design.
 
@@ -610,6 +702,133 @@ def test_absent_string_field_agrees_across_score_readers(gt_note, pred_note):
     assert field_metrics["tn"] == 1
     assert field_metrics["fn"] == 0
     assert field_metrics["fa"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests — an empty dict is absent, the third case the documented rule names
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "gt_val,pred_val",
+    [({}, {}), ({}, None), (None, {}), (None, None)],
+)
+def test_absent_dict_field_records_a_true_negative(gt_val, pred_val):
+    """``{}`` is absent, exactly as ``""`` and ``[]`` are.
+
+    ``docs/docs/Advanced/classification-logic.md`` states the rule for all
+    three: "Empty strings, empty lists, and empty objects are treated as null.
+    Comparing any of these with null yields TN."
+    ``is_effectively_null_for_primitives`` covered ``None`` and ``""`` but not
+    ``{}``, so the #233 contradiction survived for a dict field in the opposite
+    direction: two **identical** objects each holding ``{}`` classified as a
+    false discovery rather than a match.
+    """
+    gt = DictContainer(items=[DictLeaf(meta=gt_val)])
+    pred = DictContainer(items=[DictLeaf(meta=pred_val)])
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    cm = result["confusion_matrix"]
+
+    assert result["overall_score"] == 1.0
+    assert _overall(cm, "items")["tp"] == 1
+    assert _overall(cm, "items")["fd"] == 0
+    assert _overall(cm, "items", "meta")["tn"] == 1
+
+
+@pytest.mark.parametrize(
+    "gt_val,pred_val,expected",
+    [({}, {"k": "v"}, "fa"), ({"k": "v"}, {}, "fn"), (None, {"k": "v"}, "fa")],
+)
+def test_dict_field_absent_on_one_side_is_reported_not_raised(
+    gt_val, pred_val, expected
+):
+    """A populated dict against an absent one is FA/FN, and does not raise.
+
+    No comparator accepts a dict -- ``LevenshteinComparator`` raises
+    ``TypeError`` explaining that a ``StructuredModel`` should be used instead.
+    Because ``{}`` did not read as absent, ``{}`` against a populated dict fell
+    through to that comparator, so the pair was *uncomparable* rather than
+    merely mismatched: ``compare()`` raised, which took out Hungarian matching
+    for any ``List[StructuredModel]`` whose element model had a populated dict
+    field. Reading ``{}`` as absent short-circuits before any comparator is
+    consulted.
+
+    Two populated dicts still reach the comparator and still raise; that is a
+    separate gap, and this pins only the absent-on-one-side half.
+
+    Asserted on the leaf directly rather than through ``DictContainer``: the
+    pair scores ``0.0``, so inside a list it is a below-threshold FD and gets no
+    field breakdown at all -- that is the documented threshold-gated recursion,
+    not a second bug. The object-level half of that is pinned below.
+    """
+    gt = DictLeaf(meta=gt_val)
+    pred = DictLeaf(meta=pred_val)
+
+    # The regression: this used to raise TypeError out of LevenshteinComparator.
+    assert gt.compare(pred) == 0.0
+
+    cm = gt.compare_with(pred, include_confusion_matrix=True)["confusion_matrix"]
+    assert cm["fields"]["meta"]["overall"][expected] == 1
+
+
+def test_dict_field_absent_on_one_side_is_an_object_level_false_discovery():
+    """Inside a list, the same pair is an FD with no field breakdown.
+
+    The companion to the test above, pinning the gating rather than the field
+    classification. ``DictLeaf.match_threshold`` is ``1.0`` and the pair scores
+    ``0.0``, so the objects are "not really the same" and
+    ``docs/docs/Advanced/threshold-gated-evaluation.md`` calls for treating the
+    pair as atomic. What matters for this fix is that it is reached by scoring
+    rather than by raising.
+    """
+    gt = DictContainer(items=[DictLeaf(meta={})])
+    pred = DictContainer(items=[DictLeaf(meta={"k": "v"})])
+
+    cm = gt.compare_with(pred, include_confusion_matrix=True)["confusion_matrix"]
+
+    assert _overall(cm, "items")["fd"] == 1
+    assert _overall(cm, "items")["tp"] == 0
+    assert cm["fields"]["items"].get("fields", {}) == {}
+
+
+def test_maybe_absent_is_a_superset_of_both_null_rules():
+    """The perf guard must never hide a value either rule calls absent.
+
+    ``compare_field_raw`` consults a field's annotation only when
+    ``_maybe_absent`` says one side could be absent, because that lookup runs
+    for every field of every cell in a Hungarian cost matrix. The guard is
+    therefore an over-approximation of both ``NullHelper`` predicates, and it is
+    only sound while it stays a superset: a value either predicate would call
+    absent but the guard rejects would silently skip true-negative and
+    false-negative handling.
+
+    Adding a case to either predicate without widening the guard fails here.
+    """
+    candidates = [
+        None,
+        "",
+        [],
+        {},
+        "x",
+        ["x"],
+        {"k": "v"},
+        0,
+        0.0,
+        False,
+        set(),
+        (),
+        NoteLeaf(note=None),
+    ]
+
+    for value in candidates:
+        either_rule_calls_it_absent = NullHelper.is_effectively_null_for_lists(
+            value
+        ) or NullHelper.is_effectively_null_for_primitives(value)
+        if either_rule_calls_it_absent:
+            assert _maybe_absent(value) is True, (
+                f"{value!r} is absent under a NullHelper rule but the guard "
+                f"in compare_field_raw would skip the check"
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
+++ b/tests/structured_object_evaluator/test_simple_list_in_structured_list.py
@@ -12,6 +12,7 @@ from typing import Any, List, Optional
 
 import pytest
 
+from stickler.comparators.base import BaseComparator
 from stickler.comparators.exact import ExactComparator
 from stickler.comparators.levenshtein import LevenshteinComparator
 from stickler.structured_object_evaluator.models.comparable_field import (
@@ -44,6 +45,67 @@ class Pep604LineItemsInfo(StructuredModel):
 
 class Pep604Invoice(StructuredModel):
     LineItems: list[Pep604LineItemsInfo] = ComparableField(weight=1.0)
+
+
+class EveryListSpelling(StructuredModel):
+    """Every spelling of a list annotation. All must be recognized alike.
+
+    ``get_origin`` returns ``list`` only for a *parameterized* spelling, so the
+    three unparameterized ones here used to read as non-list -- including
+    ``list | None``, a PEP 604 optional list. See ``_annotation_is_list``.
+    """
+
+    bare: list = ComparableField(weight=1.0)
+    bare_pep604_optional: list | None = ComparableField(weight=1.0)
+    bare_optional: Optional[list] = ComparableField(weight=1.0)
+    bare_typing: List = ComparableField(weight=1.0)
+    param_pep604_optional: list[str] | None = ComparableField(weight=1.0)
+    param_optional: Optional[List[str]] = ComparableField(weight=1.0)
+
+
+LIST_SPELLINGS = (
+    "bare",
+    "bare_pep604_optional",
+    "bare_optional",
+    "bare_typing",
+    "param_pep604_optional",
+    "param_optional",
+)
+
+
+class UntypedListHolder(StructuredModel):
+    """An ``Any``-annotated field, which is deliberately *not* a list field."""
+
+    vals: Any = ComparableField(weight=1.0)
+
+
+class NoteLeaf(StructuredModel):
+    """A non-list field, for the primitive half of #233's parity rule."""
+
+    note: Optional[str] = ComparableField(weight=1.0)
+    match_threshold = 1.0
+
+
+class NoteContainer(StructuredModel):
+    items: List[NoteLeaf] = ComparableField(weight=1.0)
+
+
+class PartiallyWrongItem(StructuredModel):
+    """Two absent-on-both list fields and one field the prediction gets wrong.
+
+    ``match_threshold`` is low enough that the two agreeing empty fields alone
+    carry the pair over it — see
+    ``test_absent_list_fields_lift_a_disagreeing_pair_to_a_true_positive``.
+    """
+
+    a: Optional[List[str]] = ComparableField(weight=1.0)
+    b: Optional[List[str]] = ComparableField(weight=1.0)
+    c: str = ComparableField(comparator=ExactComparator(), threshold=1.0, weight=1.0)
+    match_threshold = 0.5
+
+
+class PartiallyWrongContainer(StructuredModel):
+    items: List[PartiallyWrongItem] = ComparableField(weight=1.0)
 
 
 # ---------------------------------------------------------------------------
@@ -86,6 +148,19 @@ def _overall(cm, *field_path):
         node = node["fields"][f]
     return {k: v for k, v in node["overall"].items()
             if k in ("tp", "fa", "fd", "fp", "tn", "fn")}
+
+
+class _NeverCalledComparator(BaseComparator):
+    """A comparator that fails the test if it is ever invoked.
+
+    Lets a test assert that a code path does not consult its comparator, rather
+    than leaving an unused argument that reads as significant.
+    """
+
+    def _compare(self, str1, str2) -> float:
+        raise AssertionError(
+            f"comparator must not be invoked on this path, got {str1!r}, {str2!r}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -271,9 +346,23 @@ def test_empty_simple_list_within_structured_list():
 
 
 def test_raw_empty_lists_score_as_perfect_match():
-    """The raw unordered-list path agrees that two empty lists match."""
+    """The raw unordered-list path agrees that two empty lists match.
+
+    Two empty lists take the *StructuredModel* branch of
+    ``compare_unordered_lists``, vacuously: that branch is guarded by
+    ``all(isinstance(item, StructuredModel) for item in gt_list[:1])`` on both
+    sides, and ``[][:1]`` is empty, so both ``all()`` calls are trivially true
+    however the lists are annotated. That branch hardcodes its own
+    ``classification_threshold`` of ``0.01`` and never reads ``comparator``.
+
+    So the comparator and ``threshold`` arguments below are inert, and the test
+    says so rather than implying they matter: the comparator is one that raises
+    if it is ever called, which turns the claim into an assertion instead of a
+    comment. ``threshold`` cannot be shown inert the same way -- with no matched
+    pairs the threshold loop never runs, so no value of it changes the result.
+    """
     result = ComparisonHelper.compare_unordered_lists(
-        [], [], ExactComparator(), threshold=1.0
+        [], [], _NeverCalledComparator(), threshold=1.0
     )
 
     assert result == {
@@ -284,6 +373,40 @@ def test_raw_empty_lists_score_as_perfect_match():
         "fp": 0,
         "overall_score": 1.0,
     }
+
+
+@pytest.mark.parametrize(
+    "gt_list,pred_list,expected",
+    [
+        ([], ["x"], {"fa": 1, "fn": 0}),
+        (["x"], [], {"fa": 0, "fn": 1}),
+    ],
+    ids=["gt-empty", "pred-empty"],
+)
+def test_raw_one_sided_empty_list_is_not_a_match(gt_list, pred_list, expected):
+    """One empty side scores 0.0, and reaches ``unordered_list_metrics`` the
+    other way -- through the comparator branch.
+
+    This is the companion route to ``test_raw_empty_lists_score_as_perfect_match``
+    and the guard on the ``else 0.0`` half of the both-empty conditional. Because
+    only one side is empty, exactly one of the two ``all()`` guards is false, so
+    this takes the comparator branch and the ``threshold`` argument *is* honored
+    as ``classification_threshold`` -- both of which the both-empty case cannot
+    reach, since two empty lists always satisfy both guards vacuously.
+
+    Pinning it keeps the #233 fix from over-reaching: scoring two empty lists
+    1.0 must not leak into scoring an empty list against a populated one, which
+    is a genuine miss (FN) or a genuine spurious find (FA), not agreement.
+    """
+    result = ComparisonHelper.compare_unordered_lists(
+        gt_list, pred_list, ExactComparator(), threshold=1.0
+    )
+
+    assert result["overall_score"] == 0.0
+    assert result["tp"] == 0
+    assert result["fd"] == 0
+    assert result["fa"] == expected["fa"]
+    assert result["fn"] == expected["fn"]
 
 
 @pytest.mark.parametrize("n_items", [1, 2, 3])
@@ -358,6 +481,220 @@ def test_pep604_optional_absent_list_agrees_across_score_readers(gt_days, pred_d
     assert field_metrics["tn"] == 1
     assert field_metrics["fn"] == 0
     assert field_metrics["fa"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests — every spelling of a list annotation is recognized as a list field
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("field_name", LIST_SPELLINGS)
+def test_every_list_spelling_is_recognized_as_a_list_field(field_name):
+    """``_is_list_field`` is true for parameterized and bare spellings alike.
+
+    ``get_origin`` returns ``list`` only for a parameterized annotation, so
+    ``list``, ``list | None`` and ``Optional[list]`` used to answer ``False``
+    while ``List``, ``list[str] | None`` and ``Optional[List[str]]`` answered
+    ``True``. ``list | None`` answering differently from ``list[str] | None`` is
+    the odd one: both are PEP 604 optional lists.
+    """
+    instance = EveryListSpelling(**{name: [] for name in LIST_SPELLINGS})
+
+    assert instance._is_list_field(field_name) is True
+
+
+def test_every_list_spelling_records_a_true_negative_when_empty_on_both_sides():
+    """All six spellings produce the same classification evidence.
+
+    The spelling of an annotation must not change the metrics. A field that
+    reads as non-list skips the list null handling in
+    ``ComparisonDispatcher.dispatch_field_comparison`` STEP 3 and falls into the
+    primitive null check, where ``[]`` is not "effectively null" -- so it was
+    routed to ``PrimitiveListComparator``, scored ``1.0``, and recorded *no*
+    classification evidence at all: no TN, no TP, nothing. The score looked
+    right, so the missing row was easy to miss.
+
+    A TN is what the documented rule calls for: both sides agree there are no
+    items. See ``docs/docs/Advanced/classification-logic.md``.
+    """
+    values = {name: [] for name in LIST_SPELLINGS}
+    gt = EveryListSpelling(**values)
+    pred = EveryListSpelling(**values)
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    cm = result["confusion_matrix"]
+
+    assert result["overall_score"] == 1.0
+    for name in LIST_SPELLINGS:
+        assert _overall(cm, name) == {
+            "tp": 0,
+            "fa": 0,
+            "fd": 0,
+            "fp": 0,
+            "tn": 1,
+            "fn": 0,
+        }, f"{name} disagrees with the other spellings"
+
+    # One TN per field, and no spelling silently contributing nothing.
+    assert cm["aggregate"]["tn"] == len(LIST_SPELLINGS)
+
+
+def test_an_any_annotated_field_is_not_a_list_field():
+    """``Any`` holding a list is still not a list *field*, by design.
+
+    This pins the boundary of the spelling fix. ``Any`` is not a list
+    annotation, so it keeps primitive null semantics and routes an empty list to
+    ``PrimitiveListComparator`` -- the one remaining way two empty lists reach
+    ``compare_unordered_lists`` from a model comparison, and what keeps the
+    empty-list fall-through in that function live rather than dead code.
+
+    The pair still scores ``1.0``, and still records no classification evidence.
+    Recording a TN here would mean inferring list-ness from a runtime value
+    rather than an annotation, which is a larger decision than #233 -- so this
+    documents the current answer rather than asserting it is the desired one.
+    """
+    gt = UntypedListHolder(vals=[])
+    pred = UntypedListHolder(vals=[])
+
+    assert gt._is_list_field("vals") is False
+    assert gt.compare(pred) == 1.0
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    assert result["overall_score"] == 1.0
+    assert _overall(result["confusion_matrix"], "vals") == {
+        "tp": 0,
+        "fa": 0,
+        "fd": 0,
+        "fp": 0,
+        "tn": 0,
+        "fn": 0,
+    }
+
+
+@pytest.mark.parametrize(
+    "gt_note,pred_note",
+    [
+        ("", ""),
+        (None, None),
+        ("", None),
+        (None, ""),
+    ],
+)
+def test_absent_string_field_agrees_across_score_readers(gt_note, pred_note):
+    """The parity rule covers non-list fields too, not just lists.
+
+    Regression test for GitHub issue #233.
+
+    The list half of the parity fix left the primitive half open. The dispatcher
+    reads absence for a non-list field with
+    ``NullHelper.is_effectively_null_for_primitives``, which treats ``""`` and
+    ``None`` as the same thing, while the raw path tested bare ``is None``. So
+    the same contradiction reproduced for a string field that is ``""`` on one
+    side and ``None`` on the other: ``overall_score == 1.0`` reported alongside
+    ``fd == 1``. Both readers must agree here for the same reason they must
+    agree for lists.
+    """
+    gt = NoteContainer(items=[NoteLeaf(note=gt_note)])
+    pred = NoteContainer(items=[NoteLeaf(note=pred_note)])
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    cm = result["confusion_matrix"]
+    object_metrics = _overall(cm, "items")
+    field_metrics = _overall(cm, "items", "note")
+
+    # A perfect score cannot coexist with a false discovery.
+    assert result["overall_score"] == 1.0
+    assert object_metrics["tp"] == 1
+    assert object_metrics["fd"] == 0
+
+    # Both sides agree there is no value, which is a true negative.
+    assert field_metrics["tn"] == 1
+    assert field_metrics["fn"] == 0
+    assert field_metrics["fa"] == 0
+
+
+@pytest.mark.parametrize(
+    "gt_note,pred_note",
+    [
+        ("", "n"),
+        ("n", ""),
+        (None, "n"),
+        ("n", None),
+    ],
+)
+def test_absent_string_against_populated_is_not_leniently_matched(gt_note, pred_note):
+    """Absent-vs-populated is still a total mismatch, on both readers.
+
+    The #233 rule is equivalence between the two spellings of *absent*, not
+    leniency: ``""`` does not become a wildcard that matches any string. This
+    pins the other side of the branch, so widening the null rule cannot quietly
+    turn a missed value into a match.
+    """
+    leaf_score = NoteLeaf(note=gt_note).compare(NoteLeaf(note=pred_note))
+    gt = NoteContainer(items=[NoteLeaf(note=gt_note)])
+    pred = NoteContainer(items=[NoteLeaf(note=pred_note)])
+
+    result = gt.compare_with(pred, include_confusion_matrix=True)
+    object_metrics = _overall(result["confusion_matrix"], "items")
+
+    # Both readers agree the pair is wrong, so there is no contradiction here
+    # either -- it is just a false discovery rather than a true positive.
+    assert leaf_score == 0.0
+    assert result["overall_score"] == 0.0
+    assert object_metrics["tp"] == 0
+    assert object_metrics["fd"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests — object matching counts absent-on-both fields toward the threshold
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("absent", [[], None], ids=["empty-list", "none"])
+def test_absent_list_fields_lift_a_disagreeing_pair_to_a_true_positive(absent):
+    """Absent-on-both fields count toward ``match_threshold``. Deliberate.
+
+    This is the metric consequence of the #233 fix, pinned because it is not
+    self-evidently desirable. ``HungarianHelper`` classifies an object pair by
+    its raw similarity, and an absent-on-both field now contributes a full
+    ``1.0`` to that average. So a pair that disagrees on *every* value a user
+    actually supplied can still clear ``match_threshold`` on the strength of its
+    absent fields: here two of three fields are absent on both sides, the third
+    disagrees outright, and the pair scores ``2/3`` and classifies as TP. Before
+    the fix the ``[]`` spelling scored ``0.0`` and classified as FD.
+
+    Parameterized over both spellings of absent because that is the argument for
+    the flip: ``None`` already behaved this way, so the fix extends existing
+    semantics to ``[]`` rather than inventing a rule. The two ids must stay
+    equal — if they ever diverge, the parity #233 is about has reopened.
+
+    The inflation this permits is real and worth stating: precision rises with
+    the number of absent optional fields a schema declares. The field-level
+    counts are what keep the report honest — ``c`` is still reported as a false
+    discovery, and the aggregate still carries ``fd == 1``. Only the
+    *object-level* classification moves.
+    """
+    gt_item = PartiallyWrongItem(a=absent, b=absent, c="alpha")
+    pred_item = PartiallyWrongItem(a=absent, b=absent, c="zzzzz")
+
+    # Two of three fields agree (vacuously), the third does not.
+    assert gt_item.compare(pred_item) == pytest.approx(2 / 3)
+
+    result = PartiallyWrongContainer(items=[gt_item]).compare_with(
+        PartiallyWrongContainer(items=[pred_item]), include_confusion_matrix=True
+    )
+    cm = result["confusion_matrix"]
+
+    # 2/3 clears match_threshold=0.5, so the pair is an object-level TP.
+    assert _overall(cm, "items")["tp"] == 1
+    assert _overall(cm, "items")["fd"] == 0
+
+    # The disagreement is not swallowed: the field that is wrong is still wrong,
+    # the vacuously-agreeing fields are true negatives rather than true
+    # positives, and the aggregate still reports the false discovery.
+    assert _overall(cm, "items", "c")["fd"] == 1
+    assert _overall(cm, "items", "a")["tn"] == 1
+    assert _overall(cm, "items", "b")["tn"] == 1
+    assert cm["aggregate"]["fd"] == 1
+    assert cm["aggregate"]["tp"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/structured_object_evaluator/test_structured_model_evaluator_nested.py
+++ b/tests/structured_object_evaluator/test_structured_model_evaluator_nested.py
@@ -4,23 +4,10 @@ This test verifies that we can calculate precision, recall, F1, and accuracy met
 at the field level and object level for nested structures in the toy veterinary records models
 using the direct compare_with() method.
 
-IMPORTANT: This test uses the CORRECT expected values based on the actual behavior of the
-structured comparison system. The original test had incorrect expectations based on naive
-field-by-field counting, but the system actually performs sophisticated comparison logic:
-
-1. **Threshold-based matching**: Fields must meet similarity thresholds to be considered matches
-2. **Object-level similarity scoring**: Nested objects are evaluated as units, not just field sums
-3. **Weighted aggregation**: Different field types contribute differently to overall metrics
-4. **Complex nested structure handling**: Lists and nested objects have specialized comparison logic
-
-The expected values in this test (TP=5, FD=1, FA=1, FN=1, TN=3) represent the ACTUAL correct
-behavior of the system after proper threshold-based comparison and object-level aggregation.
-These values were verified through minimal test cases that confirmed the field-level metrics
-are captured correctly and the aggregation logic is working as designed.
-
-DO NOT change these expected values without understanding that the system is working correctly
-and any changes would need to be justified by actual bugs in the comparison logic, not by
-manual field counting that ignores thresholds and object-level similarity.
+The expectations follow threshold-gated evaluation: object pairs below
+``match_threshold`` are atomic false discoveries and produce no field-level
+breakdown. True negatives are excluded from the object similarity used for
+that gate.
 """
 
 from typing import List, Optional
@@ -317,97 +304,19 @@ class TestVetRecordsMetricsCalculation:
 
     def test_pets_list_of_structured_model(self):
         """Test that list fields like 'pets' are correctly matched based on nested objects."""
-
-        # Helper function to get metrics from unified structure
-        def get_metric(field_data, metric):
-            # Use "overall" key for individual field performance metrics if it exists
-            if "overall" in field_data:
-                return field_data["overall"][metric]
-            else:
-                # Fallback: metrics are directly at the field level
-                return field_data.get(metric, 0)
-
-        # Create VeterinaryRecord objects
         gold_record = VeterinaryRecord(**self.gold_record)
         pred_record = VeterinaryRecord(**self.pred_record)
 
-        # Use direct compare_with method instead of evaluator
         results = gold_record.compare_with(pred_record, include_confusion_matrix=True)
-
-        # Expected metrics
-        # 9 true positive: recordId, owner.id, owner.name, pets[0].petId, pets[0].name, pets[0].species, pets[0].breed, pets[1].petId, pets[1].name
-        # 3 true negative: pets[1].breed, pets[1].birthdate, pets[1].weight
-        # 2 false discovery: owner.contact.phone, pets[0].birthdate
-        # 2 false alarm: owner.contact.email, pets[0].weight
-        # 1 false negative: pets[1].species
-
-        # Confusion matrix metrics
         cm = results["confusion_matrix"]
 
-        # Direct access to metrics for pet fields (not in "overall")
-        assert (
-            get_metric(cm["fields"]["pets"]["fields"]["petId"], "tp") == 1
-        ), "Expected 1 true positives"
-        assert (
-            get_metric(cm["fields"]["pets"]["fields"]["petId"], "fd") == 0
-        ), "Expected 0 false discovery"
-        assert (
-            get_metric(cm["fields"]["pets"]["fields"]["petId"], "fa") == 0
-        ), "Expected 0 false alarm"
-        assert (
-            get_metric(cm["fields"]["pets"]["fields"]["petId"], "fn") == 0
-        ), "Expected 0 false negatives"
-        assert (
-            get_metric(cm["fields"]["pets"]["fields"]["petId"], "tn") == 0
-        ), "Expected 0 true negatives"
-
-        assert (
-            get_metric(cm["fields"]["pets"]["fields"]["name"], "tp") == 1
-        ), "Expected 1 true positives"
-        assert (
-            get_metric(cm["fields"]["pets"]["fields"]["name"], "fd") == 0
-        ), "Expected 0 false discovery"
-        assert (
-            get_metric(cm["fields"]["pets"]["fields"]["name"], "fa") == 0
-        ), "Expected 0 false alarm"
-        assert (
-            get_metric(cm["fields"]["pets"]["fields"]["name"], "fn") == 0
-        ), "Expected 0 false negatives"
-        assert (
-            get_metric(cm["fields"]["pets"]["fields"]["name"], "tn") == 0
-        ), "Expected 0 true negatives"
-
-        # Species metrics - Debug showed TP=0, not 1 as expected
-        assert (
-            get_metric(cm["fields"]["pets"]["fields"]["species"], "tp") == 0
-        ), "Expected 0 true positives"
-        assert (
-            get_metric(cm["fields"]["pets"]["fields"]["species"], "fd") == 0
-        ), "Expected 0 false discovery"
-        assert (
-            get_metric(cm["fields"]["pets"]["fields"]["species"], "fa") == 0
-        ), "Expected 0 false alarm"
-        assert (
-            get_metric(cm["fields"]["pets"]["fields"]["species"], "fn") == 1
-        ), "Expected 1 false negatives"
-        assert (
-            get_metric(cm["fields"]["pets"]["fields"]["species"], "tn") == 0
-        ), "Expected 0 true negatives"
-
-        # Overall pets metrics - Using "overall" key for individual pets field performance
-        assert (
-            get_metric(cm["fields"]["pets"], "tp") == 1
-        ), "Expected 1 true positive for pets field overall performance"
-        assert (
-            get_metric(cm["fields"]["pets"], "fd") == 1
-        ), "Expected 1 false discovery for pets field overall performance"
-        assert get_metric(cm["fields"]["pets"], "fa") == 0, "Expected 0 false alarm"
-        assert (
-            get_metric(cm["fields"]["pets"], "fn") == 0
-        ), "Expected 0 false negative for pets field overall performance"
-        assert (
-            get_metric(cm["fields"]["pets"], "tn") == 0
-        ), "Expected 0 true negatives for pets field overall performance"
+        assert gold_record.pets[0].compare(pred_record.pets[0]) == pytest.approx(2 / 3)
+        assert gold_record.pets[1].compare(pred_record.pets[1]) == pytest.approx(2 / 3)
+        assert cm["fields"]["pets"]["overall"]["tp"] == 0
+        assert cm["fields"]["pets"]["overall"]["fd"] == 2
+        assert cm["fields"]["pets"]["overall"]["fa"] == 0
+        assert cm["fields"]["pets"]["overall"]["fn"] == 0
+        assert cm["fields"]["pets"]["fields"] == {}
 
     def test_overall_metrics(self):
         """Test correct aggregation and calculation of overall metrics."""
@@ -418,121 +327,31 @@ class TestVetRecordsMetricsCalculation:
         # Use direct compare_with method instead of evaluator
         results = gold_record.compare_with(pred_record, include_confusion_matrix=True)
 
-        # Expected metrics WITH OBJECT-LEVEL COUNTING
-        # With object-level counting:
-        # - recordId: 1 TP (simple field match)
-        # - owner: 0 TP (owner object similarity below threshold due to contact differences)
-        # - pets[1]: 1 TP (object-level match for second pet)
-        # - pets[0]: 0 TP (object similarity below threshold due to birthdate difference)
-        # 2 true positive: recordId, pets[1] (object-level matches)
-        # 0 true negative: (no null vs null cases in this test)
-        # 2 false discovery: owner (object below threshold), pets[0] (object below threshold)
-        # 0 false alarm: (nested field-level FAs don't aggregate to overall level)
-        # 0 false negative: (no unmatched ground truth)
-
-        # Confusion matrix metrics
         cm = results["confusion_matrix"]
 
-        assert (
-            cm["overall"]["tp"] == 2
-        ), "Expected 2 true positives (object-level counting)"
-        assert cm["overall"]["tn"] == 0, "Expected 0 true negatives"
-        assert cm["overall"]["fd"] == 2, "Expected 2 false discovery"
-        assert (
-            cm["overall"]["fa"] == 0
-        ), "Expected 0 false alarm (nested field FAs don't aggregate to overall)"
-        assert (
-            cm["overall"]["fp"] == 2
-        ), "Expected 2 false positive"  # false discovery only
-        assert cm["overall"]["fn"] == 0, "Expected 0 false negative"
+        # recordId is TP; owner and both pet pairs are atomic FDs.
+        assert cm["overall"]["tp"] == 1
+        assert cm["overall"]["tn"] == 0
+        assert cm["overall"]["fd"] == 3
+        assert cm["overall"]["fa"] == 0
+        assert cm["overall"]["fp"] == 3
+        assert cm["overall"]["fn"] == 0
 
-        # Check aggregate metrics from confusion_matrix.aggregate.derived
-        # CORRECT VALUES based on actual system behavior: TP=5, FD=1, FA=1, FN=1, TN=3
-        # These values reflect the sophisticated comparison logic including:
-        # - Threshold-based matching (not just exact field equality)
-        # - Object-level similarity scoring for nested structures
-        # - Proper aggregation across complex nested hierarchies
-        # Precision = TP/(TP+FD+FA) = 5/(5+1+1) = 5/7 = 0.714
-        # Recall = TP/(TP+FN) = 5/(5+1) = 5/6 = 0.833
-        # F1 = 2*precision*recall/(precision+recall) = 2*0.714*0.833/(0.714+0.833) = 0.769
+        # Aggregate: TP=3, FD=3, FA=1, FN=0, TN=0.
         derived_metrics = cm["aggregate"]["derived"]
-        assert derived_metrics["cm_precision"] == pytest.approx(0.714, abs=0.001)
-        assert derived_metrics["cm_recall"] == pytest.approx(0.833, abs=0.001)
-        assert derived_metrics["cm_f1"] == pytest.approx(0.769, abs=0.001)
-
-        # ============================================================================
-        # Test with alternative recall formula (recall_with_fd=True)
-        # ============================================================================
-        # IMPORTANT: This test verifies that recall_with_fd=True correctly includes
-        # False Discoveries (FD) in the recall denominator.
-        #
-        # BACKGROUND:
-        # -----------
-        # The original test incorrectly expected both recall modes to return 0.833.
-        # This was mathematically impossible because this test case has FD=1.
-        #
-        # The two recall formulas are fundamentally different:
-        #   1. Traditional recall (recall_with_fd=False): TP / (TP + FN)
-        #   2. Alternative recall (recall_with_fd=True):  TP / (TP + FN + FD)
-        #
-        # When FD > 0, these formulas CANNOT return the same value.
-        #
-        # MATHEMATICAL PROOF:
-        # -------------------
-        # Given aggregate metrics: TP=5, FD=1, FA=1, FN=1, TN=3
-        #
-        # Traditional recall:
-        #   TP / (TP + FN) = 5 / (5 + 1) = 5/6 = 0.8333...
-        #
-        # Alternative recall (with FD):
-        #   TP / (TP + FN + FD) = 5 / (5 + 1 + 1) = 5/7 = 0.7142857...
-        #
-        # These are clearly different: 0.833 ≠ 0.714
-        #
-        # WHY THE CHANGE:
-        # ---------------
-        # The original test expected 0.833 for recall_with_fd=True, which would mean
-        # FD was NOT being included in the denominator. This was incorrect.
-        #
-        # The correct expectation is 0.714, which proves that FD IS being included
-        # in the denominator as intended by the recall_with_fd parameter.
-        #
-        # F1 SCORE IMPACT:
-        # ----------------
-        # Since F1 = 2 * (Precision * Recall) / (Precision + Recall), changing
-        # recall from 0.833 to 0.714 also changes F1:
-        #
-        # With traditional recall (0.833):
-        #   F1 = 2 * (0.714 * 0.833) / (0.714 + 0.833) = 0.769
-        #
-        # With alternative recall (0.714):
-        #   F1 = 2 * (0.714 * 0.714) / (0.714 + 0.714) = 0.714
-        #
-        # VERIFICATION:
-        # -------------
-        # You can verify this is correct by checking that:
-        #   cm["aggregate"]["tp"] = 5
-        #   cm["aggregate"]["fn"] = 1
-        #   cm["aggregate"]["fd"] = 1
-        #   5 / (5 + 1 + 1) = 0.7142857... ✓
-        # ============================================================================
+        assert derived_metrics["cm_precision"] == pytest.approx(3 / 7)
+        assert derived_metrics["cm_recall"] == 1.0
+        assert derived_metrics["cm_f1"] == pytest.approx(0.6)
 
         results_alt = gold_record.compare_with(
             pred_record, include_confusion_matrix=True, recall_with_fd=True
         )
         derived_metrics_alt = results_alt["confusion_matrix"]["aggregate"]["derived"]
 
-        # Verify the aggregate metrics are what we expect
         cm_alt = results_alt["confusion_matrix"]
-        assert cm_alt["aggregate"]["tp"] == 5, "Sanity check: TP should be 5"
-        assert cm_alt["aggregate"]["fn"] == 1, "Sanity check: FN should be 1"
-        assert cm_alt["aggregate"]["fd"] == 1, "Sanity check: FD should be 1"
-
-        # Now verify the derived metrics with FD included in recall denominator
-        assert derived_metrics_alt["cm_precision"] == pytest.approx(0.714, abs=0.001)
-        assert (
-            derived_metrics_alt["cm_recall"] == pytest.approx(0.714, abs=0.001)
-        ), "Recall with FD should be TP/(TP+FN+FD) = 5/(5+1+1) = 0.714, not 0.833"
-        assert (
-            derived_metrics_alt["cm_f1"] == pytest.approx(0.714, abs=0.001)
-        ), "F1 changes because recall changed from 0.833 to 0.714"
+        assert cm_alt["aggregate"]["tp"] == 3
+        assert cm_alt["aggregate"]["fn"] == 0
+        assert cm_alt["aggregate"]["fd"] == 3
+        assert derived_metrics_alt["cm_precision"] == pytest.approx(3 / 7)
+        assert derived_metrics_alt["cm_recall"] == pytest.approx(0.5)
+        assert derived_metrics_alt["cm_f1"] == pytest.approx(6 / 13)


### PR DESCRIPTION
# Fixes #233

*Description of changes:*

Aligns raw list scoring with `compare_with()` semantics:

- Scores two empty lists as a perfect match.
- Treats `None` and `[]` as equivalent for list fields.
- Supports both `Optional[List[T]]` and `list[T] | None`.
- Adds regression coverage for single/multiple items and the raw helper path.

This prevents identical objects from reporting `overall_score=1.0` while being classified as false discoveries.

*Validation:*

- 1,979 tests passed, 12 skipped
- `ruff check src tests` passed

---

> ⚠️**Note:** this replaces #272, reopened from a different GitHub account (`dimasjackson` -> `dimasjac`). The branch contents are unchanged. The review discussion on #272 covering threshold-gated recursion and the mAP framing is still the relevant context for this change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
