### PR TITLE
fix(pretty_print): default name_width to 0 when per-field confusion matrix is empty (#307)

### DIFF
--- a/src/stickler/structured_object_evaluator/utils/pretty_print.py
+++ b/src/stickler/structured_object_evaluator/utils/pretty_print.py
@@ -518,7 +518,7 @@ def _print_field_details(
         sorted_fields = sorted(cm_fields.items(), key=get_metric, reverse=True)
 
     # Prepare format strings for the table
-    name_width = max(max(len(name) for name in cm_fields.keys()), 20)
+    name_width = max(max((len(name) for name in cm_fields.keys()), default=0), 20)
     row_format = (
         "{:<"
         + str(name_width)

--- a/tests/structured_object_evaluator/test_confusion_matrix_printing.py
+++ b/tests/structured_object_evaluator/test_confusion_matrix_printing.py
@@ -1,0 +1,88 @@
+"""Tests for print_confusion_matrix, including empty-fields edge cases (issue #307)."""
+
+import pytest
+
+from stickler import StructuredModel
+from stickler.structured_object_evaluator.utils.pretty_print import (
+    print_confusion_matrix,
+)
+
+
+class EmptyModel(StructuredModel):
+    pass
+
+
+class PersonModel(StructuredModel):
+    name: str
+    age: int
+
+
+def test_print_confusion_matrix_empty_model_does_not_raise(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An empty StructuredModel produces an empty fields dict and must not raise."""
+    cm = EmptyModel().compare_with(EmptyModel(), include_confusion_matrix=True)
+    print_confusion_matrix(cm, use_color=False)
+
+    captured = capsys.readouterr()
+    assert "CONFUSION MATRIX SUMMARY" in captured.out
+    assert "FIELD-LEVEL METRICS" in captured.out
+
+
+def test_print_confusion_matrix_empty_dict_does_not_raise(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A hand-built results dict with empty fields must not raise."""
+    raw_cm = {
+        "confusion_matrix": {
+            "fields": {},
+            "overall": {
+                "tp": 0,
+                "fp": 0,
+                "tn": 0,
+                "fn": 0,
+                "fd": 0,
+                "derived": {
+                    "cm_precision": 0.0,
+                    "cm_recall": 0.0,
+                    "cm_f1": 0.0,
+                    "cm_accuracy": 0.0,
+                },
+            },
+        }
+    }
+    print_confusion_matrix(raw_cm, use_color=False)
+
+    captured = capsys.readouterr()
+    assert "CONFUSION MATRIX SUMMARY" in captured.out
+    assert "FIELD-LEVEL METRICS" in captured.out
+
+
+def test_print_confusion_matrix_filter_matching_nothing_does_not_raise(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When field_filter matches zero fields, the empty filtered set must not raise."""
+    gt = PersonModel(name="Alice", age=30)
+    pred = PersonModel(name="Alice", age=30)
+    cm = gt.compare_with(pred, include_confusion_matrix=True)
+
+    print_confusion_matrix(cm, field_filter="^nomatch_.*", use_color=False)
+
+    captured = capsys.readouterr()
+    assert "FIELD-LEVEL METRICS" in captured.out
+
+
+def test_print_confusion_matrix_normal_model_renders_fields(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Non-empty models continue to format field rows as before."""
+    gt = PersonModel(name="Alice", age=30)
+    pred = PersonModel(name="Alice", age=30)
+    cm = gt.compare_with(pred, include_confusion_matrix=True)
+
+    print_confusion_matrix(cm, use_color=False)
+
+    captured = capsys.readouterr()
+    assert "FIELD-LEVEL METRICS" in captured.out
+    assert "name" in captured.out
+    assert "age" in captured.out


### PR DESCRIPTION
Fixes #307.

## Problem

`print_confusion_matrix` raises a `ValueError` when printing a comparison that has an empty per-field confusion matrix (such as a model with no comparable fields, an empty results dictionary, or a regex filter that matches no fields):

```
src/stickler/structured_object_evaluator/utils/pretty_print.py:521: in _print_field_details
    name_width = max(max(len(name) for name in cm_fields.keys()), 20)
ValueError: max() iterable argument is empty
```

## Solution

Give the inner `max()` a default value of `0`:

```python
name_width = max(max((len(name) for name in cm_fields.keys()), default=0), 20)
```

Since the outer `max` floors the result at `20`, providing `default=0` ensures that empty field maps fall back cleanly to `20` without throwing a `ValueError`.

## Changes

- `src/stickler/structured_object_evaluator/utils/pretty_print.py`: Added `default=0` to the inner generator `max()`.
- `tests/structured_object_evaluator/test_confusion_matrix_printing.py`: Added tests verifying that:
  - An empty `StructuredModel` does not raise.
  - A raw results dict with empty fields does not raise.
  - A regex filter matching zero fields does not raise.
  - Standard populated models continue to print with expected columns and field names.

## Verification

- `pytest tests/structured_object_evaluator/test_confusion_matrix_printing.py` passes (4/4).
- `pytest tests/structured_object_evaluator/test_confusion_matrix_*.py` passes (19/19).
- `ruff check` and `black --check` pass cleanly.
