### PR TITLE
docs(239): state one rule for fields the author did not configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Each release links to full notes on the
 
 ## [Unreleased]
 
+### Documentation
+
+- Stated the contract for fields the author did not configure: when no comparator
+  is named, the comparator and threshold are inferred from the field's type and
+  name, and the answer is the same whether the model came from a plain
+  `BaseModel`, a `StructuredModel` with bare annotations, `model_from_json`, or
+  `from_json_schema`. Also stated that `match_threshold` gates object pairing
+  only and never sets a field's threshold, which the threshold cheat sheet
+  already implied but one section contradicted. Documentation only; the code does
+  not yet match on every path, and where it disagrees the entry point is the
+  defect ([#239](https://github.com/awslabs/stickler/issues/239),
+  [#237](https://github.com/awslabs/stickler/issues/237)).
+
 ### Fixed
 
 - `overall_score` and the confusion matrix no longer disagree about a field that

--- a/docs/docs/Getting-Started/thresholds-and-metrics.md
+++ b/docs/docs/Getting-Started/thresholds-and-metrics.md
@@ -39,7 +39,12 @@ class Invoice(StructuredModel):
 - **TP vs FD classification:** If `similarity >= threshold`, the field is a True Positive. Otherwise, it's a False Discovery.
 - **Score clipping:** When `clip_under_threshold=True` (the default), scores below the threshold are zeroed out in the weighted average.
 
-**Default:** `0.5`
+**Default:** `0.5` when you write `ComparableField(...)` and omit `threshold`.
+
+**When you name no comparator at all,** the threshold is not `0.5`. It is inferred
+alongside the comparator, from the field's type and name, and it is tuned to
+whatever was chosen: exact matching demands `1.0`, loose text matching accepts
+`0.85`. See [Unspecified fields](#unspecified-fields) below.
 
 ### 3. Model Match Threshold
 
@@ -75,6 +80,43 @@ spec = stickler.eval_for(Invoice, match_threshold=0.8)
 
 **Default:** `0.7`
 
+## Unspecified fields
+
+If you tell Stickler how to compare a field, it does what you said. If you
+don't, Stickler picks for you, by looking at the field's type and its name.
+
+There is one rule, and it does not depend on how you built the model. All four
+of these say the same thing, so all four get the same answer:
+
+```python
+sku: str                                      # plain annotation
+sku: str = ComparableField()                  # no comparator named
+{"sku": {"type": "str"}}                      # JSON config, no comparator key
+{"sku": {"type": "string"}}                   # JSON Schema, no extension
+```
+
+Stickler reads the type first, then the name. A number is compared as a number.
+A date as a date. A true/false exactly. Text loosely, so a small typo still
+counts. But text in a field *named* like an identifier, `sku`, `invoice_id`,
+`code`, is compared exactly, because being one character off on an ID is being
+wrong, not being close.
+
+Each choice carries a threshold suited to it, which is why there is no single
+default to quote. `auto/README.md` holds the full table.
+
+To see what was chosen for a given model:
+
+```python
+stickler.eval_for(MyModel).explain()
+```
+
+That reports the comparator, the threshold, and why each was picked. Nothing is
+decided invisibly.
+
+Inference is a default, not a verdict. Stickler guesses from a name and a type
+and cannot know your data, so if `reference` is a fuzzy human-entered string in
+your world, declare it explicitly.
+
 ## Threshold Precedence
 
 When multiple thresholds could apply, here's which one wins:
@@ -82,6 +124,7 @@ When multiple thresholds could apply, here's which one wins:
 | Situation | Which threshold applies |
 |-----------|------------------------|
 | **Primitive field comparison** (str, int, float) | Field threshold (`ComparableField(threshold=...)`) |
+| **Primitive field with no comparator named** | Inferred threshold, from the field's type and name |
 | **Nested object comparison** | Recurses into fields; each field uses its own field threshold |
 | **List element pairing** (`List[StructuredModel]`) | Runtime match threshold if provided, else Model match threshold |
 | **Score clipping** | Field threshold (when `clip_under_threshold=True`) |
@@ -94,6 +137,10 @@ When multiple thresholds could apply, here's which one wins:
 2. **Match threshold** controls object-level TP/FD classification for list matching.
 3. **Runtime match threshold** overrides model-level match threshold.
 4. **Comparator threshold** is only used by `binary_compare()`; evaluation ignores it.
+5. **`match_threshold` never sets a field's threshold.** It answers one question:
+   are these two objects in a list the same object? Whether a field matched is a
+   different question, and a single number cannot mean both. To make one field
+   lenient, say so on that field: `ComparableField(threshold=0.6)`.
 
 ### Example: All Four in Action
 
@@ -243,14 +290,15 @@ subject to any threshold, so:
   precision `0.667`
 - 2 against 1 still yields an FN, giving recall `0.5`
 
-**`match_threshold = 0.0` warns unconditionally**, because the value is used two
-ways: as the object-matching threshold for a `List[StructuredModel]` element,
-*and* as the default field threshold for any field with no explicit config. A
-plainly annotated `name: str` inherits it, so a standalone model with no list
-anywhere still reports `1.0` across the board. Declaring the field with
-`ComparableField()` instead takes an earlier branch that supplies a hardcoded
-`0.5`, which is why the value can look inert when probed that way (see
-[#237](https://github.com/awslabs/stickler/issues/237)).
+**`match_threshold = 0.0` warns unconditionally**, because a model that is not a
+list element today may become one tomorrow, and the warning is cheaper than the
+silent `1.0` that follows.
+
+It gates object pairing only. It does not set the threshold of any field, so a
+standalone model with no list anywhere is unaffected by it. If you probe a
+plainly annotated `name: str` and find it carrying the `match_threshold` value,
+that is [#237](https://github.com/awslabs/stickler/issues/237), a defect against
+the contract stated above, not the contract itself.
 
 **Fix:** use a small positive value.
 
@@ -373,7 +421,8 @@ Recall (with FD) = TP / (TP + FN + FD) = 5 / (5 + 1 + 1) = 0.714
 |-----------|-----------|------------------|---------|
 | Comparator | `Comparator(threshold=...)` | `binary_compare()` only | varies |
 | Field | `ComparableField(threshold=...)` | TP/FD for primitives, clipping | 0.5 |
-| Model | `match_threshold = ...` on class | Hungarian pairing | 0.7 |
+| Field (inferred) | nothing; no comparator named | same as above | per type and name |
+| Model | `match_threshold = ...` on class | Hungarian pairing, and nothing else | 0.7 |
 | Runtime | `evaluate(..., match_threshold=...)` | Overrides model threshold | 0.7 |
 
 ### Metric Formulas

--- a/src/stickler/auto/README.md
+++ b/src/stickler/auto/README.md
@@ -27,11 +27,31 @@ The two pre-existing entry points lose information from real pydantic models:
   thresholds, weights and comparators.
 - Unannotated `StructuredModel` fields fall through
   `configuration_helper.py`'s type-blind default and get compared with
-  `LevenshteinComparator`, which is wrong for `float`, `bool`, `date`.
+  `LevenshteinComparator`, which is wrong for `float`, `bool`, `date`. This is a
+  defect against the parity contract below, tracked by
+  [#239](https://github.com/awslabs/stickler/issues/239), not a property of that
+  entry point.
 
 `auto` walks the **live** `cls.model_fields` (keeping every python-type signal)
 and infers a real per-field comparator, so "unconfigured" already means
 "reasonably configured."
+
+## The inference table governs every path
+
+`infer_field_config` is the single answer to "no comparator was named", not just
+the answer for plain `BaseModel`. The same table applies whether the model came
+from a plain `BaseModel`, a hand-written `StructuredModel` with bare annotations,
+`model_from_json`, or `from_json_schema`. A field the author did not configure
+gets the same comparator and threshold on all four, and
+`stickler.eval_for(Model).explain()` reports it on all four.
+
+That parity is the contract. Where an entry point currently disagrees, the entry
+point is wrong, not the table
+([#239](https://github.com/awslabs/stickler/issues/239)).
+
+An explicit declaration always wins, per parameter: naming a comparator but not
+a threshold takes the inferred threshold, and vice versa. Inference fills gaps;
+it never overrides a stated choice.
 
 ## Architecture
 


### PR DESCRIPTION
## Issue Reference

Refs #239, #237

## What this is

**Documentation only.** No behavior change: 0 python files touched, `2023 passed, 12 skipped`.

This is step 1 of #239. It records what *should* happen before any code moves, so the contract is reviewable on its own terms and the implementation has a spec to be measured against rather than a spec to define. Review this on whether the rule is right and completely stated, not on whether the code currently does it. It does not.

## The rule being stated

**1. If no comparator is named, the comparator and threshold are inferred from the field's type and name, and the answer does not depend on how the model was built.**

All four of these say the same thing, so all four get the same answer:

```python
sku: str                                      # plain annotation
sku: str = ComparableField()                  # no comparator named
{"sku": {"type": "str"}}                      # JSON config, no comparator key
{"sku": {"type": "string"}}                   # JSON Schema, no extension
```

**2. `match_threshold` gates object pairing and nothing else.** It does not set any field's threshold. "Is this the same line item?" and "is this the right SKU?" are different questions, and one number cannot answer both.

## Neither of these is new

That is the part worth checking hardest, because it changes what this PR is.

The threshold cheat sheet already listed `match_threshold` as controlling "Hungarian pairing" and nothing else. Section 3, "What it gates", already described it as Hungarian classification plus recursive evaluation, with no mention of field thresholds.

Only one paragraph said otherwise, in the zero-threshold section:

> `match_threshold = 0.0` warns unconditionally, because the value is used two ways: as the object-matching threshold for a `List[StructuredModel]` element, *and* as the default field threshold for any field with no explicit config. A plainly annotated `name: str` inherits it ... (see #237)

That paragraph documented observed behavior and cited #237 as the tracking issue. It is rewritten to name the coupling as a defect against the contract rather than as the contract.

So the code is what diverged. This makes the documentation self-consistent and gives the fix a clear target.

## What the code does today

The same logical model, declared two ways:

```
class P(BaseModel):          class S(StructuredModel):
    qty: int                     qty: int

eval_for(P).explain()        eval_for(S).explain()
  qty  Numeric     @ 1.0       qty  Levenshtein @ 0.7
```

Three defects in one line: a quantity compared by string edit distance, a threshold of `0.7` that is `StructuredModel.match_threshold`'s class default (`structured_model.py:326`) leaking in where the documented field default is `0.5`, and the same model scoring differently based on its base class.

`10` against `100` scores `0.667` under that configuration.

## Changes

| File | Change |
|---|---|
| `thresholds-and-metrics.md` | New "Unspecified fields" section stating the rule. Field Threshold section distinguishes the `ComparableField(threshold=...)` default of `0.5` from the inferred case. Precedence table and Key Rules gain the separation, as rule 5. Cheat sheet gains an inferred row and says `match_threshold` controls "Hungarian pairing, and nothing else". Zero-threshold paragraph rewritten. |
| `auto/README.md` | New "The inference table governs every path" section. The existing note about type-blind `StructuredModel` defaults now names itself a defect against that contract. States that explicit declarations win per parameter. |
| `CHANGELOG.md` | `### Documentation` entry under `[Unreleased]`, saying explicitly that code does not yet match. |

## Verification

- `2023 passed, 12 skipped`
- 0 python files changed
- `mkdocs build` produces the same 9 warnings as `origin/dev`, so no new documentation warning. Note the strict build already fails on `dev` for unrelated griffe/autorefs reasons; that is pre-existing and not addressed here.
- The new `#unspecified-fields` cross-reference resolves in built output (`id="unspecified-fields"` present, both `href`s point at it)

## What is deliberately not here

No code. The implementation is step 2 of #239 and is sequenced behind #285 (which rewrites the JSON Schema path) and #300 (which rewrites `configuration_helper.py`). The correctness bar for it, including the four-way parity test that would turn this document into something CI enforces, is written up on #239.
