### PR TITLE
fix(210): reject unrecognized x-aws-stickler-* keys instead of dropping them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -342,11 +342,30 @@ Each release links to full notes on the
   in a file they can edit, and the alternative is a model that builds and reports
   a wrong number.
 
+  The check runs over the raw schema, so it reaches every position an extension
+  can be written in, not only the ones that produce a field: the root object,
+  `items`, and a list-form `["object", "null"]` node were all silently dropping
+  keys while the same typo one level down raised.
+
+  Position is part of validity, because the two key sets are not interchangeable.
+  `x-aws-stickler-match-threshold` and `-model-name` are read on the root object
+  and on any object-typed property, and dropped on a scalar field; the field keys
+  are the other way round. Accepting both everywhere let the suggester answer a
+  field-position typo of `-match-threshold` with "did you mean
+  `x-aws-stickler-match-threshold`", where taking that advice imported cleanly
+  and did nothing. A valid key in a position that does not read it now says so
+  and names the position it belongs in.
+
   This also corrects two places that taught the wrong prefix: the
   `structured_object_evaluator/README.md` extension section and
   `examples/scripts/json_schema_demo.py`. Both used `x-stickler-*` and lowercase
   comparator names (`"fuzzy"`, `"exact"`), neither of which works, so the
-  README's own example applied none of its settings. It now applies all of them.
+  README's own example applied none of its settings. It now applies all of them,
+  which a test asserts verbatim. Correcting the prefix without correcting the
+  values would have turned a double no-op into a hard error for anyone copying
+  the page, so both moved together. The README now also separates the field-level
+  keys from the object-level ones and gives the real `clip-under-threshold`
+  default, which it had recorded as `false` rather than `true`.
   ([#210](https://github.com/awslabs/stickler/issues/210))
 
 - `overall_score` and the confusion matrix no longer disagree about a field that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,6 +317,38 @@ Each release links to full notes on the
   marginal object lowers `match_threshold` until it qualifies. See
   [#288](https://github.com/awslabs/stickler/issues/288) for the naming.
 
+- An unrecognized `x-aws-stickler-*` extension key in a JSON Schema now raises
+  instead of being silently dropped. The sharpest shape was a typo beside a
+  correctly-spelled sibling, which produced a configuration nobody would choose:
+
+  ```
+  x-aws-stickler-comparitor: ExactComparator   (typo, dropped)
+  x-aws-stickler-threshold:  1.0               (honoured)
+  -> LevenshteinComparator at threshold 1.0
+  ```
+
+  A wrong prefix (`x-stickler-*`) is caught too, and the error names the offending
+  key, the field, and the closest valid key. Suggestions compare the suffix after
+  the prefix rather than the whole key, because every valid key shares
+  `x-aws-stickler-` and whole-string similarity returned a confident match for
+  anything at all. A key with no plausible correction raises without inventing
+  one. Unrelated `x-*` extensions from other tooling are left alone, and
+  `x-aws-stickler-aggregate` is still accepted so schemas exported by older
+  versions keep importing.
+
+  Raising rather than warning is safe here in a way it is not elsewhere: a schema
+  is read deterministically at import, so there is no risk of failing on document
+  N of a corpus after succeeding on N-1. The author is present and the mistake is
+  in a file they can edit, and the alternative is a model that builds and reports
+  a wrong number.
+
+  This also corrects two places that taught the wrong prefix: the
+  `structured_object_evaluator/README.md` extension section and
+  `examples/scripts/json_schema_demo.py`. Both used `x-stickler-*` and lowercase
+  comparator names (`"fuzzy"`, `"exact"`), neither of which works, so the
+  README's own example applied none of its settings. It now applies all of them.
+  ([#210](https://github.com/awslabs/stickler/issues/210))
+
 - `overall_score` and the confusion matrix no longer disagree about a field that
   is absent on both sides. The two read different scores for the same object
   pair: `overall_score` takes the threshold-corrected score, while object

--- a/examples/scripts/json_schema_demo.py
+++ b/examples/scripts/json_schema_demo.py
@@ -7,7 +7,7 @@ JSON Schema documents and use them for evaluation.
 Key Features:
 - Create models from JSON Schema (Draft 7 compatible)
 - Support for nested objects and arrays
-- Custom comparison behavior via x-stickler extensions
+- Custom comparison behavior via x-aws-stickler extensions
 - Full evaluation with confusion matrices and metrics
 """
 
@@ -156,7 +156,7 @@ def nested_json_schema_example():
 
 
 def custom_extensions_example():
-    """Example using x-stickler extensions for custom comparison behavior."""
+    """Example using x-aws-stickler extensions for custom comparison behavior."""
     print("=" * 80)
     print("CUSTOM EXTENSIONS EXAMPLE")
     print("=" * 80)
@@ -331,7 +331,7 @@ def real_world_api_schema_example():
 
 
 def advanced_extensions_and_refs_example():
-    """Example showcasing comprehensive x-stickler extensions with $ref usage."""
+    """Example showcasing comprehensive x-aws-stickler extensions with $ref usage."""
     print("=" * 80)
     print("ADVANCED EXTENSIONS AND $REF EXAMPLE")
     print("=" * 80)
@@ -421,7 +421,7 @@ def advanced_extensions_and_refs_example():
     print(f"Created model class: {ECommerceOrder.__name__}")
     print(f"Model match threshold: {ECommerceOrder.match_threshold}")
     
-    # Create test data demonstrating the impact of different x-stickler configurations
+    # Create test data demonstrating the impact of different x-aws-stickler configurations
     ground_truth_json = {
         "order_id": "ORD-2024-001",
         "customer": {
@@ -443,7 +443,7 @@ def advanced_extensions_and_refs_example():
         ]
     }
     
-    # Prediction with various differences to showcase x-stickler behavior
+    # Prediction with various differences to showcase x-aws-stickler behavior
     prediction_json = {
         "order_id": "ORD-2024-001",  # Exact match (ExactComparator)
         "customer": {
@@ -513,7 +513,7 @@ Key Takeaways:
 1. Use StructuredModel.from_json_schema() to create models from JSON Schema
 2. Supports nested objects, arrays, and all JSON Schema primitive types
 3. Use x-aws-stickler-* extensions for custom comparison behavior:
-   - x-aws-stickler-comparator: Choose comparison algorithm (fuzzy, exact, etc.)
+   - x-aws-stickler-comparator: comparator class name, e.g. FuzzyComparator
    - x-aws-stickler-threshold: Set matching threshold (0.0 to 1.0)
    - x-aws-stickler-weight: Adjust field importance in scoring
 4. Full compatibility with compare_with() for evaluation and metrics

--- a/examples/scripts/json_schema_demo.py
+++ b/examples/scripts/json_schema_demo.py
@@ -168,16 +168,16 @@ def custom_extensions_example():
         "properties": {
             "title": {
                 "type": "string",
-                "x-stickler-comparator": "fuzzy",  # Use fuzzy string matching
-                "x-stickler-threshold": 0.8  # Require 80% similarity
+                "x-aws-stickler-comparator": "FuzzyComparator",  # Use fuzzy string matching
+                "x-aws-stickler-threshold": 0.8  # Require 80% similarity
             },
             "content": {
                 "type": "string",
-                "x-stickler-comparator": "fuzzy"
+                "x-aws-stickler-comparator": "FuzzyComparator"
             },
             "priority": {
                 "type": "integer",
-                "x-stickler-weight": 2.0  # Double weight for priority
+                "x-aws-stickler-weight": 2.0  # Double weight for priority
             },
             "tags": {
                 "type": "array",
@@ -512,10 +512,10 @@ def main():
 Key Takeaways:
 1. Use StructuredModel.from_json_schema() to create models from JSON Schema
 2. Supports nested objects, arrays, and all JSON Schema primitive types
-3. Use x-stickler-* extensions for custom comparison behavior:
-   - x-stickler-comparator: Choose comparison algorithm (fuzzy, exact, etc.)
-   - x-stickler-threshold: Set matching threshold (0.0 to 1.0)
-   - x-stickler-weight: Adjust field importance in scoring
+3. Use x-aws-stickler-* extensions for custom comparison behavior:
+   - x-aws-stickler-comparator: Choose comparison algorithm (fuzzy, exact, etc.)
+   - x-aws-stickler-threshold: Set matching threshold (0.0 to 1.0)
+   - x-aws-stickler-weight: Adjust field importance in scoring
 4. Full compatibility with compare_with() for evaluation and metrics
 5. Works seamlessly with existing StructuredModel features
 

--- a/src/stickler/structured_object_evaluator/README.md
+++ b/src/stickler/structured_object_evaluator/README.md
@@ -191,9 +191,9 @@ result = ground_truth.compare_with(
 )
 ```
 
-#### Custom Comparison Behavior with x-stickler Extensions
+#### Custom Comparison Behavior with x-aws-stickler Extensions
 
-Use `x-stickler-*` extensions in your JSON Schema to customize comparison behavior:
+Use `x-aws-stickler-*` extensions in your JSON Schema to customize comparison behavior:
 
 ```python
 document_schema = {
@@ -202,12 +202,12 @@ document_schema = {
     "properties": {
         "title": {
             "type": "string",
-            "x-stickler-comparator": "fuzzy",  # Use fuzzy string matching
-            "x-stickler-threshold": 0.8  # Require 80% similarity
+            "x-aws-stickler-comparator": "FuzzyComparator",  # Use fuzzy string matching
+            "x-aws-stickler-threshold": 0.8  # Require 80% similarity
         },
         "priority": {
             "type": "integer",
-            "x-stickler-weight": 2.0  # Double weight for priority field
+            "x-aws-stickler-weight": 2.0  # Double weight for priority field
         },
         "tags": {
             "type": "array",
@@ -220,11 +220,11 @@ document_schema = {
 Document = StructuredModel.from_json_schema(document_schema)
 ```
 
-**Available x-stickler Extensions:**
-- `x-stickler-comparator`: Comparison algorithm (`"exact"`, `"fuzzy"`, `"levenshtein"`, `"semantic"`)
-- `x-stickler-threshold`: Matching threshold (0.0 to 1.0, default: 0.5)
-- `x-stickler-weight`: Field importance weight (default: 1.0)
-- `x-stickler-clip-under-threshold`: Clip scores below threshold to 0.0 (boolean, default: false)
+**Available x-aws-stickler Extensions:**
+- `x-aws-stickler-comparator`: Comparison algorithm (`"exact"`, `"fuzzy"`, `"levenshtein"`, `"semantic"`)
+- `x-aws-stickler-threshold`: Matching threshold (0.0 to 1.0, default: 0.5)
+- `x-aws-stickler-weight`: Field importance weight (default: 1.0)
+- `x-aws-stickler-clip-under-threshold`: Clip scores below threshold to 0.0 (boolean, default: false)
 
 **Supported JSON Schema Features:**
 - All primitive types: `string`, `number`, `integer`, `boolean`, `null`

--- a/src/stickler/structured_object_evaluator/README.md
+++ b/src/stickler/structured_object_evaluator/README.md
@@ -220,11 +220,24 @@ document_schema = {
 Document = StructuredModel.from_json_schema(document_schema)
 ```
 
-**Available x-aws-stickler Extensions:**
-- `x-aws-stickler-comparator`: Comparison algorithm (`"exact"`, `"fuzzy"`, `"levenshtein"`, `"semantic"`)
-- `x-aws-stickler-threshold`: Matching threshold (0.0 to 1.0, default: 0.5)
-- `x-aws-stickler-weight`: Field importance weight (default: 1.0)
-- `x-aws-stickler-clip-under-threshold`: Clip scores below threshold to 0.0 (boolean, default: false)
+**Field-level extensions**, valid on a property:
+
+- `x-aws-stickler-comparator`: comparator **class name**, such as `"ExactComparator"`, `"FuzzyComparator"`, `"LevenshteinComparator"`, `"SemanticComparator"`. Lowercase aliases are not accepted and raise.
+- `x-aws-stickler-comparator-config`: keyword arguments for that comparator's constructor
+- `x-aws-stickler-threshold`: matching threshold, 0.0 to 1.0 (default: 0.5)
+- `x-aws-stickler-weight`: field importance weight (default: 1.0)
+- `x-aws-stickler-clip-under-threshold`: clip scores below threshold to 0.0 (boolean, default: true)
+
+**Object-level extensions**, valid on the root schema or on any object-typed property:
+
+- `x-aws-stickler-model-name`: the generated class name (default: `DynamicModel`)
+- `x-aws-stickler-match-threshold`: the score at which two objects count as the same object (default: 0.7)
+
+The two sets are not interchangeable, and position matters. A field-level key on
+the root, or an object-level key on a scalar field, is not read, so it is
+rejected rather than dropped. An unrecognized or misspelled `x-aws-stickler-*`
+key raises and names the closest valid key for that position; unrelated `x-*`
+extensions from other tooling are left alone.
 
 **Supported JSON Schema Features:**
 - All primitive types: `string`, `number`, `integer`, `boolean`, `null`

--- a/src/stickler/structured_object_evaluator/models/json_schema_importer.py
+++ b/src/stickler/structured_object_evaluator/models/json_schema_importer.py
@@ -12,6 +12,7 @@ from typing import (
     Annotated,
     Any,
     Dict,
+    FrozenSet,
     List,
     Literal,
     Optional,
@@ -88,7 +89,25 @@ _KNOWN_MODEL_EXTENSIONS = frozenset(
 _EXTENSION_PREFIXES = ("x-aws-stickler-", "x-stickler-")
 
 
-def _closest_known_key(key: str) -> Optional[str]:
+def _is_object_schema(node: Any) -> bool:
+    """Whether this node generates a StructuredModel of its own.
+
+    Such a node reads both key sets: the field keys describe how its parent
+    scores it, the model keys configure the class it generates. Checked
+    structurally rather than by `type` alone so the list form
+    (``["object", "null"]``) and a bare ``properties`` both count.
+    """
+    if not isinstance(node, dict):
+        return False
+    if "properties" in node or "patternProperties" in node:
+        return True
+    declared = node.get("type")
+    if declared == "object":
+        return True
+    return isinstance(declared, list) and "object" in declared
+
+
+def _closest_known_key(key: str, candidates: FrozenSet[str]) -> Optional[str]:
     """The valid key a typo was probably reaching for, or None.
 
     Compares the SUFFIX after the prefix, not the whole key. Every valid key
@@ -97,9 +116,15 @@ def _closest_known_key(key: str) -> Optional[str]:
     `x-aws-stickler-zzzzzzzz` scored as a near-miss on `-weight`. Comparing
     suffixes makes both a real suggestion and no suggestion possible, and a wrong
     suggestion is worse than none.
+
+    `candidates` is scoped to the position being checked. Suggesting a key that
+    is valid *somewhere* is worse than suggesting nothing: a field-position typo
+    of `-match-threshold` used to be answered with "did you mean
+    `x-aws-stickler-match-threshold`", and taking that advice imported cleanly
+    and did nothing, which is the silent drop this module exists to prevent.
     """
     known = {}
-    for full in sorted(_DOCUMENTED_FIELD_EXTENSIONS | _KNOWN_MODEL_EXTENSIONS):
+    for full in sorted(candidates):
         for prefix in _EXTENSION_PREFIXES:
             if full.startswith(prefix):
                 known[full[len(prefix) :]] = full
@@ -118,32 +143,74 @@ def _closest_known_key(key: str) -> Optional[str]:
     return known[matches[0]] if matches else None
 
 
-def _reject_unknown_extensions(extra: Any, field_path: str) -> None:
-    """Raise for any extension-shaped key this importer does not honour.
+def _reject_unknown_extensions(
+    extra: Any,
+    field_path: str,
+    *,
+    scope: str = "field",
+) -> None:
+    """Raise for any extension-shaped key this importer does not honour here.
 
     Raising rather than warning, deliberately, and unlike the mapping-comparator
     case elsewhere: a schema is authored once and read deterministically, so there
     is no risk of failing on document N of a corpus after succeeding on N-1. The
     author is present, the mistake is in a file they can edit, and the alternative
     is a model that builds and reports the wrong number.
+
+    `scope` decides which keys are honoured at this position, because the two sets
+    are not interchangeable. `x-aws-stickler-match-threshold` on an object is read;
+    the same key on a scalar field is dropped. Accepting both everywhere made the
+    check pass on keys that do nothing, so a valid-but-misplaced key was exactly
+    as silent as the typo it was mistaken for.
     """
     if not isinstance(extra, dict):
         return
+
+    if scope == "model":
+        accepted = _KNOWN_MODEL_EXTENSIONS
+        suggestible = _KNOWN_MODEL_EXTENSIONS
+        other_scope, other_keys = "field", _DOCUMENTED_FIELD_EXTENSIONS
+        where = f"object '{field_path}'"
+    elif scope == "field_or_model":
+        # An object-typed property honours both sets, so there is no misplacement
+        # to report and nothing to route elsewhere.
+        accepted = _KNOWN_FIELD_EXTENSIONS | _KNOWN_MODEL_EXTENSIONS
+        suggestible = _DOCUMENTED_FIELD_EXTENSIONS | _KNOWN_MODEL_EXTENSIONS
+        other_scope, other_keys = "", frozenset()
+        where = f"field '{field_path}'"
+    else:
+        accepted = _KNOWN_FIELD_EXTENSIONS
+        suggestible = _DOCUMENTED_FIELD_EXTENSIONS
+        other_scope, other_keys = "object", _KNOWN_MODEL_EXTENSIONS
+        where = f"field '{field_path}'"
+
     for key in extra:
         if not isinstance(key, str):
             continue
-        if key in _KNOWN_FIELD_EXTENSIONS or key in _KNOWN_MODEL_EXTENSIONS:
+        if key in accepted:
             continue
         if not key.startswith(_EXTENSION_PREFIXES):
             continue  # an unrelated x-* extension is none of our business
-        suggestion = _closest_known_key(key)
+
+        # A real key in the wrong position. Naming the position is the whole
+        # answer here, so say that instead of offering a spelling correction.
+        if key in other_keys:
+            raise ValueError(
+                f"Stickler extension '{key}' is not read on {where}. It belongs "
+                f"on the {other_scope}. Left in place it would be dropped "
+                f"silently. Valid keys here: {', '.join(sorted(suggestible))}."
+            )
+
+        suggestion = _closest_known_key(key, suggestible)
         hint = f" Did you mean '{suggestion}'?" if suggestion else ""
         raise ValueError(
-            f"Unrecognized Stickler extension '{key}' on field '{field_path}'."
-            f"{hint} It would otherwise be dropped silently, leaving the field "
-            "configured by fallback while its correctly-spelled siblings were "
-            f"honoured. Valid keys: {', '.join(sorted(_DOCUMENTED_FIELD_EXTENSIONS))}."
+            f"Unrecognized Stickler extension '{key}' on {where}."
+            f"{hint} It would otherwise be dropped silently, leaving the "
+            "configuration to fall back while its correctly-spelled siblings "
+            f"were honoured. Valid keys here: {', '.join(sorted(suggestible))}."
         )
+
+
 _COMBINERS = frozenset({"allOf", "anyOf", "oneOf"})
 _NON_VALIDATING_SCHEMA_KEYWORDS = frozenset(
     {
@@ -534,15 +601,26 @@ class JsonSchemaImporter:
 
     @classmethod
     def _validate_supported_shapes(cls, schema: Dict[str, Any]) -> None:
-        """Reject shapes the comparison model cannot represent faithfully."""
+        """Reject shapes the comparison model cannot represent faithfully.
 
-        def walk(node: Any, path: str) -> None:
+        Also where extension keys are checked, because this walk sees every node
+        of the RAW schema before `_prepare_schema` rewrites list-form types into
+        `anyOf`. Checking per-field at extraction time reached only the positions
+        that produce a field, so a typo on the root object, on `items`, or on a
+        `["object", "null"]` node was silently dropped while the same typo one
+        level down raised.
+        """
+
+        def walk(node: Any, path: str, scope: Optional[str] = "model") -> None:
             if isinstance(node, list):
                 for index, value in enumerate(node):
-                    walk(value, f"{path}[{index}]")
+                    walk(value, f"{path}[{index}]", scope)
                 return
             if not isinstance(node, dict):
                 return
+
+            if scope is not None:
+                _reject_unknown_extensions(node, path or "(root)", scope=scope)
 
             if "patternProperties" in node:
                 location = f" at '{path}'" if path else ""
@@ -573,15 +651,30 @@ class JsonSchemaImporter:
 
             for key, value in node.items():
                 child_path = path
+                child_scope: Optional[str] = None
                 if key == "properties" and isinstance(value, dict):
                     for name, child in value.items():
-                        walk(child, f"{path}.{name}" if path else name)
+                        # A property is scored as a field of this object, and if
+                        # it is itself an object it also configures its own
+                        # generated class, so both key sets are honoured there.
+                        walk(
+                            child,
+                            f"{path}.{name}" if path else name,
+                            "field_or_model" if _is_object_schema(child) else "field",
+                        )
                     continue
                 if key == "items":
                     child_path = f"{path}[]" if path else "[]"
-                walk(value, child_path)
+                    # Field keys are NOT read on `items`: weight, threshold and
+                    # comparator there are all dropped, since the field they would
+                    # configure is the array itself, one level up. Only the element
+                    # class's own settings are read.
+                    child_scope = "model"
+                elif key in _COMBINERS or key in ("$defs", "definitions"):
+                    child_scope = "model"
+                walk(value, child_path, child_scope)
 
-        walk(schema, "")
+        walk(schema, "", "model")
 
     @staticmethod
     def _translate_import_error(message: str, schema: Dict[str, Any]) -> str:
@@ -680,7 +773,13 @@ class JsonSchemaImporter:
         extra = field_info.json_schema_extra
         if not isinstance(extra, dict):
             return {}
-        _reject_unknown_extensions(extra, field_path)
+        # Backstop for entry points that do not walk a raw schema, such as an
+        # already-parsed pydantic model. `_validate_supported_shapes` is the
+        # precise gate: it sees each node's position, so it is what distinguishes
+        # a model key on a scalar field from the same key on an object. Here the
+        # position is no longer visible, so both sets are accepted rather than
+        # re-deciding it from an annotation and disagreeing with the walker.
+        _reject_unknown_extensions(extra, field_path, scope="field_or_model")
         extensions: Dict[str, Any] = {}
 
         if "x-aws-stickler-comparator" in extra:

--- a/src/stickler/structured_object_evaluator/models/json_schema_importer.py
+++ b/src/stickler/structured_object_evaluator/models/json_schema_importer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import difflib
 import re
 from copy import copy, deepcopy
 from datetime import date, datetime, time
@@ -39,6 +40,110 @@ _JSON_DEFAULTS = {
 }
 
 _PRESERVED_EXAMPLES_KEY = "x-aws-stickler-internal-examples"
+
+# Every extension key this importer honours, on a field. Anything else that LOOKS
+# like one is a typo or a wrong prefix, and is rejected rather than dropped.
+#
+# The asymmetry this closes: a bad extension VALUE already raised a clear error,
+# so the schema path taught users it validated their input, then said nothing
+# about the case that actually bites. A dropped key leaves a plausible model that
+# scores wrong in the direction of over-reporting accuracy, which is the worst
+# combination for an evaluation library.
+_KNOWN_FIELD_EXTENSIONS = frozenset(
+    {
+        "x-aws-stickler-comparator",
+        "x-aws-stickler-comparator-config",
+        "x-aws-stickler-threshold",
+        "x-aws-stickler-weight",
+        "x-aws-stickler-clip-under-threshold",
+        # Removed in #226. Accepted and ignored so schemas exported by older
+        # versions still import.
+        "x-aws-stickler-aggregate",
+        _PRESERVED_EXAMPLES_KEY,
+    }
+)
+
+# The subset worth suggesting to an author. `aggregate` is removed and
+# `internal-examples` is ours, so offering either as a fix would be misleading.
+_DOCUMENTED_FIELD_EXTENSIONS = frozenset(
+    {
+        "x-aws-stickler-comparator",
+        "x-aws-stickler-comparator-config",
+        "x-aws-stickler-threshold",
+        "x-aws-stickler-weight",
+        "x-aws-stickler-clip-under-threshold",
+    }
+)
+
+# Model-level keys, read elsewhere but valid, so they must not be flagged.
+_KNOWN_MODEL_EXTENSIONS = frozenset(
+    {
+        "x-aws-stickler-model-name",
+        "x-aws-stickler-match-threshold",
+    }
+)
+
+# Prefixes that mean "the author was reaching for a Stickler extension". The
+# second appears in our own README, so it is a mistake we taught.
+_EXTENSION_PREFIXES = ("x-aws-stickler-", "x-stickler-")
+
+
+def _closest_known_key(key: str) -> Optional[str]:
+    """The valid key a typo was probably reaching for, or None.
+
+    Compares the SUFFIX after the prefix, not the whole key. Every valid key
+    starts with `x-aws-stickler-`, so whole-string similarity is dominated by
+    that shared prefix and returns a confident match for anything at all:
+    `x-aws-stickler-zzzzzzzz` scored as a near-miss on `-weight`. Comparing
+    suffixes makes both a real suggestion and no suggestion possible, and a wrong
+    suggestion is worse than none.
+    """
+    known = {}
+    for full in sorted(_DOCUMENTED_FIELD_EXTENSIONS | _KNOWN_MODEL_EXTENSIONS):
+        for prefix in _EXTENSION_PREFIXES:
+            if full.startswith(prefix):
+                known[full[len(prefix) :]] = full
+                break
+
+    suffix = key
+    for prefix in _EXTENSION_PREFIXES:
+        if key.startswith(prefix):
+            suffix = key[len(prefix) :]
+            break
+
+    # An exact suffix match is the wrong-prefix case: `x-stickler-comparator`.
+    if suffix in known:
+        return known[suffix]
+    matches = difflib.get_close_matches(suffix, sorted(known), n=1, cutoff=0.75)
+    return known[matches[0]] if matches else None
+
+
+def _reject_unknown_extensions(extra: Any, field_path: str) -> None:
+    """Raise for any extension-shaped key this importer does not honour.
+
+    Raising rather than warning, deliberately, and unlike the mapping-comparator
+    case elsewhere: a schema is authored once and read deterministically, so there
+    is no risk of failing on document N of a corpus after succeeding on N-1. The
+    author is present, the mistake is in a file they can edit, and the alternative
+    is a model that builds and reports the wrong number.
+    """
+    if not isinstance(extra, dict):
+        return
+    for key in extra:
+        if not isinstance(key, str):
+            continue
+        if key in _KNOWN_FIELD_EXTENSIONS or key in _KNOWN_MODEL_EXTENSIONS:
+            continue
+        if not key.startswith(_EXTENSION_PREFIXES):
+            continue  # an unrelated x-* extension is none of our business
+        suggestion = _closest_known_key(key)
+        hint = f" Did you mean '{suggestion}'?" if suggestion else ""
+        raise ValueError(
+            f"Unrecognized Stickler extension '{key}' on field '{field_path}'."
+            f"{hint} It would otherwise be dropped silently, leaving the field "
+            "configured by fallback while its correctly-spelled siblings were "
+            f"honoured. Valid keys: {', '.join(sorted(_DOCUMENTED_FIELD_EXTENSIONS))}."
+        )
 _COMBINERS = frozenset({"allOf", "anyOf", "oneOf"})
 _NON_VALIDATING_SCHEMA_KEYWORDS = frozenset(
     {
@@ -575,6 +680,7 @@ class JsonSchemaImporter:
         extra = field_info.json_schema_extra
         if not isinstance(extra, dict):
             return {}
+        _reject_unknown_extensions(extra, field_path)
         extensions: Dict[str, Any] = {}
 
         if "x-aws-stickler-comparator" in extra:

--- a/tests/structured_object_evaluator/test_unknown_schema_extensions.py
+++ b/tests/structured_object_evaluator/test_unknown_schema_extensions.py
@@ -16,6 +16,8 @@ mistake is in a file they can edit.
 See https://github.com/awslabs/stickler/issues/210
 """
 
+import typing
+
 import pytest
 
 from stickler import StructuredModel
@@ -150,3 +152,284 @@ class TestNestedFields:
                 }
             )
         assert "x-aws-stickler-thresold" in str(exc.value)
+
+
+def _unwrap(annotation):
+    """The class behind `Optional[X]` / `List[X]` / `Optional[List[X]]`."""
+    while True:
+        args = [a for a in typing.get_args(annotation) if a is not type(None)]
+        if not args:
+            return annotation
+        annotation = args[0]
+
+
+class TestTheCheckReachesEveryPosition:
+    """A field-level check only reached positions that produce a field.
+
+    The root object, `items`, and a list-form `["object", "null"]` node all
+    carried extension keys that were dropped in silence, while the same typo one
+    level down raised. The guarantee is worth little if it has holes, so the walk
+    over the raw schema is what enforces it now.
+    """
+
+    def test_a_typo_on_the_root_object_raises(self):
+        with pytest.raises(ValueError, match="x-aws-stickler-match-treshold"):
+            StructuredModel.from_json_schema(
+                {
+                    "type": "object",
+                    "title": "T",
+                    "x-aws-stickler-match-treshold": 0.95,
+                    "properties": {"a": {"type": "string"}},
+                }
+            )
+
+    def test_a_model_name_typo_on_the_root_raises(self):
+        with pytest.raises(ValueError, match="x-aws-stickler-model-nmae"):
+            StructuredModel.from_json_schema(
+                {
+                    "type": "object",
+                    "title": "T",
+                    "x-aws-stickler-model-nmae": "Foo",
+                    "properties": {"a": {"type": "string"}},
+                }
+            )
+
+    def test_the_wrong_prefix_on_the_root_raises(self):
+        with pytest.raises(ValueError, match="x-stickler-match-threshold"):
+            StructuredModel.from_json_schema(
+                {
+                    "type": "object",
+                    "title": "T",
+                    "x-stickler-match-threshold": 0.9,
+                    "properties": {"a": {"type": "string"}},
+                }
+            )
+
+    def test_a_typo_on_array_items_raises(self):
+        with pytest.raises(ValueError, match="x-aws-stickler-thresold"):
+            StructuredModel.from_json_schema(
+                {
+                    "type": "object",
+                    "title": "T",
+                    "properties": {
+                        "tags": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "x-aws-stickler-thresold": 0.9,
+                            },
+                        }
+                    },
+                }
+            )
+
+    @pytest.mark.parametrize("declared", (["object", "null"], ["array", "null"]))
+    def test_the_wrong_prefix_on_a_list_form_type_raises(self, declared):
+        """The check runs before list-form types are rewritten to `anyOf`.
+
+        Running after normalization was how these escaped: the node the author
+        wrote no longer existed in the shape being inspected.
+        """
+        node = {"type": declared, "x-stickler-comparator": "fuzzy"}
+        if "object" in declared:
+            node["properties"] = {"z": {"type": "string"}}
+        else:
+            node["items"] = {"type": "string"}
+
+        with pytest.raises(ValueError, match="x-stickler-comparator"):
+            StructuredModel.from_json_schema(
+                {"type": "object", "title": "T", "properties": {"o": node}}
+            )
+
+
+class TestPositionIsPartOfValidity:
+    """A valid key in a position that does not read it is still a silent drop.
+
+    Allowlisting both key sets everywhere made the check pass on keys that do
+    nothing, and worse, let the suggester answer a field-position typo of
+    `-match-threshold` with "did you mean `x-aws-stickler-match-threshold`" when
+    applying that advice imported cleanly and changed nothing.
+    """
+
+    @pytest.mark.parametrize(
+        "key, value",
+        (
+            ("x-aws-stickler-match-threshold", 0.9),
+            ("x-aws-stickler-model-name", "Foo"),
+        ),
+    )
+    def test_an_object_level_key_on_a_scalar_field_raises(self, key, value):
+        with pytest.raises(ValueError) as exc:
+            StructuredModel.from_json_schema(
+                {
+                    "type": "object",
+                    "title": "T",
+                    "properties": {"a": {"type": "string", key: value}},
+                }
+            )
+        message = str(exc.value)
+        assert key in message
+        assert "belongs on the object" in message
+
+    def test_the_suggester_never_routes_to_a_key_that_is_not_read_here(self):
+        """The failure this closes: a suggestion that reintroduces the bug."""
+        with pytest.raises(ValueError) as exc:
+            StructuredModel.from_json_schema(
+                {
+                    "type": "object",
+                    "title": "T",
+                    "properties": {
+                        "a": {"type": "string", "x-aws-stickler-match-treshold": 0.9}
+                    },
+                }
+            )
+        message = str(exc.value)
+        assert "x-aws-stickler-match-threshold" not in message.split("Valid keys")[0]
+
+
+class TestObjectPropertiesReadBothKeySets:
+    """An object-typed property is a field of its parent AND its own class.
+
+    Both key sets are honoured there, so scoping the check must not turn a
+    working schema into an error. These pin the values, not just that it imports.
+    """
+
+    @staticmethod
+    def _object_property(**extensions):
+        return {
+            "type": "object",
+            "title": "T",
+            "properties": {
+                "inner": {
+                    "type": "object",
+                    "properties": {"b": {"type": "string"}},
+                    **extensions,
+                }
+            },
+        }
+
+    def test_match_threshold_on_a_nested_object_is_honoured(self):
+        model = StructuredModel.from_json_schema(
+            self._object_property(**{"x-aws-stickler-match-threshold": 0.93})
+        )
+        assert _unwrap(model.model_fields["inner"].annotation).match_threshold == 0.93
+
+    def test_model_name_on_a_nested_object_is_honoured(self):
+        model = StructuredModel.from_json_schema(
+            self._object_property(**{"x-aws-stickler-model-name": "Renamed"})
+        )
+        assert _unwrap(model.model_fields["inner"].annotation).__name__ == "Renamed"
+
+    def test_weight_on_a_nested_object_is_honoured(self):
+        model = StructuredModel.from_json_schema(
+            self._object_property(**{"x-aws-stickler-weight": 3.0})
+        )
+        assert model._get_comparison_info("inner").weight == 3.0
+
+    def test_match_threshold_on_array_items_is_honoured(self):
+        model = StructuredModel.from_json_schema(
+            {
+                "type": "object",
+                "title": "T",
+                "properties": {
+                    "rows": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "x-aws-stickler-match-threshold": 0.91,
+                            "properties": {"b": {"type": "string"}},
+                        },
+                    }
+                },
+            }
+        )
+        assert _unwrap(model.model_fields["rows"].annotation).match_threshold == 0.91
+
+    def test_the_root_still_reads_both_of_its_own_keys(self):
+        model = StructuredModel.from_json_schema(
+            {
+                "type": "object",
+                "title": "T",
+                "x-aws-stickler-model-name": "Invoice",
+                "x-aws-stickler-match-threshold": 0.9,
+                "properties": {"a": {"type": "string"}},
+            }
+        )
+        assert model.__name__ == "Invoice"
+        assert model.match_threshold == 0.9
+
+
+class TestTheDocumentedValuesWork:
+    """The README's own values must import, since copying them is the point.
+
+    Correcting the prefix without correcting the values would have turned a
+    double no-op into a hard error for anyone following the page.
+    """
+
+    @pytest.mark.parametrize(
+        "comparator_name",
+        (
+            "ExactComparator",
+            "FuzzyComparator",
+            "LevenshteinComparator",
+        ),
+    )
+    def test_each_documented_comparator_class_name_is_accepted(self, comparator_name):
+        model = StructuredModel.from_json_schema(
+            {
+                "type": "object",
+                "title": "T",
+                "properties": {
+                    "a": {
+                        "type": "string",
+                        "x-aws-stickler-comparator": comparator_name,
+                    }
+                },
+            }
+        )
+        installed = model._get_comparison_info("a").comparator
+        assert type(installed).__name__ == comparator_name
+
+    @pytest.mark.parametrize("alias", ("exact", "fuzzy", "levenshtein", "semantic"))
+    def test_the_lowercase_aliases_the_readme_used_to_list_still_raise(self, alias):
+        """Recorded so the corrected README cannot quietly regress.
+
+        These were documented for a prefix that was itself wrong, so the example
+        applied none of its settings and raised nothing. Now the prefix is right,
+        a lowercase value is a hard error, which is why both halves had to move
+        together.
+        """
+        with pytest.raises(ValueError, match="Invalid x-aws-stickler-comparator"):
+            StructuredModel.from_json_schema(
+                {
+                    "type": "object",
+                    "title": "T",
+                    "properties": {
+                        "a": {"type": "string", "x-aws-stickler-comparator": alias}
+                    },
+                }
+            )
+
+    def test_the_readme_example_applies_every_setting_it_documents(self):
+        """Verbatim from `structured_object_evaluator/README.md`."""
+        document_schema = {
+            "type": "object",
+            "title": "Document",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "x-aws-stickler-comparator": "FuzzyComparator",
+                    "x-aws-stickler-threshold": 0.8,
+                },
+                "priority": {"type": "integer", "x-aws-stickler-weight": 2.0},
+                "tags": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["title", "priority"],
+        }
+
+        model = StructuredModel.from_json_schema(document_schema)
+
+        title = model._get_comparison_info("title")
+        assert type(title.comparator).__name__ == "FuzzyComparator"
+        assert title.threshold == 0.8
+        assert model._get_comparison_info("priority").weight == 2.0

--- a/tests/structured_object_evaluator/test_unknown_schema_extensions.py
+++ b/tests/structured_object_evaluator/test_unknown_schema_extensions.py
@@ -1,0 +1,152 @@
+"""An extension key Stickler does not honour is rejected, not dropped.
+
+A dropped key left a model that built, ran, and produced numbers wrong in the
+direction of over-reporting accuracy. The sharpest shape was a typo alongside a
+correctly-spelled sibling, which produced a configuration nobody would choose:
+
+    x-aws-stickler-comparitor: ExactComparator   (typo, dropped)
+    x-aws-stickler-threshold:  1.0               (honoured)
+    -> LevenshteinComparator at threshold 1.0
+
+Raising is safe here in a way it is not elsewhere in the codebase: a schema is
+authored once and read deterministically, so there is no risk of failing on
+document N of a corpus after succeeding on N-1. The author is present and the
+mistake is in a file they can edit.
+
+See https://github.com/awslabs/stickler/issues/210
+"""
+
+import pytest
+
+from stickler import StructuredModel
+
+
+def build(props: dict):
+    return StructuredModel.from_json_schema(
+        {"type": "object", "title": "T", "properties": props}
+    )
+
+
+class TestTypoAndWrongPrefixAreRejected:
+    def test_a_typo_raises_and_suggests_the_right_key(self):
+        with pytest.raises(ValueError) as exc:
+            build(
+                {
+                    "invoice_id": {
+                        "type": "string",
+                        "x-aws-stickler-comparitor": "ExactComparator",
+                        "x-aws-stickler-threshold": 1.0,
+                    }
+                }
+            )
+        message = str(exc.value)
+        assert "x-aws-stickler-comparitor" in message, "names the offending key"
+        assert "invoice_id" in message, "names the field"
+        assert "x-aws-stickler-comparator" in message, "suggests the correction"
+
+    def test_the_wrong_prefix_raises_too(self):
+        """`x-stickler-*` appears in our own README, so it is a mistake we taught.
+
+        The suggestion has to work across a four-character prefix difference,
+        which plain string similarity does not catch, so it is matched on the
+        suffix as well.
+        """
+        with pytest.raises(ValueError, match="x-aws-stickler-comparator"):
+            build({"name": {"type": "string", "x-stickler-comparator": "fuzzy"}})
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "x-aws-stickler-thresold",
+            "x-aws-stickler-weightt",
+            "x-aws-stickler-clip-under-treshold",
+            "x-aws-stickler-nonsense",
+            "x-stickler-threshold",
+        ],
+    )
+    def test_every_extension_shaped_key_is_checked(self, key):
+        with pytest.raises(ValueError, match="Unrecognized Stickler extension"):
+            build({"a": {"type": "string", key: 0.9}})
+
+    def test_the_suggestion_is_omitted_rather_than_wrong(self):
+        """A key with no plausible correction still raises, without inventing one."""
+        with pytest.raises(ValueError) as exc:
+            build({"a": {"type": "string", "x-aws-stickler-zzzzzzzz": 1}})
+        assert "Did you mean" not in str(exc.value)
+
+
+class TestWhatMustKeepWorking:
+    def test_correct_keys_are_honoured(self):
+        model = build(
+            {
+                "a": {
+                    "type": "string",
+                    "x-aws-stickler-comparator": "ExactComparator",
+                    "x-aws-stickler-threshold": 1.0,
+                    "x-aws-stickler-weight": 2.0,
+                    "x-aws-stickler-clip-under-threshold": False,
+                }
+            }
+        )
+        info = model._get_comparison_info("a")
+        assert type(info.comparator).__name__ == "ExactComparator"
+        assert info.threshold == 1.0
+        assert info.weight == 2.0
+        assert info.clip_under_threshold is False
+
+    def test_a_schema_exported_by_an_older_version_still_imports(self):
+        """`x-aws-stickler-aggregate` was removed in #226 and is accepted, not
+        advertised. Rejecting it would break every schema file already on disk."""
+        model = build(
+            {
+                "a": {
+                    "type": "string",
+                    "x-aws-stickler-comparator": "ExactComparator",
+                    "x-aws-stickler-aggregate": True,
+                }
+            }
+        )
+        assert type(model._get_comparison_info("a").comparator).__name__ == (
+            "ExactComparator"
+        )
+
+    def test_an_unrelated_x_extension_is_left_alone(self):
+        """Other tooling puts `x-*` keys in schemas. Only Stickler-shaped ones
+        are our business."""
+        model = build({"a": {"type": "string", "x-my-own-tool": {"anything": 1}}})
+        assert model is not None
+
+    def test_a_bad_value_still_raises_its_own_error(self):
+        """The pre-existing value check must not be shadowed by the key check."""
+        with pytest.raises(ValueError, match="Invalid x-aws-stickler-comparator"):
+            build({"a": {"type": "string", "x-aws-stickler-comparator": "Nonsense"}})
+
+    def test_the_advertised_key_list_omits_internal_and_removed_keys(self):
+        """Suggesting `aggregate` (removed) or `internal-examples` (ours) would
+        send an author somewhere useless."""
+        with pytest.raises(ValueError) as exc:
+            build({"a": {"type": "string", "x-aws-stickler-nonsense": 1}})
+        message = str(exc.value)
+        assert "x-aws-stickler-aggregate" not in message
+        assert "x-aws-stickler-internal-examples" not in message
+        assert "x-aws-stickler-comparator" in message
+
+
+class TestNestedFields:
+    def test_a_typo_inside_a_nested_object_names_its_path(self):
+        with pytest.raises(ValueError) as exc:
+            StructuredModel.from_json_schema(
+                {
+                    "type": "object",
+                    "title": "Outer",
+                    "properties": {
+                        "inner": {
+                            "type": "object",
+                            "properties": {
+                                "a": {"type": "string", "x-aws-stickler-thresold": 0.9}
+                            },
+                        }
+                    },
+                }
+            )
+        assert "x-aws-stickler-thresold" in str(exc.value)


### PR DESCRIPTION
Closes #210 (partially — scope note at the bottom).

## The bug

A misspelled extension key was silently discarded. The sharpest shape is a typo beside a correctly-spelled sibling, which produces a configuration nobody would choose:

```
x-aws-stickler-comparitor: ExactComparator   (typo, dropped)
x-aws-stickler-threshold:  1.0               (honoured)
-> LevenshteinComparator at threshold 1.0
```

Measured on `dev` before this change, all silent, all zero warnings:

| schema | result |
|---|---|
| typo'd comparator key | `LevenshteinComparator` @ 1.0 |
| wrong prefix `x-stickler-*` | `LevenshteinComparator` @ 0.5, 0 of 2 settings applied |
| unknown key | `LevenshteinComparator` @ 0.5 |
| bad **value** | already raised a clear error |

That last row is the asymmetry: the schema path taught users it validated their input, then said nothing about the case that actually bites.

## The fix

Any `x-aws-stickler-*` or `x-stickler-*` key the importer does not honour now raises, naming the key, the field, and the closest valid key:

```
Unrecognized Stickler extension 'x-aws-stickler-comparitor' on field 'invoice_id'.
Did you mean 'x-aws-stickler-comparator'? It would otherwise be dropped silently,
leaving the field configured by fallback while its correctly-spelled siblings were
honoured. Valid keys: ...
```

**Raising rather than warning**, unlike the mapping-comparator gate elsewhere in this codebase. A schema is read deterministically at import, so there is no risk of failing on document N of a corpus after succeeding on N-1. The author is present and the mistake is in a file they can edit; the alternative is a model that builds and reports a wrong number.

### One thing a test caught in my own implementation

Suggestions compare the **suffix** after the prefix, not the whole key. Every valid key starts with `x-aws-stickler-`, so whole-string similarity is dominated by that shared prefix and returns a confident match for anything: `x-aws-stickler-zzzzzzzz` scored as a near-miss on `-weight`. Found by a test I wrote expecting *no* suggestion, and pinned. A wrong suggestion is worse than none.

### Backward compatibility

`x-aws-stickler-aggregate` (removed in #226) is still accepted so schemas already on disk keep importing, but is not advertised as a correction. Unrelated `x-*` keys from other tooling are left alone.

## Docs that were teaching the bug

`structured_object_evaluator/README.md` and `examples/scripts/json_schema_demo.py` both used `x-stickler-*` **and** lowercase comparator names (`"fuzzy"`, `"exact"`). Neither works, so the README's own example applied **none** of its four settings and raised nothing.

With this change it would have *raised*, so correcting it is part of the fix rather than a follow-up. The example now applies all three of its settings, verified by execution. `AGENTS.md` names that README as the one an AI assistant loads first, so this was actively being taught.

## Scope: two acceptance criteria deliberately not here

- **`explain()` reporting a schema fallback as `source: "explicit"`** needs a marker recording whether a setting was actually read. That is `_comparator_explicit`, which #300 introduces and `dev` does not have. Adding a second marker for one concept would be worse. Note this criterion's harmful case is removed anyway: a typo can no longer produce a built model at all.
- **The auto-versus-schema divergence table** belongs to #239, and its numbers changed when #285 merged. Current measurements are posted on #239 and #186.

`nullable: true` (criterion 4) was already fixed by #285 and now yields `Optional[str]`.

## Verification

- `2053 passed, 12 skipped`
- `ruff check src tests` clean
- `examples/scripts/json_schema_demo.py` exits 0
- 14 new tests, including the wrong-prefix suggestion, the no-suggestion case, nested field paths, and that old exported schemas still import