### PR TITLE
feat: add normalized text comparator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Each release links to full notes on the
 
 ### Added
 
+- **`NormalizedComparator`** for explicit formatting-insensitive equality.
+  Its independent case, whitespace, and punctuation options round-trip through
+  JSON Schema. Punctuation follows Unicode `P*` categories, whitespace follows
+  `str.isspace()`, and Unicode symbols and combining marks remain significant
+  ([#223](https://github.com/awslabs/stickler/issues/223)).
+
 - **`ANLSStarComparator`**, which scores a `dict` (or any nesting of dicts and
   lists) structurally instead of by whole-object equality, and is now what
   zero-config evaluation installs for a `dict` / `Dict[...]` / `Mapping[...]`

--- a/docs/docs/Guides/Comparators/README.md
+++ b/docs/docs/Guides/Comparators/README.md
@@ -9,6 +9,7 @@ Comparators are the algorithms that determine how similar two field values are. 
 | Comparator | Best For | Speed | Needs AWS? | Score Type |
 |---|---|---|---|---|
 | [**ExactComparator**](#exactcomparator) | IDs, codes, booleans | Instant | No | Binary (0.0 or 1.0) |
+| [**NormalizedComparator**](#normalizedcomparator) | Text where formatting differences are noise | Instant | No | Binary (0.0 or 1.0) |
 | [**LevenshteinComparator**](#levenshteincomparator) | Names, addresses, text with typos | Instant | No | Continuous (0.0--1.0) |
 | [**NumericComparator**](#numericcomparator) | Prices, quantities, measurements | Instant | No | Binary (0.0 or 1.0) |
 | [**DateComparator**](date-comparator.md) | Date fields with mixed formats, partial dates, ranges | Instant | No | Continuous (0.0--1.0) |
@@ -25,7 +26,7 @@ Comparators are the algorithms that determine how similar two field values are. 
 
 ### ExactComparator
 
-Checks for exact string matching after normalizing whitespace, punctuation, and (by default) case. Returns 1.0 for exact matches and 0.0 otherwise.
+Checks for exact string matching. Case, whitespace, and punctuation are significant by default. Returns 1.0 for exact matches and 0.0 otherwise.
 
 **When to use:** Critical identifiers, status codes, booleans, or any field where partial matches are meaningless.
 
@@ -46,7 +47,35 @@ class Order(StructuredModel):
 | Parameter | Default | Description |
 |---|---|---|
 | `threshold` | `1.0` | Similarity threshold for binary classification |
-| `case_sensitive` | `False` | Whether comparison is case-sensitive |
+| `case_sensitive` | `True` | Whether comparison is case-sensitive |
+
+### NormalizedComparator
+
+Checks equality after a declared set of text transforms. By default it ignores
+case, Unicode whitespace, and Unicode punctuation. Punctuation means characters
+in the Unicode `P*` categories, so em dashes, curly quotes, and full-width
+punctuation are handled consistently. Symbols such as `$`, `±`, and emoji remain
+significant, as do accents. NFC normalization makes composed and decomposed
+spellings equivalent.
+
+**When to use:** OCR or LLM output where formatting drift is noise but edit
+distance is not meaningful, such as `"U.S.A."` versus `"USA"`.
+
+```python
+from stickler import ComparableField, NormalizedComparator, StructuredModel
+
+class Contact(StructuredModel):
+    name: str = ComparableField(comparator=NormalizedComparator())
+```
+
+**Key parameters:**
+
+| Parameter | Default | Description |
+|---|---|---|
+| `threshold` | `1.0` | Similarity threshold for binary classification |
+| `case_sensitive` | `False` | Preserve case differences when `True` |
+| `ignore_whitespace` | `True` | Remove Unicode whitespace |
+| `ignore_punctuation` | `True` | Remove Unicode `P*` punctuation; symbols remain |
 
 ---
 

--- a/src/stickler/__init__.py
+++ b/src/stickler/__init__.py
@@ -21,6 +21,7 @@ from .comparators.date import DateComparator
 from .comparators.exact import ExactComparator
 from .comparators.fuzzy import FuzzyComparator
 from .comparators.levenshtein import LevenshteinComparator
+from .comparators.normalized import NormalizedComparator
 from .comparators.numeric import NumericComparator
 from .comparators.phone import PhoneComparator
 from .comparators.semantic import SemanticComparator
@@ -163,6 +164,7 @@ __all__ = [
     "BBoxIoUComparator",
     "FuzzyComparator",
     "LevenshteinComparator",
+    "NormalizedComparator",
     "NumericComparator",
     "SemanticComparator",
     "StructuredModelComparator",

--- a/src/stickler/comparators/Comparators.md
+++ b/src/stickler/comparators/Comparators.md
@@ -11,13 +11,26 @@ The comparator system provides a flexible framework for measuring similarity bet
 
 #### Exact Comparator
 ```python
-comparator = ExactComparator(threshold=1.0, case_sensitive=False)
+comparator = ExactComparator(threshold=1.0, case_sensitive=True)
 ```
-- Performs exact string matching after normalization
-- Removes whitespace and punctuation by default
+- Performs exact string matching without normalization
 - Options for case-sensitive comparison
 - Returns 1.0 for exact matches, 0.0 otherwise
 - Useful for strict matching requirements
+
+#### Normalized Comparator
+```python
+comparator = NormalizedComparator(
+    case_sensitive=False,
+    ignore_whitespace=True,
+    ignore_punctuation=True,
+)
+```
+- Performs equality after independently configured text transforms
+- Removes Unicode whitespace and Unicode `P*` punctuation by default
+- Preserves symbols such as `$`, `±`, and emoji, plus accents and combining marks
+- Uses NFC normalization and Unicode case folding
+- Useful when formatting differences are noise but typos should not match
 
 #### Numeric Comparator
 ```python
@@ -129,6 +142,7 @@ comparator = BBoxIoUComparator(threshold=0.5)
 
 1. **Choosing the Right Comparator**
    - Use ExactComparator for strict matching requirements
+   - Use NormalizedComparator for formatting-insensitive equality
    - Use FuzzyComparator for general string matching with tolerance for variations
    - Use semantic comparators (BERT/Semantic) for meaning-based comparison
    - Use LevenshteinComparator for simple edit distance-based matching

--- a/src/stickler/comparators/__init__.py
+++ b/src/stickler/comparators/__init__.py
@@ -15,6 +15,7 @@ from stickler.comparators.bbox import BBoxIoUComparator
 from stickler.comparators.date import DateComparator
 from stickler.comparators.exact import ExactComparator
 from stickler.comparators.levenshtein import LevenshteinComparator
+from stickler.comparators.normalized import NormalizedComparator
 from stickler.comparators.numeric import NumericComparator, NumericExactC
 from stickler.comparators.phone import PhoneComparator
 from stickler.comparators.semantic import SemanticComparator
@@ -113,6 +114,7 @@ __all__ = [
     "BaseComparator",
     "BBoxIoUComparator",
     "LevenshteinComparator",
+    "NormalizedComparator",
     "NumericComparator",
     "NumericExactC",
     "ExactComparator",

--- a/src/stickler/comparators/normalized.py
+++ b/src/stickler/comparators/normalized.py
@@ -1,0 +1,90 @@
+"""Configurable equality after Unicode-aware text normalization."""
+
+import unicodedata
+from typing import Any, Dict, Optional
+
+from stickler.comparators.base import BaseComparator
+
+
+class NormalizedComparator(BaseComparator):
+    """Compare text after applying an explicit set of normalizations.
+
+    By default this restores the formatting-insensitive equality behavior that
+    ``ExactComparator`` provided before 0.7.0: case, whitespace, and punctuation
+    differences are ignored. Unlike the old implementation, punctuation means
+    every character in a Unicode ``P*`` category and whitespace is identified
+    with :meth:`str.isspace`. Unicode symbols such as ``$``, ``±``, and emoji
+    are retained, as are combining marks. Text is normalized to NFC so composed
+    and decomposed spellings compare consistently.
+
+    Each transform can be disabled independently. This makes the normalization
+    policy visible in code and in serialized comparator configuration instead
+    of hiding it behind a single ambiguous "strip punctuation" operation.
+
+    Args:
+        threshold: Similarity threshold (default 1.0). This comparator returns
+            only 0.0 or 1.0.
+        case_sensitive: Preserve case differences when True (default False).
+        ignore_whitespace: Remove Unicode whitespace when True (default True).
+        ignore_punctuation: Remove Unicode punctuation when True (default True).
+    """
+
+    def __init__(
+        self,
+        threshold: float = 1.0,
+        case_sensitive: bool = False,
+        ignore_whitespace: bool = True,
+        ignore_punctuation: bool = True,
+    ):
+        super().__init__(threshold=threshold)
+        self.case_sensitive = case_sensitive
+        self.ignore_whitespace = ignore_whitespace
+        self.ignore_punctuation = ignore_punctuation
+
+    @property
+    def name(self) -> str:
+        """Return the comparator's short name."""
+        return "normalized"
+
+    @property
+    def config(self) -> Optional[Dict[str, Any]]:
+        """Return non-default options for JSON-friendly serialization."""
+        config: Dict[str, Any] = {}
+        if self.case_sensitive:
+            config["case_sensitive"] = True
+        if not self.ignore_whitespace:
+            config["ignore_whitespace"] = False
+        if not self.ignore_punctuation:
+            config["ignore_punctuation"] = False
+        return config or None
+
+    def _normalize(self, value: Any) -> str:
+        """Convert a value to text and apply the configured transforms."""
+        text = unicodedata.normalize("NFC", str(value))
+        if not self.case_sensitive:
+            text = text.casefold()
+        if self.ignore_whitespace or self.ignore_punctuation:
+            text = "".join(
+                character
+                for character in text
+                if not (self.ignore_whitespace and character.isspace())
+                and not (
+                    self.ignore_punctuation
+                    and unicodedata.category(character).startswith("P")
+                )
+            )
+        return text
+
+    def _compare(self, str1: Any, str2: Any) -> float:
+        """Return 1.0 when normalized values are equal, otherwise 0.0."""
+        return 1.0 if self._normalize(str1) == self._normalize(str2) else 0.0
+
+    def __repr__(self) -> str:
+        """Return a representation containing every effective option."""
+        return (
+            "NormalizedComparator("
+            f"threshold={self.threshold}, "
+            f"case_sensitive={self.case_sensitive}, "
+            f"ignore_whitespace={self.ignore_whitespace}, "
+            f"ignore_punctuation={self.ignore_punctuation})"
+        )

--- a/src/stickler/structured_object_evaluator/models/comparable_field.py
+++ b/src/stickler/structured_object_evaluator/models/comparable_field.py
@@ -189,6 +189,13 @@ def _reconstruct_comparator_from_type(
         pass
 
     try:
+        from stickler.comparators.normalized import NormalizedComparator
+
+        comparator_map["NormalizedComparator"] = NormalizedComparator
+    except ImportError:
+        pass
+
+    try:
         from stickler.comparators.phone import PhoneComparator
 
         comparator_map["PhoneComparator"] = PhoneComparator

--- a/src/stickler/structured_object_evaluator/models/comparator_registry.py
+++ b/src/stickler/structured_object_evaluator/models/comparator_registry.py
@@ -27,6 +27,7 @@ class ComparatorRegistry:
     _BUILTINS = {
         "LevenshteinComparator": ("stickler.comparators.levenshtein", None, None),
         "ExactComparator": ("stickler.comparators.exact", None, None),
+        "NormalizedComparator": ("stickler.comparators.normalized", None, None),
         "PhoneComparator": ("stickler.comparators.phone", None, None),
         "NumericComparator": ("stickler.comparators.numeric", None, None),
         "DateComparator": ("stickler.comparators.date", None, None),

--- a/tests/common/comparators/test_none_handling.py
+++ b/tests/common/comparators/test_none_handling.py
@@ -26,6 +26,7 @@ from stickler.comparators import (
     DateComparator,
     ExactComparator,
     LevenshteinComparator,
+    NormalizedComparator,
     NumericComparator,
     SemanticComparator,
     StructuredModelComparator,
@@ -78,6 +79,7 @@ def _bert():
 BUILTIN_COMPARATORS = [
     pytest.param(ExactComparator, id="Exact"),
     pytest.param(LevenshteinComparator, id="Levenshtein"),
+    pytest.param(NormalizedComparator, id="Normalized"),
     pytest.param(NumericComparator, id="Numeric"),
     pytest.param(DateComparator, id="Date"),
     pytest.param(BBoxIoUComparator, id="BBox"),

--- a/tests/common/comparators/test_normalized.py
+++ b/tests/common/comparators/test_normalized.py
@@ -1,0 +1,104 @@
+"""Behavior and integration tests for NormalizedComparator."""
+
+import json
+
+from stickler import ComparableField, NormalizedComparator, StructuredModel, eval_for
+from stickler.structured_object_evaluator.models.comparator_registry import (
+    create_comparator,
+    get_global_registry,
+)
+
+
+class TestDefaultNormalization:
+    """The default policy ignores formatting, not semantic symbols or accents."""
+
+    def setup_method(self):
+        self.comparator = NormalizedComparator()
+
+    def test_ascii_formatting_differences_match(self):
+        assert self.comparator.compare("U.S.A.", "USA") == 1.0
+        assert self.comparator.compare("John  Smith", "john smith") == 1.0
+
+    def test_unicode_punctuation_and_whitespace_are_removed(self):
+        assert self.comparator.compare("it’s ready", "itsready") == 1.0
+        assert self.comparator.compare("Ａ－Ｂ", "ＡＢ") == 1.0
+
+    def test_symbols_are_not_punctuation(self):
+        assert self.comparator.compare("$1,247.50", "$124750") == 1.0
+        assert self.comparator.compare("$1,247.50", "124750") == 0.0
+        assert self.comparator.compare("x±y", "xy") == 0.0
+        assert self.comparator.compare("emoji🎉here", "emojihere") == 0.0
+
+    def test_accents_are_preserved_and_canonicalized(self):
+        assert self.comparator.compare("côte", "cote") == 0.0
+        assert self.comparator.compare("côte", "co\u0302te") == 1.0
+
+
+class TestConfiguration:
+    """Every transform can be selected independently and serialized."""
+
+    def test_case_can_be_preserved(self):
+        comparator = NormalizedComparator(case_sensitive=True)
+        assert comparator.compare("Hello!", "hello") == 0.0
+
+    def test_whitespace_can_be_preserved(self):
+        comparator = NormalizedComparator(ignore_whitespace=False)
+        assert comparator.compare("John Smith", "JohnSmith") == 0.0
+        assert comparator.compare("John-Smith", "JohnSmith") == 1.0
+
+    def test_punctuation_can_be_preserved(self):
+        comparator = NormalizedComparator(ignore_punctuation=False)
+        assert comparator.compare("U.S.A.", "USA") == 0.0
+        assert comparator.compare("U S A", "USA") == 1.0
+
+    def test_config_omits_defaults_and_round_trips(self):
+        assert NormalizedComparator().config is None
+        original = NormalizedComparator(
+            case_sensitive=True,
+            ignore_whitespace=False,
+            ignore_punctuation=False,
+        )
+        encoded = json.loads(json.dumps(original.config))
+        rebuilt = create_comparator("NormalizedComparator", encoded)
+
+        assert rebuilt.config == original.config
+        assert rebuilt.compare("A-B", "a b") == 0.0
+
+    def test_name_and_repr_describe_the_policy(self):
+        comparator = NormalizedComparator(ignore_punctuation=False)
+        assert comparator.name == "normalized"
+        assert "ignore_punctuation=False" in repr(comparator)
+
+
+class TestFrameworkIntegration:
+    """The comparator participates in registry, schema, and explain flows."""
+
+    def test_registry_exposes_the_canonical_class(self):
+        registry = get_global_registry()
+        assert registry.is_registered("NormalizedComparator")
+        assert registry.get("NormalizedComparator") is NormalizedComparator
+
+    def test_json_schema_round_trip_preserves_configuration(self):
+        class Label(StructuredModel):
+            value: str = ComparableField(
+                comparator=NormalizedComparator(ignore_punctuation=False)
+            )
+
+        schema = Label.to_json_schema()
+        property_schema = schema["properties"]["value"]
+        assert property_schema["x-aws-stickler-comparator"] == "NormalizedComparator"
+        assert property_schema["x-aws-stickler-comparator-config"] == {
+            "ignore_punctuation": False
+        }
+
+        rebuilt = StructuredModel.from_json_schema(schema)
+        assert rebuilt(value="U.S.A.").compare(rebuilt(value="USA")) == 0.0
+        assert rebuilt(value="U S A").compare(rebuilt(value="USA")) == 1.0
+
+    def test_explain_reports_explicit_comparator(self):
+        class Label(StructuredModel):
+            value: str = ComparableField(comparator=NormalizedComparator())
+
+        explanation = eval_for(Label).explain()["value"]
+        assert explanation["comparator"] == "NormalizedComparator"
+        assert explanation["source"] == "explicit"

--- a/tests/test_top_level_exports.py
+++ b/tests/test_top_level_exports.py
@@ -19,6 +19,7 @@ ALWAYS_AVAILABLE_EXPORTS = {
     "ExactComparator": "stickler.comparators.exact",
     "FuzzyComparator": "stickler.comparators.fuzzy",
     "LevenshteinComparator": "stickler.comparators.levenshtein",
+    "NormalizedComparator": "stickler.comparators.normalized",
     "NumericComparator": "stickler.comparators.numeric",
     "PhoneComparator": "stickler.comparators.phone",
     "SemanticComparator": "stickler.comparators.semantic",


### PR DESCRIPTION
*Issue #, if available:*

Closes #223

*Description of changes:*

Adds `NormalizedComparator` for binary equality after an explicit set of Unicode-aware text transforms.

- Makes case, whitespace, and punctuation handling independently configurable.
- Uses NFC normalization, Unicode case folding, `str.isspace()`, and Unicode `P*` punctuation categories.
- Preserves symbols such as `$`, `±`, and emoji, plus accents and combining marks.
- Registers and exports the comparator and supports config, JSON Schema round-trip, and explanation metadata.
- Documents the API and migration path from pre-0.7.0 `ExactComparator` behavior.

Verification:

- Focused integration suite: 124 passed, 7 skipped.
- Full suite on current `dev`: 2,286 passed, 12 skipped.
- Changed-file Ruff checks passed.
- MkDocs build passed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.