### PR TITLE
fix: warn when NormalizedComparator is used on mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,18 @@ Each release links to full notes on the
 
 ### Fixed
 
+- **Scores change for mapping fields explicitly using `NormalizedComparator`.**
+  Both `compare` and `compare_with` now warn and count the pair as a false
+  discovery with score `0.0`, even for identical dictionaries. For example,
+  `Optional[Dict[str, Any]] = ComparableField(comparator=NormalizedComparator())`
+  with `{"k": "v", "n": 1}` on both sides previously scored `1.0`; it now scores
+  `0.0`. Reordering the prediction's keys previously scored `0.0` and still does,
+  but now warns. Use `ANLSStarComparator()` for structural comparison or
+  `ExactComparator()` for order-independent whole-mapping equality instead.
+  The refusal is unconditional, including when case, whitespace and punctuation
+  options disable those transforms. Scalar normalization is unchanged
+  ([#315](https://github.com/awslabs/stickler/issues/315)).
+
 - **Breaking:** a threshold set on a comparator now reaches the field that names
   it. `Comparator(threshold=...)` was accepted everywhere and read almost
   nowhere: the only functional reader outside ANLS\* is `binary_compare()`, which
@@ -366,9 +378,10 @@ Each release links to full notes on the
   `handles_mappings` attribute, which no comparator outside this repo could carry,
   so a user who wrote a mapping comparator and asked for it by name had their
   score silently replaced with `0.0`. An explicit `comparator=` is consent by
-  definition. Only `LevenshteinComparator` (raises on a dict) and
+  definition. `LevenshteinComparator` (raises on a dict),
   `FuzzyComparator` (scores a changed value `0.944`, above a mere key reordering
-  at `0.667`) are refused, both on measured evidence. `handles_mappings` is
+  at `0.667`) and `NormalizedComparator` (depends on key order) are refused on
+  measured evidence. `handles_mappings` is
   removed entirely rather than documented, since nothing reads it now.
 
 - `List[Dict[...]]` is routed on the explicit path too, keyed on the element type.
@@ -420,9 +433,14 @@ Each release links to full notes on the
   no longer zeroed for trying. `ExactComparator` now canonicalises a mapping
   first, so identical content scores `1.0` regardless of key order; it previously
   used `str(dict)`, which made key order significant and returned `0.0` or `1.0`
-  depending only on how the JSON arrived. `LevenshteinComparator` and
-  `FuzzyComparator` stay excluded: the first raises on a dict, and the second
-  scores a changed value (`0.944`) higher than a mere reordering (`0.667`).
+  depending only on how the JSON arrived. `LevenshteinComparator`,
+  `FuzzyComparator` and `NormalizedComparator` stay excluded: the first raises
+  on a dict, the second scores a changed value (`0.944`) higher than a mere
+  reordering (`0.667`), and the third depends on key order. Canonicalization is
+  not a general fix for `NormalizedComparator`: with its default whitespace
+  and punctuation removal, canonical JSON for `{"a": "bc"}` and `{"ab": "c"}`
+  both normalize to `abc`, manufacturing an exact match between different
+  mappings.
 
 - The mapping substitution copies the field descriptor instead of mutating it.
   Pydantic does not clone the `json_schema_extra` closure, so one

--- a/src/stickler/structured_object_evaluator/models/comparison_dispatcher.py
+++ b/src/stickler/structured_object_evaluator/models/comparison_dispatcher.py
@@ -229,9 +229,9 @@ class ComparisonDispatcher:
             if not ConfigurationHelper.can_score_mapping(
                 self.model.__class__, field_name, info.comparator
             ):
-                # Reachable via `Any` or a multi-arm union, where no annotation
-                # declared the field a mapping so nothing could install a
-                # structural comparator. Scored, warned, and not raised -- see
+                # Reachable via `Any` or a multi-arm union, or a mapping annotation
+                # (including Optional[Dict]) with an explicit comparator that
+                # prevents ANLS* substitution. Scored, warned, and not raised -- see
                 # ConfigurationHelper.can_score_mapping.
                 return {
                     "overall": {"tp": 0, "fa": 0, "fd": 1, "fp": 1, "tn": 0, "fn": 0},

--- a/src/stickler/structured_object_evaluator/models/configuration_helper.py
+++ b/src/stickler/structured_object_evaluator/models/configuration_helper.py
@@ -22,13 +22,13 @@ if TYPE_CHECKING:
 from stickler.comparators.structured import StructuredModelComparator
 
 # Comparators that must not be handed a mapping, by class name so an out-of-tree
-# comparator is never caught by it. Both entries are here on measured evidence:
-# Levenshtein raises, and Fuzzy ranks a changed value above a reordering.
+# comparator is never caught by it. Entries are here on measured evidence:
+# Levenshtein raises, Fuzzy misranks values, and Normalized depends on key order.
 #
 # Deliberately a denylist. An allowlist would silently zero any mapping-capable
 # comparator written outside this repo, since it could not know to opt in.
 _COMPARATORS_THAT_CANNOT_SCORE_MAPPINGS = frozenset(
-    {"LevenshteinComparator", "FuzzyComparator"}
+    {"LevenshteinComparator", "FuzzyComparator", "NormalizedComparator"}
 )
 
 
@@ -155,12 +155,14 @@ class ConfigurationHelper:
         by definition, and the gate was overriding it -- reproducing the very
         symptom of #297 for a different population.
 
-        The two refused comparators are refused on evidence, not by category:
+        The refused comparators are refused on evidence, not by category:
 
             LevenshteinComparator  raises TypeError on a dict
             FuzzyComparator        scores a CHANGED value (0.944) above a mere
                                    key reordering (0.667), so its ordering is
                                    not defensible as a metric
+            NormalizedComparator   flattens keys and values in insertion order,
+                                   so identical content can score 0.0
 
         Callers report a false discovery rather than raising: the shape of a value
         can be data-dependent, so raising ends a corpus run on document N after

--- a/src/stickler/structured_object_evaluator/models/configuration_helper.py
+++ b/src/stickler/structured_object_evaluator/models/configuration_helper.py
@@ -21,8 +21,10 @@ if TYPE_CHECKING:
     )
 from stickler.comparators.structured import StructuredModelComparator
 
-# Comparators that must not be handed a mapping, by class name so an out-of-tree
-# comparator is never caught by it. Entries are here on measured evidence:
+# Comparators that must not be handed a mapping, matched by exact class name.
+# Differently named external comparators are left alone, but this also misses
+# differently named subclasses of these comparators, even with inherited behavior.
+# Entries are here on measured evidence:
 # Levenshtein raises, Fuzzy misranks values, and Normalized depends on key order.
 #
 # Deliberately a denylist. An allowlist would silently zero any mapping-capable
@@ -169,6 +171,9 @@ class ConfigurationHelper:
         succeeding on N-1, and no test would catch it. The warning carries the
         same information without stopping.
         """
+        # Refusal is deliberately independent of instance options: even
+        # NormalizedComparator with its case/whitespace/punctuation transforms
+        # disabled is refused. Option-aware mapping support is a separate change.
         if comparator.__class__.__name__ not in _COMPARATORS_THAT_CANNOT_SCORE_MAPPINGS:
             return True
         warn_once(

--- a/tests/comparators/README.md
+++ b/tests/comparators/README.md
@@ -6,6 +6,9 @@ Most comparator tests live in `tests/common/comparators/`. This directory holds
 tests for comparators whose behaviour spans more than the comparator itself, so
 a unit test of the class alone would not catch the defect.
 
+`test_normalized_mapping.py` checks that both StructuredModel comparison APIs
+warn and complete when a text-only NormalizedComparator is named for a mapping.
+
 ## `test_anls_star.py`
 
 `ANLSStarComparator` scores mappings structurally. Its correctness depends on

--- a/tests/comparators/test_normalized_mapping.py
+++ b/tests/comparators/test_normalized_mapping.py
@@ -1,0 +1,29 @@
+"""Regression for #315: text normalization must not silently score mappings."""
+
+from typing import Any, Dict, Optional
+
+import pytest
+
+from stickler import ComparableField, StructuredModel
+from stickler.comparators.normalized import NormalizedComparator
+from stickler.utils import deprecation
+
+
+@pytest.mark.parametrize("method", ["compare", "compare_with"])
+@pytest.mark.parametrize("prediction", [{"k": "v", "n": 1}, {"n": 1, "k": "v"}])
+def test_normalized_mapping_warns_and_completes(monkeypatch, method, prediction):
+    # Each case must observe its own warning, independent of earlier tests.
+    monkeypatch.setattr(deprecation, "_warned", set())
+
+    class Model(StructuredModel):
+        meta: Optional[Dict[str, Any]] = ComparableField(
+            comparator=NormalizedComparator(), default=None
+        )
+
+    expected = Model(meta={"k": "v", "n": 1})
+    actual = Model(meta=prediction)
+    with pytest.warns(UserWarning, match="NormalizedComparator.*ANLSStarComparator"):
+        result = getattr(expected, method)(actual)
+
+    score = result["overall_score"] if method == "compare_with" else result
+    assert score == 0.0


### PR DESCRIPTION
*Issue #, if available:*

Fixes #315.

*Description of changes:*

Add `NormalizedComparator` to the existing mapping denylist. Explicitly using it on a dictionary emits the existing warning and returns the existing rejected-mapping score instead of silently comparing flattened text. Scalar normalization and default structural mapping behavior are unchanged.

The regression covers `compare` and `compare_with`, each with identical and reordered dictionary keys. It checks that evaluation warns and completes with a score of `0.0`.

The changelog records the identical-mapping score change from `1.0` to `0.0`, corrects both comparator lists, and explains why canonical JSON plus punctuation removal can manufacture matches. Comments also document the exact-class-name/subclass limitation, the unconditional instance-option policy, and the explicit-comparator route for `Optional[Dict]`. These review revisions do not expand runtime behavior.

### Verification

Updated against `dev` at `6580ecb`; final revision `cd805cb`, Python 3.13.15, frozen dependencies:

- Original test-first command: `python -m pytest tests/comparators/test_normalized_mapping.py -q -o addopts= --tb=short` produced four expected missing-warning failures before the fix. All four pass with it. Repeated the process-local negative control on this integrated revision: removing only the denylist entry again produces four expected missing-warning failures.
- Focused/related and changelog-contract modules: **323 passed** on native Windows.
- Full offline Linux container suite: `python -m coverage run -m pytest tests/ -q -o addopts= --tb=short -ra` — **2,724 passed, 12 skipped**, 201 warnings; production-source coverage **85%**.
- Full native Windows suite: `python -m pytest tests/ -q -o addopts= --tb=short -ra` — **2,718 passed, 6 failed, 12 skipped**. The identical command on unchanged `dev@6580ecb` gives **2,714 passed, the same 6 failed, 12 skipped**. All six failures are the existing unavailable `signal.SIGALRM` timeout wrappers; all pass in Linux. No tests or timeouts were disabled.
- Scoped Ruff, final diff checks, offline wheel/source-distribution build and dependency compatibility checks passed. Repository-wide Ruff has the same **16 lint findings and 140 formatting candidates** as unchanged upstream; no unrelated formatting changes are included.
- Verified the maintainer's score/canonicalization examples and the documented subclass/instance-option limitations. AST comparison confirms upstream executable code is preserved except for the original denylist entry. Tested source, final checkout and packaged changed source were checked for identity.

The 12 skips cover missing optional BERT/Strands extras and two existing unimplemented tests. Extra-enabled paths and other Python versions were not run locally; the hosted CI matrix must validate this updated head.

AI assistance was used for implementation and verification.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
