### PR TITLE
fix(320): refuse SecretStr/SecretBytes rather than compare the mask

### DIFF
--- a/src/stickler/comparators/anls.py
+++ b/src/stickler/comparators/anls.py
@@ -21,8 +21,10 @@ partial credit depends on the data being evaluated. It is deliberately not calle
 every comparator, and a cutoff applied inside the recursion is a different thing.
 """
 
+from collections.abc import Mapping
 from typing import Any, Dict, Optional
 
+from pydantic import BaseModel, SecretBytes, SecretStr
 from pydantic_core import to_jsonable_python
 
 from stickler.comparators.base import BaseComparator
@@ -89,6 +91,52 @@ def _jsonable_or_unscoreable(value: Any) -> Any:
         category=UserWarning,
     )
     return _UNSCOREABLE
+
+
+def _refuse_secrets(value: Any) -> Any:
+    """Replace every ``SecretStr`` / ``SecretBytes`` leaf with ``_UNSCOREABLE``.
+
+    Run before ``to_jsonable_python`` because that call is where the value is
+    lost: pydantic masks a secret to the constant ``'**********'`` there, so two
+    DIFFERENT secrets arrive at the metric byte-identical and score a perfect
+    match on a mismatch (#320). The masked form is a valid JSON string, so
+    ``_jsonable_or_unscoreable`` never fires for it -- a secret has to be caught
+    by type, here, while the real value is still intact.
+
+    A secret is refused, not unwrapped: scoring it would require holding
+    plaintext in the comparison and its ``non_matches`` payload, which is the
+    opposite of what a ``SecretStr`` field exists to guarantee. ``_UNSCOREABLE``
+    routes it to the same refusal ANLS* already uses for out-of-domain values
+    (``ANLSLeaf`` short-circuits to 0.0 without consulting equality), so an
+    identical pair is refused too -- the honest signal is "not scored", not
+    "matched".
+
+    Recurses containers and plain ``BaseModel`` values. A model is dumped with
+    ``model_dump()`` (python mode, NOT ``mode="json"``) precisely because that
+    keeps secrets as ``SecretStr`` objects instead of masking them, while still
+    lowering nested models to dicts and preserving computed fields.
+    """
+    if isinstance(value, (SecretStr, SecretBytes)):
+        warn_once(
+            "anls-secret-unscoreable",
+            type(value).__qualname__,
+            f"ANLSStarComparator refused a '{type(value).__qualname__}' value "
+            "(scored 0.0): pydantic masks it to a constant before comparison, "
+            "so two different secrets are indistinguishable and would score a "
+            "perfect match. Unwrap it with .get_secret_value() before "
+            "evaluating, or exclude the field.",
+            category=UserWarning,
+        )
+        return _UNSCOREABLE
+    if isinstance(value, BaseModel):
+        return _refuse_secrets(value.model_dump())
+    if isinstance(value, Mapping):
+        return {key: _refuse_secrets(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_refuse_secrets(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        return {_refuse_secrets(item) for item in value}
+    return value
 
 
 class ANLSStarComparator(BaseComparator):
@@ -264,8 +312,16 @@ class ANLSStarComparator(BaseComparator):
         # the normalization asymmetric, so `Dict[str, Tuple[int, int]]` scored
         # 0.0 against an identical copy and 1.0 against a truncated prediction.
         # The 1-of-n contract lives on `anls_score`, which normalizes nothing.
-        gt_value = to_jsonable_python(str1, fallback=_jsonable_or_unscoreable)
-        pred_value = to_jsonable_python(str2, fallback=_jsonable_or_unscoreable)
+        # Refuse secrets BEFORE coercion: to_jsonable_python masks a SecretStr
+        # to a constant, which destroys the difference it is supposed to score
+        # (#320). _refuse_secrets marks each secret leaf so the tree refuses it,
+        # the same treatment an out-of-domain value already gets below.
+        gt_value = to_jsonable_python(
+            _refuse_secrets(str1), fallback=_jsonable_or_unscoreable
+        )
+        pred_value = to_jsonable_python(
+            _refuse_secrets(str2), fallback=_jsonable_or_unscoreable
+        )
 
         gt_tree = ANLSTree.make_tree(
             gt_value, is_gt=True, threshold=self.leaf_threshold

--- a/src/stickler/comparators/anls.py
+++ b/src/stickler/comparators/anls.py
@@ -24,7 +24,7 @@ every comparator, and a cutoff applied inside the recursion is a different thing
 from collections.abc import Mapping
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, SecretBytes, SecretStr
+from pydantic import BaseModel
 from pydantic_core import to_jsonable_python
 
 from stickler.comparators.base import BaseComparator
@@ -94,29 +94,48 @@ def _jsonable_or_unscoreable(value: Any) -> Any:
 
 
 def _refuse_secrets(value: Any) -> Any:
-    """Replace every ``SecretStr`` / ``SecretBytes`` leaf with ``_UNSCOREABLE``.
+    """Replace every pydantic secret leaf with ``_UNSCOREABLE``.
 
     Run before ``to_jsonable_python`` because that call is where the value is
     lost: pydantic masks a secret to the constant ``'**********'`` there, so two
     DIFFERENT secrets arrive at the metric byte-identical and score a perfect
     match on a mismatch (#320). The masked form is a valid JSON string, so
     ``_jsonable_or_unscoreable`` never fires for it -- a secret has to be caught
-    by type, here, while the real value is still intact.
+    here, while the real value is still intact.
+
+    Detected by ``get_secret_value``, not by ``isinstance``. ``SecretStr``,
+    ``SecretBytes`` and ``Secret[T]`` are SIBLINGS under a private base, so
+    ``isinstance(v, Secret)`` does not match a ``SecretStr`` and naming the two
+    concrete classes misses every ``Secret[T]``. The duck-type is the only public
+    spelling that covers all three, and ``pydantic.types._SecretBase`` is private
+    so it carries no compatibility promise.
 
     A secret is refused, not unwrapped: scoring it would require holding
     plaintext in the comparison and its ``non_matches`` payload, which is the
-    opposite of what a ``SecretStr`` field exists to guarantee. ``_UNSCOREABLE``
+    opposite of what a secret field exists to guarantee. ``_UNSCOREABLE``
     routes it to the same refusal ANLS* already uses for out-of-domain values
     (``ANLSLeaf`` short-circuits to 0.0 without consulting equality), so an
     identical pair is refused too -- the honest signal is "not scored", not
     "matched".
 
-    Recurses containers and plain ``BaseModel`` values. A model is dumped with
-    ``model_dump()`` (python mode, NOT ``mode="json"``) precisely because that
-    keeps secrets as ``SecretStr`` objects instead of masking them, while still
-    lowering nested models to dicts and preserving computed fields.
+    Recurses mappings, lists, tuples, sets and plain ``BaseModel`` values. A
+    model is dumped with ``model_dump()`` (python mode, NOT ``mode="json"``)
+    precisely because that keeps secrets as secret objects instead of masking
+    them, while still lowering nested models to dicts and preserving computed
+    fields. ``by_alias=True`` because ``to_jsonable_python`` keys a model by
+    ALIAS: without it, inserting this function in front of that call silently
+    changed the key convention for every aliased model, secrets or not.
+
+    A set is rebuilt as a LIST, not a set. The tuple branch returns a list, and
+    lists are unhashable, so ``{...}`` here raised ``TypeError`` on any
+    ``Set[Tuple[...]]``. Nothing is lost: ``to_jsonable_python`` lowers a set to
+    a list regardless.
+
+    NOT reached: a secret held by a plain ``dataclass``, which falls through to
+    ``return value`` and is masked downstream like before. Out of scope here;
+    handle it by declaring the field on a ``BaseModel``.
     """
-    if isinstance(value, (SecretStr, SecretBytes)):
+    if hasattr(value, "get_secret_value"):
         warn_once(
             "anls-secret-unscoreable",
             type(value).__qualname__,
@@ -129,13 +148,13 @@ def _refuse_secrets(value: Any) -> Any:
         )
         return _UNSCOREABLE
     if isinstance(value, BaseModel):
-        return _refuse_secrets(value.model_dump())
+        return _refuse_secrets(value.model_dump(by_alias=True))
     if isinstance(value, Mapping):
         return {key: _refuse_secrets(item) for key, item in value.items()}
     if isinstance(value, (list, tuple)):
         return [_refuse_secrets(item) for item in value]
     if isinstance(value, (set, frozenset)):
-        return {_refuse_secrets(item) for item in value}
+        return [_refuse_secrets(item) for item in value]
     return value
 
 

--- a/tests/comparators/conftest.py
+++ b/tests/comparators/conftest.py
@@ -1,0 +1,19 @@
+"""Shared fixtures for comparator tests."""
+
+import pytest
+
+from stickler.utils import deprecation as _deprecation
+
+
+@pytest.fixture(autouse=True)
+def _reset_deprecation_sentinels():
+    """Clear ``warn_once`` sentinels so each test sees fresh warnings.
+
+    The library suppresses repeat warnings by remembering
+    ``(deprecation_id, context)`` tuples in a process-scoped set. Tests that
+    assert ``with pytest.warns(...):`` would otherwise silently fail when run
+    after a peer test that already tripped the same sentinel.
+    """
+    _deprecation._warned.clear()
+    yield
+    _deprecation._warned.clear()

--- a/tests/comparators/test_anls_secret_refusal.py
+++ b/tests/comparators/test_anls_secret_refusal.py
@@ -1,0 +1,145 @@
+"""A ``SecretStr`` / ``SecretBytes`` leaf is refused, never scored (#320).
+
+Pydantic masks a secret to the constant ``'**********'`` the moment it is
+converted to JSON form, which is the first thing every comparison path does.
+By the time any comparator sees the value, both sides are byte-identical and
+the real difference is gone -- so two DIFFERENT secrets scored a perfect 1.0,
+an invented match on a credential mismatch.
+
+The fix routes a secret leaf to the same refusal ANLS* already uses for values
+it cannot represent (see ``_UNSCOREABLE`` in ``stickler.comparators.anls``): it
+scores 0.0 and warns, rather than comparing the mask. Refusal does not consult
+equality -- an unscoreable value is not scored whether or not the two happen to
+be equal -- so identical secrets are refused too. That is the honest signal:
+"we could not score this," not "these matched."
+
+The issue makes two constraints non-negotiable, both pinned here: the fix must
+cover ``SecretBytes`` as well as ``SecretStr``, and it must apply to a bare
+``Dict[str, SecretStr]`` as well as a plain-model field.
+"""
+
+from typing import Dict, Optional
+
+import pytest
+from pydantic import BaseModel, SecretBytes, SecretStr
+
+import stickler
+from stickler import ANLSStarComparator, StructuredModel
+
+
+class Creds(BaseModel):
+    api_key: Optional[SecretStr] = None
+
+
+class CredsBytes(BaseModel):
+    token: Optional[SecretBytes] = None
+
+
+class DocPlainModel(StructuredModel):
+    creds: Optional[Creds] = None
+
+
+class DocPlainModelBytes(StructuredModel):
+    creds: Optional[CredsBytes] = None
+
+
+class DocSecretDict(StructuredModel):
+    creds: Optional[Dict[str, SecretStr]] = None
+
+
+class TestTheComparatorRefusesSecretLeaves:
+    """Directly on ANLS*, the smallest unit that owns the coercion."""
+
+    def test_two_different_secrets_are_not_a_match(self):
+        c = ANLSStarComparator()
+        assert c.compare(
+            {"k": SecretStr("s3cret")}, {"k": SecretStr("hunter2")}
+        ) == pytest.approx(0.0)
+
+    def test_identical_secrets_are_refused_not_matched(self):
+        """Refusal does not consult equality: an unscoreable value scores 0.0
+        whether or not the two sides are equal."""
+        c = ANLSStarComparator()
+        assert c.compare(
+            {"k": SecretStr("s3cret")}, {"k": SecretStr("s3cret")}
+        ) == pytest.approx(0.0)
+
+    def test_secret_bytes_are_refused_too(self):
+        c = ANLSStarComparator()
+        assert c.compare(
+            {"k": SecretBytes(b"aaa")}, {"k": SecretBytes(b"bbb")}
+        ) == pytest.approx(0.0)
+
+    def test_a_secret_nested_in_a_plain_model_is_refused(self):
+        c = ANLSStarComparator()
+        assert c.compare(
+            Creds(api_key=SecretStr("s3cret")),
+            Creds(api_key=SecretStr("hunter2")),
+        ) == pytest.approx(0.0)
+
+
+class TestTheRefusalIsAnnounced:
+    def test_a_secret_leaf_warns(self):
+        """A silent 0.0 is indistinguishable from a wrong extraction, so the
+        caller is told the value was refused because it is masked."""
+        with pytest.warns(UserWarning, match="masks it to a constant"):
+            ANLSStarComparator().compare(
+                {"k": SecretStr("s3cret")}, {"k": SecretStr("hunter2")}
+            )
+
+    def test_secret_bytes_also_warns(self):
+        """warn_once keys on the type name, so SecretBytes is tracked separately
+        from SecretStr and needs its own coverage."""
+        with pytest.warns(UserWarning, match="masks it to a constant"):
+            ANLSStarComparator().compare(
+                {"k": SecretBytes(b"aaa")}, {"k": SecretBytes(b"bbb")}
+            )
+
+
+class TestTheModelLevelReproduction:
+    """The exact shapes from issue #320, via ``compare_with``."""
+
+    def test_plain_model_field_no_longer_invents_a_match(self):
+        r = DocPlainModel(creds=Creds(api_key=SecretStr("s3cret"))).compare_with(
+            DocPlainModel(creds=Creds(api_key=SecretStr("hunter2"))),
+            include_confusion_matrix=True,
+        )
+        assert r["field_scores"]["creds"] == pytest.approx(0.0)
+        assert r["confusion_matrix"]["overall"]["tp"] == 0
+
+    def test_bare_secret_dict_no_longer_invents_a_match(self):
+        r = DocSecretDict(creds={"k": SecretStr("aaa")}).compare_with(
+            DocSecretDict(creds={"k": SecretStr("bbb")})
+        )
+        assert r["field_scores"]["creds"] == pytest.approx(0.0)
+
+    def test_secret_bytes_field_no_longer_invents_a_match(self):
+        r = DocPlainModelBytes(
+            creds=CredsBytes(token=SecretBytes(b"aaa"))
+        ).compare_with(
+            DocPlainModelBytes(creds=CredsBytes(token=SecretBytes(b"bbb"))),
+            include_confusion_matrix=True,
+        )
+        assert r["field_scores"]["creds"] == pytest.approx(0.0)
+        assert r["confusion_matrix"]["overall"]["tp"] == 0
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Separate masking site, out of #320's scope. The zero-config "
+            "`evaluate` (auto) facade normalizes the whole instance with "
+            "`model_dump(mode='json')` before comparison, which masks every "
+            "secret up front -- earlier than, and independent of, the ANLS* "
+            "coercion #320 fixes. Refusing it needs `auto/inference.py` to route "
+            "SecretStr to a refusing comparator, which lands in the builder/"
+            "inference files #255/#250/#263 are rewriting. Tracked separately; "
+            "when that fix lands this flips to XPASS and should be un-xfailed."
+        ),
+    )
+    def test_zero_config_evaluate_path(self):
+        """The route a user hits without any Stickler-specific code."""
+        result = stickler.evaluate(
+            Creds(api_key=SecretStr("s3cret")),
+            Creds(api_key=SecretStr("hunter2")),
+        )
+        assert result.field_scores["api_key"] == pytest.approx(0.0)

--- a/tests/comparators/test_anls_secret_refusal.py
+++ b/tests/comparators/test_anls_secret_refusal.py
@@ -21,7 +21,7 @@ cover ``SecretBytes`` as well as ``SecretStr``, and it must apply to a bare
 from typing import Dict, Optional
 
 import pytest
-from pydantic import BaseModel, SecretBytes, SecretStr
+from pydantic import BaseModel, Field, Secret, SecretBytes, SecretStr
 
 import stickler
 from stickler import ANLSStarComparator, StructuredModel
@@ -143,3 +143,69 @@ class TestTheModelLevelReproduction:
             Creds(api_key=SecretStr("hunter2")),
         )
         assert result.field_scores["api_key"] == pytest.approx(0.0)
+
+
+class TestTheRefusalDoesNotBreakWhatItPassesThrough:
+    """`_refuse_secrets` runs in front of EVERY `to_jsonable_python` call in
+    `_compare`, so it sees values with no secret in them at all. Whatever it
+    does to those has to be a no-op. Two ways it was not.
+    """
+
+    def test_a_set_of_tuples_still_scores(self):
+        """Rebuilding a set from the recursive results raised.
+
+        The `(list, tuple)` branch returns a LIST, and lists are unhashable, so
+        `{_refuse_secrets(item) for item in value}` raised
+        `TypeError: unhashable type: 'list'` on any set or frozenset holding a
+        tuple. No secret involved: this broke a comparison that worked before.
+        """
+        c = ANLSStarComparator()
+        assert c.compare({(1, 2), (3, 4)}, {(1, 2), (3, 4)}) == pytest.approx(1.0)
+        assert c.compare(frozenset({(1, 2)}), frozenset({(1, 2)})) == pytest.approx(1.0)
+
+    def test_an_aliased_model_keeps_its_alias_keys(self):
+        """`model_dump()` keys by FIELD NAME; `to_jsonable_python` keys by ALIAS.
+
+        Dumping without `by_alias=True` silently changed the key convention for
+        every aliased model, including models with no secret anywhere in them, so
+        a model compared against its own `model_dump(by_alias=True)` lost a field
+        per alias. It is a straight swap, so both directions are pinned.
+        """
+
+        class Aliased(BaseModel):
+            model_config = {"populate_by_name": True}
+            tok: str = Field(alias="token")
+            a: int = 1
+
+        m = Aliased(token="plain")
+        c = ANLSStarComparator()
+        assert c.compare(m, m.model_dump(by_alias=True)) == pytest.approx(1.0)
+        assert c.compare(m, m.model_dump()) < 1.0
+
+
+class TestEverySecretFamilyIsRefused:
+    def test_secret_of_t_is_refused_too(self):
+        """`Secret[T]` is a SIBLING of `SecretStr`, not a parent or a child.
+
+        `isinstance(v, Secret)` does not match a `SecretStr`, and naming the two
+        concrete classes misses every `Secret[T]`, so `Secret[int](1)` against
+        `Secret[int](2)` kept scoring 1.0 -- #320's exact symptom. The public
+        duck-type `get_secret_value` is what covers all three families.
+        """
+        c = ANLSStarComparator()
+        with pytest.warns(UserWarning, match="refused"):
+            assert c.compare(Secret[int](1), Secret[int](2)) == pytest.approx(0.0)
+
+    @pytest.mark.parametrize(
+        "make",
+        [
+            lambda v: SecretStr(str(v)),
+            lambda v: SecretBytes(str(v).encode()),
+            lambda v: Secret[int](v),
+        ],
+        ids=["SecretStr", "SecretBytes", "Secret[int]"],
+    )
+    def test_identical_secrets_are_refused_not_matched(self, make):
+        """Refusal does not consult equality, so identical is refused as well."""
+        c = ANLSStarComparator()
+        assert c.compare(make(1), make(1)) == pytest.approx(0.0)


### PR DESCRIPTION
Pydantic masks a SecretStr/SecretBytes to the constant '**********' during JSON coercion, so two different secrets reached ANLSStarComparator byte-identical and scored a false perfect match on a credential mismatch.

Refuse the secret at the ANLS* coercion point, the treatment already given to values with no JSON form: route it to _UNSCOREABLE so the tree scores it 0.0 and warns, without ever handling plaintext. Covers both SecretStr and SecretBytes, and both a plain-model field and a bare Dict[str, SecretStr].

Known gap, left out of scope and pinned as a strict xfail: the zero-config stickler.evaluate() path masks the whole instance via model_dump(mode="json") before comparison, a separate and earlier masking site whose fix belongs in auto/inference.py (files #255/#250/#263 are rewriting). The strict xfail flips to a failure and self-documents the moment that path is fixed.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
