### PR TITLE
docs: measure against the branch, not the installed stickler (#342)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,19 @@
 ## Testing
 - Test documentation and guidelines can be found in [tests/README.md](./tests/README.md).
 
+## Measuring behaviour by hand
+- **Print which stickler you imported before you trust a number.** CI is not the risk: it runs `uv sync --frozen`, so its `import stickler` is always the checkout. The risk is a shell, a notebook, or a review where it is not.
+
+  ```python
+  import stickler, inspect; print(inspect.getfile(stickler))
+  ```
+
+  Or pin it: `PYTHONPATH=/path/to/checkout/src python ...`, or `uv run --project /path/to/checkout`.
+- **Check the path, not `__version__`.** `dev` and the published release both report `0.7.0` until the 1.0 bump lands, so the version string cannot tell the two apart. The file path can.
+- `pip install stickler-eval` currently gives **0.7.0**, which is weeks behind `dev` and pre-1.0. This repo is also routinely checked out a dozen times at once, so an editable install can point at a different worktree than the one you are reading.
+- Known 0.7.0 vs `dev` divergences: schema-path comparator defaults (`format`/`enum`/`const` are read on `dev`, ignored in 0.7.0), the built-in comparator count (13 vs 11), extension-typo rejection (raises on `dev`, dropped silently in 0.7.0), and `EvalResult.matched` (`overall_score >= match_threshold` on `dev`, `all_fields_matched` in 0.7.0). Not exhaustive, and it grows until 1.0 publishes.
+- A review that cites measured numbers should say which tree produced them. Measuring the wrong build produces internally consistent, confidently wrong conclusions, and it has twice sent a PR author to delete correct work. See [#342](https://github.com/awslabs/stickler/issues/342).
+
 ## Dependencies and `uv.lock`
 - `uv.lock` is committed deliberately. Do not gitignore or delete it: every CI workflow runs `uv sync --frozen`, which fails immediately if the lockfile is absent.
 - It does not constrain consumers of the published package. Installers resolve the `dependencies` ranges in `pyproject.toml`, which is what the wheel metadata carries; the lockfile is uv-specific and governs only this repo's dev and CI environments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,21 @@ reported the issue. Please try to include as much information as you can. Detail
 * Any modifications you've made relevant to the bug
 * Anything unusual about your environment or deployment
 
+If you are reporting *measured* behaviour, in an issue or in a code review, please say which build
+produced the numbers, by **file path**:
+
+```python
+import stickler, inspect; print(inspect.getfile(stickler))
+```
+
+`stickler.__version__` is not sufficient on its own: `dev` and the latest release currently report
+the same string, so the version tells you nothing about which of the two you imported. The path does.
+
+`pip install stickler-eval` currently resolves to a release that is behind `dev`, and several
+behaviours differ between them, so a measurement taken against an installed copy can be internally
+consistent and still describe different code than the branch under discussion. To pin it, use
+`PYTHONPATH=/path/to/checkout/src` or `uv run --project /path/to/checkout`.
+
 
 ## Contributing via Pull Requests
 


### PR DESCRIPTION
## Description

Docs only. Adds a "Measuring behaviour by hand" section to `AGENTS.md` and a provenance note to `CONTRIBUTING.md`.

Closes #342.

Twice this week a claim was measured against an *installed* stickler rather than the checkout. Both times the numbers were internally consistent and described different code than the branch under discussion, with nothing to indicate it.

**#328.** A `CHANGES_REQUESTED` round asked the author to delete accurate `format`/`enum`/`const` documentation on the grounds that the mechanism did not exist. It does. Three fingerprints place the measurement at v0.7.0:

| Cited | v0.7.0 (2026-08-25) | #328 merge base (2026-09-04) |
|---|---|---|
| `JSON_TYPE_TO_DEFAULT_COMPARATOR` at `json_schema_field_converter.py:38` | present, that file and line | deleted by `04ce3cf` |
| "registry has exactly 11 built-ins" | exactly those 11, that order | 13 |
| "no closest-key validation exists" | `_closest_known_key` absent | `json_schema_importer.py:110` |

`04ce3cf` landed one day after v0.7.0 shipped. The author then spent a round deleting correct text, which had to be reverted.

**The strands-evals notebook.** Same trap from the other side: it declared a floor of `stickler-eval>=0.7.0` and the documented scores did not reproduce, because `EvalResult.matched` changed meaning in #287 (`all_fields_matched` then, `overall_score >= match_threshold` now).

## Why this is not a CI gap

`run_pytest.yaml` matrixes 3.10 through 3.14 and runs `uv sync --frozen`, so CI's `import stickler` is always the checkout. CI is correct and is not what failed.

The gap is that CI validates the branch against itself and never observes what a reviewer's shell imported. No test can fail to report that a reviewer measured a different build. The only available defense is printing provenance, so that is what these two files now ask for.

## One detail worth flagging

The instruction names the **file path**, not `stickler.__version__`. Measured on this branch:

```
$ PYTHONPATH=src python -c "import stickler, inspect; print(inspect.getfile(stickler), stickler.__version__)"
/private/tmp/r342/src/stickler/__init__.py 0.7.0
```

`dev` and the published release both report `0.7.0` until the 1.0 bump lands, so telling people to print the version would give them a false sense of having checked. Once 1.0 publishes and the strings diverge, `__version__` becomes useful again and this note can be relaxed.

## Related Issues

Closes #342. The divergence table in that issue should be deleted once 1.0 publishes and `pip install stickler-eval` matches `dev`.

## Type of Change

Documentation

## Testing

- [x] The snippet in both files was executed and prints the checkout path.
- [x] No source changes, so no test impact. `AGENTS.md` and `CONTRIBUTING.md` are not built by mkdocs.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
