### PR TITLE
chore: bump version to 1.0.0 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2319,7 +2319,8 @@ Initial public release: structured JSON comparison with configurable
 comparators, Hungarian-algorithm list matching, confusion-matrix metrics, and
 HTML reporting.
 
-[Unreleased]: https://github.com/awslabs/stickler/compare/v0.7.0...dev
+[Unreleased]: https://github.com/awslabs/stickler/compare/v1.0.0...dev
+[1.0.0]: https://github.com/awslabs/stickler/compare/v0.7.0...v1.0.0
 [0.7.0]: https://github.com/awslabs/stickler/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/awslabs/stickler/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/awslabs/stickler/compare/v0.4.0...v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Each release links to full notes on the
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-09-11
+
 ### Added
 
 - Config-driven models can have their unspecified fields inferred, with
@@ -1330,24 +1332,6 @@ Each release links to full notes on the
   Lower the element model's `match_threshold` to inspect leaf comparisons for
   weaker pairs.
 
-### Performance
-
-- Restored the fast path in `ComparisonHelper.compare_field_raw`. Reading a
-  field's absence rule requires knowing whether the field is a list, and
-  `_is_list_field` re-reads `model_fields` and destructures the annotation on
-  every call. The bare `is None` check it replaced short-circuited before doing
-  any of that, so consulting the annotation unconditionally cost about 23% on a
-  60x60 Hungarian cost matrix of 20-field models -- 72,000 calls for one list
-  comparison (0.531s to 0.651s; measured best-of-three).
-
-  The lookup is now guarded by a cheap value test that is the union of both
-  `NullHelper` rules, so anything either one calls absent still reaches the full
-  check and no outcome changes, while the common case of both sides being
-  populated skips the annotation entirely (0.537s, within noise of the original).
-  A test pins the superset property so adding a case to either rule without
-  widening the guard fails loudly rather than silently skipping the check.
-### Fixed
-
 - The pretty printers accept the `EvalResult` that `stickler.evaluate()` returns,
   and report its failures. They handled the comparison `dict` and nothing else, so
   passing the object the public API actually hands back printed
@@ -1368,6 +1352,23 @@ Each release links to full notes on the
 
   Unrecognized input no longer prints the success message either. It prints
   nothing, which is the honest answer for data the printer could not read.
+
+### Performance
+
+- Restored the fast path in `ComparisonHelper.compare_field_raw`. Reading a
+  field's absence rule requires knowing whether the field is a list, and
+  `_is_list_field` re-reads `model_fields` and destructures the annotation on
+  every call. The bare `is None` check it replaced short-circuited before doing
+  any of that, so consulting the annotation unconditionally cost about 23% on a
+  60x60 Hungarian cost matrix of 20-field models -- 72,000 calls for one list
+  comparison (0.531s to 0.651s; measured best-of-three).
+
+  The lookup is now guarded by a cheap value test that is the union of both
+  `NullHelper` rules, so anything either one calls absent still reaches the full
+  check and no outcome changes, while the common case of both sides being
+  populated skips the annotation entirely (0.537s, within noise of the original).
+  A test pins the superset property so adding a case to either rule without
+  widening the guard fails loudly rather than silently skipping the check.
 
 ### Documentation
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -62,14 +62,28 @@ git push origin dev
 Also add a `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md` (move entries
 out of `[Unreleased]`) in the same commit.
 
-**Leave an empty `## [Unreleased]` heading above it.** Renaming the heading
-instead of adding a new one breaks the docs-drift guards in
-`tests/structured_object_evaluator/test_rollup_node_semantics.py`, which read the
-changelog's newest section and assert it is non-empty. Cutting 1.0 hit this: four
-tests failed on the rename alone. The walker now finds the newest section by
-content rather than by the literal heading, so both states work, but the empty
-`[Unreleased]` is still what Keep a Changelog expects and is where the next
-cycle's entries go.
+Three parts, and the last two are easy to miss:
+
+1. **Move the entries** out of `[Unreleased]` under the new `## [X.Y.Z]` heading.
+2. **Leave an empty `## [Unreleased]` heading above it**, for the next cycle.
+3. **Add the link definition** at the bottom of the file, and retarget
+   `[Unreleased]`:
+
+   ```
+   [Unreleased]: https://github.com/awslabs/stickler/compare/vX.Y.Z...dev
+   [X.Y.Z]: https://github.com/awslabs/stickler/compare/vPREV...vX.Y.Z
+   ```
+
+   Every version heading resolves through that block. Skip it and the new heading
+   renders on GitHub as literal bracketed text, uniquely among all releases, in
+   notes that are then permanent. Cutting 1.0 missed this step.
+
+The docs-drift guards in
+`tests/structured_object_evaluator/test_rollup_node_semantics.py` read the
+changelog's newest section, so step 2 matters to them: renaming `[Unreleased]`
+instead of adding a new one failed four of them outright when 1.0 was cut. The
+walker finds the newest section by content rather than by the literal heading, so
+it survives both states.
 
 Before opening the release PR, confirm the version really is what you think it
 is, by path and not just by string:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -62,6 +62,26 @@ git push origin dev
 Also add a `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md` (move entries
 out of `[Unreleased]`) in the same commit.
 
+**Leave an empty `## [Unreleased]` heading above it.** Renaming the heading
+instead of adding a new one breaks the docs-drift guards in
+`tests/structured_object_evaluator/test_rollup_node_semantics.py`, which read the
+changelog's newest section and assert it is non-empty. Cutting 1.0 hit this: four
+tests failed on the rename alone. The walker now finds the newest section by
+content rather than by the literal heading, so both states work, but the empty
+`[Unreleased]` is still what Keep a Changelog expects and is where the next
+cycle's entries go.
+
+Before opening the release PR, confirm the version really is what you think it
+is, by path and not just by string:
+
+```bash
+uv run python -c "import stickler, inspect; print(inspect.getfile(stickler), stickler.__version__)"
+uv lock --check
+```
+
+The path matters because a stale install elsewhere on the machine reports its own
+version quite happily. See [#342](https://github.com/awslabs/stickler/issues/342).
+
 ### What belongs in the changelog
 
 Entries are for changes a user can observe. A PR needs one when it changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stickler-eval"
-version = "0.7.0"
+version = "1.0.0"
 description = "Structured object comparison and evaluation library"
 authors = [
     {name = "Spencer Romo", email = "sromo@amazon.com"},

--- a/src/stickler/__init__.py
+++ b/src/stickler/__init__.py
@@ -139,7 +139,7 @@ def __dir__() -> list:
     """Include lazily-available comparators in `dir(stickler)`."""
     return sorted(set(globals()) | set(__all__))
 
-__version__ = "0.7.0"
+__version__ = "1.0.0"
 __all__ = [
     # Models and evaluation
     "StructuredModel",

--- a/tests/structured_object_evaluator/test_rollup_node_semantics.py
+++ b/tests/structured_object_evaluator/test_rollup_node_semantics.py
@@ -158,9 +158,10 @@ def _authored_prose(repo_root: Path):
     release notes record what was said at the time and are not rewritten, while the
     newest section is authored by the same change as the docs and drifted from them
     twice. "Newest" is the first heading through the end of the first section with
-    content, not the literal `## [Unreleased]`, which a release empties. The walk this replaces never reached the changelog at all, and
-    carried an `exempt = {Path("CHANGELOG.md")}` that therefore could not fire --
-    dead code reading as a deliberate exemption.
+    content, not the literal `## [Unreleased]`, which a release empties. The walk
+    this replaces never reached the changelog at all, and carried an
+    `exempt = {Path("CHANGELOG.md")}` that therefore could not fire -- dead code
+    reading as a deliberate exemption.
 
     This file is skipped of necessity: the guards below spell the banned phrases out.
     """
@@ -183,16 +184,23 @@ def _authored_prose(repo_root: Path):
     # The NEWEST notes: `## [Unreleased]` between releases, and the just-cut version
     # immediately after one. Keyed on "first section with content" rather than on the
     # literal `[Unreleased]`, because cutting a release empties that heading and moves
-    # the notes under a version number. Pinning the literal broke every guard here the
-    # moment 1.0 was cut, and an empty window cannot satisfy
-    # `test_every_page_publishes_the_current_clean_check`, which asserts it is
-    # non-empty. Older shipped sections stay out, which is the original point.
-    window_end = len(lines)
+    # the notes under a version number, which broke every guard here the moment 1.0
+    # was cut. Older shipped sections stay out, which is the original point.
+    window_end = None
     for index, start in enumerate(starts):
         section_end = starts[index + 1] if index + 1 < len(starts) else len(lines)
         if any(lines[j].strip() for j in range(start + 1, section_end)):
             window_end = section_end
             break
+    # Asserted, not defaulted. `window_end = len(lines)` as a fallback would scan
+    # every shipped release note -- the exact inverse of the intent above -- and do
+    # it silently. The paired test derives the window the same way and asserts here
+    # too, so a default would also make the two disagree in precisely the case this
+    # pair exists to keep in agreement.
+    assert window_end is not None, (
+        "every `## [...]` section in CHANGELOG.md is empty, so there are no newest "
+        "notes to scan"
+    )
     for number in range(starts[0], window_end):
         yield Path("CHANGELOG.md"), number + 1, lines[number]
 
@@ -605,7 +613,7 @@ class TestTheDocsAndTheEngineCannotDrift:
         for relative in _PAGES_PUBLISHING_THE_CLEAN_CHECK:
             page = repo_root / relative
             assert page.exists(), f"{relative} moved; update this list"
-            # `CHANGELOG.md` is read through the same `[Unreleased]`-only window as
+            # `CHANGELOG.md` is read through the same newest-notes window as
             # `_authored_prose`, not whole. Reading all of it forbade the retired
             # form anywhere in the file, including a future shipped note quoting it
             # as history -- which contradicts the policy that shipped notes record
@@ -617,12 +625,25 @@ class TestTheDocsAndTheEngineCannotDrift:
                     for path, _, line in _authored_prose(repo_root)
                     if path == Path("CHANGELOG.md")
                 )
+                # PRESENCE is not required here, unlike the doc pages. A release
+                # note publishes the snippet once and is then frozen, so the
+                # snippet leaves this window as soon as any entry is added after
+                # that release. Requiring it would fail on the first post-release
+                # PR -- which is what happened when 1.0 was cut and the window
+                # became the shipped `[1.0.0]` section.
+                #
+                # What must hold is the other two halves: if the newest notes DO
+                # publish it, it is the current form, and they never publish the
+                # retired form. Both still run below.
+                publishes = "clean = (" in text
             else:
                 text = page.read_text()
+                publishes = True
+                assert "clean = (" in text, f"{relative} no longer publishes the check"
 
-            assert "clean = (" in text, f"{relative} no longer publishes the check"
-            for line in expected_lines:
-                assert line in text, f"{relative} is missing: {line}"
+            if publishes:
+                for line in expected_lines:
+                    assert line in text, f"{relative} is missing: {line}"
 
             # The form that reported a hallucinated value as clean.
             assert superseded not in text, (
@@ -643,8 +664,8 @@ class TestTheDocsAndTheEngineCannotDrift:
         pages, it is published to the API reference through two docstrings, and every
         recurrence has been a fresh review finding. The fourth recurrence was in
         `CHANGELOG.md` under `## [Unreleased]`, which the walk did not reach, so
-        `_authored_prose` now scans that section; shipped release notes stay exempt
-        because they record what was said at the time.
+        `_authored_prose` now scans the changelog's newest notes; older shipped
+        release notes stay exempt because they record what was said at the time.
 
         This file is exempt of necessity, since `banned` below spells the phrases
         out. That exemption is doing real work rather than being a formality: the
@@ -698,8 +719,8 @@ class TestTheDocsAndTheEngineCannotDrift:
         window_end = None
         for index, start in enumerate(starts):
             section_end = starts[index + 1] if index + 1 < len(starts) else None
-            body = changelog[start : (section_end - 1) if section_end else len(changelog)]
-            if any(line.strip() for line in body):
+            body_end = (section_end - 1) if section_end else len(changelog)
+            if any(line.strip() for line in changelog[start:body_end]):
                 window_end = section_end
                 break
         assert window_end is not None, (

--- a/tests/structured_object_evaluator/test_rollup_node_semantics.py
+++ b/tests/structured_object_evaluator/test_rollup_node_semantics.py
@@ -154,10 +154,11 @@ def _authored_prose(repo_root: Path):
 
     `src/**/*.py` and `docs/**/*.md` are the surfaces a reader sees, and
     `tests/**/*.py` because a worked example in a test is the next person's copy
-    source. `CHANGELOG.md` is included too, but only its `## [Unreleased]` section:
-    shipped release notes record what was said at the time and are not rewritten,
-    while the open section is authored by the same change as the docs and drifted
-    from them twice. The walk this replaces never reached the changelog at all, and
+    source. `CHANGELOG.md` is included too, but only its NEWEST notes: older shipped
+    release notes record what was said at the time and are not rewritten, while the
+    newest section is authored by the same change as the docs and drifted from them
+    twice. "Newest" is the first heading through the end of the first section with
+    content, not the literal `## [Unreleased]`, which a release empties. The walk this replaces never reached the changelog at all, and
     carried an `exempt = {Path("CHANGELOG.md")}` that therefore could not fire --
     dead code reading as a deliberate exemption.
 
@@ -177,20 +178,22 @@ def _authored_prose(repo_root: Path):
             yield relative, number, line
 
     lines = (repo_root / "CHANGELOG.md").read_text().splitlines()
-    start = next(
-        (i for i, line in enumerate(lines) if line.startswith("## [Unreleased]")),
-        None,
-    )
-    assert start is not None, "CHANGELOG.md has no `## [Unreleased]` heading to scan"
-    end = next(
-        (
-            i
-            for i, line in enumerate(lines[start + 1 :], start + 1)
-            if line.startswith("## [")
-        ),
-        len(lines),
-    )
-    for number in range(start, end):
+    starts = [i for i, line in enumerate(lines) if line.startswith("## [")]
+    assert starts, "CHANGELOG.md has no `## [...]` heading to scan"
+    # The NEWEST notes: `## [Unreleased]` between releases, and the just-cut version
+    # immediately after one. Keyed on "first section with content" rather than on the
+    # literal `[Unreleased]`, because cutting a release empties that heading and moves
+    # the notes under a version number. Pinning the literal broke every guard here the
+    # moment 1.0 was cut, and an empty window cannot satisfy
+    # `test_every_page_publishes_the_current_clean_check`, which asserts it is
+    # non-empty. Older shipped sections stay out, which is the original point.
+    window_end = len(lines)
+    for index, start in enumerate(starts):
+        section_end = starts[index + 1] if index + 1 < len(starts) else len(lines)
+        if any(lines[j].strip() for j in range(start + 1, section_end)):
+            window_end = section_end
+            break
+    for number in range(starts[0], window_end):
         yield Path("CHANGELOG.md"), number + 1, lines[number]
 
 
@@ -670,48 +673,43 @@ class TestTheDocsAndTheEngineCannotDrift:
             f"and in both docstrings published to the API reference: {offenders}"
         )
 
-    def test_the_changelog_unreleased_section_is_the_part_that_gets_scanned(self):
+    def test_only_the_newest_changelog_notes_are_scanned(self):
         """Both directions on the scanner, because the last exemption was dead code.
 
         `exempt = {Path("CHANGELOG.md")}` read as a policy and was unreachable: the
-        walk covered `src`, `docs` and `tests` only. So this asserts the open section
-        really is reached, and that a shipped one really is not.
+        walk covered `src`, `docs` and `tests` only. So this asserts the newest notes
+        really are reached, and that an older shipped release really is not.
+
+        Derives the window the same way `_authored_prose` does rather than pinning
+        the literal `## [Unreleased]`. A release empties that heading and moves the
+        notes under a version number, so the literal made this test and the walker
+        disagree exactly when a release was cut.
         """
         repo_root = Path(__file__).resolve().parents[2]
         scanned = {(path, number) for path, number, _ in _authored_prose(repo_root)}
         changelog = (repo_root / "CHANGELOG.md").read_text().splitlines()
-        # `startswith`, matching `_authored_prose`. Exact equality here meant the
-        # two disagreed the moment the heading gained a suffix (`## [Unreleased] -
-        # TBD`), and a bare `next()` then died with `StopIteration` rather than
-        # saying what was wrong.
-        unreleased = next(
-            (
-                i
-                for i, line in enumerate(changelog, start=1)
-                if line.startswith("## [Unreleased]")
-            ),
-            None,
-        )
-        assert unreleased is not None, (
-            "CHANGELOG.md has no `## [Unreleased]` heading; `_authored_prose` scans "
-            "that section, so this test and the walker must find it the same way"
-        )
-        shipped = next(
-            (
-                i
-                for i, line in enumerate(changelog, start=1)
-                if line.startswith("## [") and i > unreleased
-            ),
-            None,
-        )
-        assert shipped is not None, (
-            "CHANGELOG.md has no shipped release heading after `## [Unreleased]`, so "
-            "the not-scanned half of this test cannot be checked"
+        # `startswith`, matching `_authored_prose`. Exact equality meant the two
+        # disagreed the moment a heading gained a suffix (`## [Unreleased] - TBD`).
+        starts = [
+            i for i, line in enumerate(changelog, start=1) if line.startswith("## [")
+        ]
+        assert starts, "CHANGELOG.md has no `## [...]` heading for either side to find"
+
+        window_end = None
+        for index, start in enumerate(starts):
+            section_end = starts[index + 1] if index + 1 < len(starts) else None
+            body = changelog[start : (section_end - 1) if section_end else len(changelog)]
+            if any(line.strip() for line in body):
+                window_end = section_end
+                break
+        assert window_end is not None, (
+            "every `## [...]` section in CHANGELOG.md is empty, or the newest notes "
+            "run to end of file, so the not-scanned half cannot be checked"
         )
 
-        assert (Path("CHANGELOG.md"), unreleased) in scanned
-        assert (Path("CHANGELOG.md"), unreleased + 1) in scanned
-        assert (Path("CHANGELOG.md"), shipped) not in scanned
+        assert (Path("CHANGELOG.md"), starts[0]) in scanned
+        assert (Path("CHANGELOG.md"), window_end - 1) in scanned
+        assert (Path("CHANGELOG.md"), window_end) not in scanned
         assert (Path("CHANGELOG.md"), len(changelog)) not in scanned
 
     def test_no_file_states_the_retired_all_zero_fallback_mechanism(self):

--- a/uv.lock
+++ b/uv.lock
@@ -4042,7 +4042,7 @@ wheels = [
 
 [[package]]
 name = "stickler-eval"
-version = "0.7.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "json-schema-to-pydantic" },


### PR DESCRIPTION
## Description

Version bump for the 1.0.0 release. Step 2 of [RELEASING.md](RELEASING.md); the `dev` → `main` release PR follows once this is in.

**1.0 milestone is empty: 25 closed, 0 open.** The last three blockers merged today: #328 (#211), #331 (#315), #341 (#320).

## Version

`0.7.0` → `1.0.0`. **Major**, per RELEASING.md's table: 332 commits since 0.7.0, breaking changes in seven entries, plus the explicit stable decision.

Bumped in the four places that carry it:

| File | Note |
|---|---|
| `pyproject.toml` | |
| `src/stickler/__init__.py` | |
| `uv.lock` | hand-edited one line per AGENTS.md, so `exclude-newer` and the CUDA/nvidia platform markers are untouched. Diff is exactly `-version = "0.7.0"` / `+version = "1.0.0"`. `uv lock --check` passes |
| `CHANGELOG.md` | `[Unreleased]` → `[1.0.0] - 2026-09-11`, with a fresh empty `[Unreleased]` above it |

## Two things the release surfaced

Both are fixed here rather than deferred, because both would have shipped into the permanent 1.0 notes.

### The changelog had two `### Fixed` sections

`[Unreleased]` carried `### Fixed` at two places, the second holding one entry (the pretty-printer fix) and sitting *below* `### Performance`. Merged into the first. A Keep-a-Changelog reader, and any tooling that parses the format, only sees the first heading.

### The docs-drift guards broke on the rename

Four tests in `test_rollup_node_semantics.py` read the changelog through a window pinned to the literal `## [Unreleased]`. Retitling that heading failed all four:

```
AssertionError: CHANGELOG.md has no `## [Unreleased]` heading to scan
```

Adding a fresh empty `[Unreleased]` back is necessary but **not sufficient**: `test_every_page_publishes_the_current_clean_check` asserts the window is *non-empty*, so an empty section fails it too. These guards landed this week via #317/#239 and had never seen a release.

The window now runs from the first `## [` heading through the end of the first section **with content**. That is `[Unreleased]` between releases, and the just-cut version immediately after one. Older shipped sections stay out, which was the original intent: they record what was said at the time and are not rewritten.

I checked the guard is not merely passing vacuously. Injecting the retired `cm['overall']['fa']` form into the shipped `[1.0.0]` notes still fails:

```
FAILED test_every_page_publishes_the_current_clean_check
```

`test_the_changelog_unreleased_section_is_the_part_that_gets_scanned` is renamed to `test_only_the_newest_changelog_notes_are_scanned` and derives the window the same way the walker does. It was deliberately paired with the walker, and its "a shipped section is not scanned" half was selecting the *newest* release as the shipped one, which is exactly the section that should now be scanned.

## Related Issues

Unblocks the 1.0.0 release. RELEASING.md now records the empty-`[Unreleased]` requirement, and a provenance check on the version, per #342.

## Type of Change

Chore / release

## Testing

- [x] `pytest tests/` — **2739 passed, 12 skipped, 1 xfailed**
- [x] `ruff check` — clean
- [x] `uv lock --check` — passes; `uv.lock` diff is one line
- [x] `import stickler` reports `1.0.0` from the checkout, verified by **path** not just version string
- [x] The drift guard was adversarially checked by injecting a banned phrase into the shipped notes

Deliberately did **not** run `ruff format`: CI runs only `ruff check`, 119 files in the repo are already unformatted, and formatting the touched test file added 53 lines of unrelated churn to a release commit.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.