### PR TITLE
fix!: stop absent-on-both fields paying out as matches (#345 review blockers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,6 +294,43 @@ Each release links to full notes on the
 
 ### Fixed
 
+- **Breaking: a field absent on BOTH sides no longer counts toward the score.**
+  Every score on a model with unpopulated optional fields changes, downward. An
+  empty-on-both field arrived at the weighted average with a perfect per-field
+  score and full weight, so empty fields paid out as matches. On a five-field
+  model whose one populated field disagreed completely, four empty fields carried
+  `overall_score` to `0.8` and `matched` to `True` at an F1 of `0.0` -- the pair
+  this library exists to catch, reported as passing. It now scores `0.0` with
+  `matched=False`.
+
+  The reasoning was already written down at `compare()`'s call site for
+  [#233](https://github.com/awslabs/stickler/issues/233) -- a true negative is
+  absence of evidence, not evidence that two objects match -- and simply never
+  reached the aggregation path. So `compare()` skipped absent pairs while
+  `compare_with()` folded them in, and the same pair scored `0.174` and `0.8` on
+  the two entry points. `compare()` is the Hungarian cost function, so list
+  pairing and per-item tp/fd classification were decided on one number while the
+  score printed beside them was another. That is the score-versus-classification
+  split [#301](https://github.com/awslabs/stickler/issues/301) closed for the
+  *gate* the two paths consult, still open on the arithmetic.
+
+  Both paths now share one predicate, `absent_on_both`, rather than owning a copy
+  each. Absent-on-both fields remain true negatives in the confusion matrix and
+  remain present in `field_scores`; only their contribution to the mean is gone.
+  Two identical empty objects still score `1.0` (#233).
+
+  The effect scales with how optional a schema is, so sparse documents -- the
+  common case in extraction -- are where scores drop most, and every corpus-level
+  average was inflated.
+
+- **Breaking: declared weights summing to zero no longer score `1.0`.** The
+  `total_weight == 0` guard returned a perfect match for two causes that need
+  different answers: nothing was compared (identical empty objects, correct), and
+  fields *were* compared at weights totalling zero. In the second case two
+  completely different objects scored `1.0`, and because this feeds the Hungarian
+  cost function it made every pairing in a list of such models free. It now
+  returns `0.0`, matching what `compare_with()` already returned.
+
 - **Scores change for mapping fields explicitly using `NormalizedComparator`.**
   Both `compare` and `compare_with` now warn and count the pair as a false
   discovery with score `0.0`, even for identical dictionaries. For example,

--- a/src/stickler/structured_object_evaluator/models/comparison_engine.py
+++ b/src/stickler/structured_object_evaluator/models/comparison_engine.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
 from stickler.structured_object_evaluator.models.bbox import MAPCalculator
 from stickler.utils.deprecation import warn_once
 
+from .comparison_helper import absent_on_both, weighted_mean_or_default
+
 if TYPE_CHECKING:
     from .confidence import ConfidenceMetric
     from .structured_model import StructuredModel
@@ -145,6 +147,7 @@ class ComparisonEngine:
         # Score percolation variables
         total_score = 0.0
         total_weight = 0.0
+        compared_fields = 0
 
         for field_name in self.model.__class__.model_fields:
             if field_name == "extra_fields":
@@ -161,10 +164,23 @@ class ComparisonEngine:
             # Simple aggregation to overall metrics
             self._aggregate_to_overall(field_result, result["overall"])
 
+            # A field absent on BOTH sides still belongs in `fields` and still
+            # counts as a true negative in the matrix above -- it is only kept out
+            # of the weighted average, because absence of evidence is not evidence
+            # that two objects match. Without this, four empty fields on a
+            # five-field model carried a completely wrong single value to an
+            # overall of 0.8 and `matched=True` at an F1 of 0.0.
+            #
+            # `compare()` has skipped these since #233; this path had not, so the
+            # same pair scored 0.174 there and 0.8 here. Shared predicate now.
+            if absent_on_both(self.model, field_name, gt_val, pred_val):
+                continue
+
             # Score percolation - aggregate scores upward
             if "similarity_score" in field_result and "weight" in field_result:
                 weight = field_result["weight"]
                 threshold_applied_score = field_result["threshold_applied_score"]
+                compared_fields += 1
                 total_score += threshold_applied_score * weight
                 total_weight += weight
 
@@ -173,9 +189,13 @@ class ComparisonEngine:
         result["overall"]["fa"] += extra_fields_fa
         result["overall"]["fp"] += extra_fields_fa
 
-        # Calculate overall similarity score from percolated scores
-        if total_weight > 0:
-            result["overall"]["similarity_score"] = total_score / total_weight
+        # Calculate overall similarity score from percolated scores. Routed through
+        # the same helper `compare()` uses, so the two agree on both zero-weight
+        # cases too: nothing compared is 1.0 (identical empty objects, #233) and
+        # compared-at-zero-weight is 0.0.
+        result["overall"]["similarity_score"] = weighted_mean_or_default(
+            total_score, total_weight, compared_fields
+        )
 
         return result
 

--- a/src/stickler/structured_object_evaluator/models/comparison_helper.py
+++ b/src/stickler/structured_object_evaluator/models/comparison_helper.py
@@ -168,6 +168,78 @@ def _maybe_absent(val: Any) -> bool:
     return val is None or (isinstance(val, (str, list, dict)) and len(val) == 0)
 
 
+def absent_on_both(model: Any, field_name: str, gt_val: Any, pred_val: Any) -> bool:
+    """Whether a field is absent on BOTH sides, and so contributes no evidence.
+
+    A true negative is absence of evidence, not evidence that two objects match.
+    A field empty on both sides arrives with a perfect per-field score and full
+    weight, so folding it into a weighted average pays out an empty field as a
+    match: on a five-field model with one populated field that disagrees
+    completely, four empty fields carried the mean to 0.8 and `matched` to True
+    at an F1 of 0.0.
+
+    This lives here, called by both aggregation paths, because the two owned
+    separate copies of the decision and drifted: `compare()` skipped absent pairs
+    while `compare_recursive()` folded them in, so the same pair scored 0.174 and
+    0.8 on the two entry points. `compare()` is the Hungarian cost function, so
+    list pairing and per-item classification were decided on one number while the
+    score reported beside them was another -- the score-versus-classification
+    split #301 set out to close, still open on the aggregation path. One
+    predicate, two callers, is what keeps them from diverging a third time.
+
+    Args:
+        model: The ground-truth model, read for its list-field annotations.
+        field_name: The field being judged.
+        gt_val: The ground-truth value.
+        pred_val: The predicted value.
+
+    Returns:
+        True when both sides are absent under the rule that applies to this
+        field's annotation, and the field should be omitted from the weighted
+        average entirely.
+    """
+    # The cheap guard first: it preserves the populated-value fast path in
+    # pairwise cost matrices, where this runs once per cell.
+    if not (_maybe_absent(gt_val) and _maybe_absent(pred_val)):
+        return False
+    is_absent = (
+        NullHelper.is_effectively_null_for_lists
+        if model._is_list_field(field_name)
+        else NullHelper.is_effectively_null_for_primitives
+    )
+    return is_absent(gt_val) and is_absent(pred_val)
+
+
+def weighted_mean_or_default(
+    total_score: float, total_weight: float, compared_fields: int
+) -> float:
+    """The weighted average, with the two zero-weight cases told apart.
+
+    `total_weight == 0` has two causes that must not share an answer:
+
+    * Nothing was compared, because every field was absent on both sides. Two
+      identical empty objects have nothing that disagrees, so they stay a perfect
+      match (#233).
+    * Fields WERE compared, and their declared weights sum to zero. Returning 1.0
+      there scores two completely different objects a perfect match, and because
+      this feeds the Hungarian cost function it makes every pairing in a list of
+      such models free. `compare_with()` already returned 0.0 for this, so 0.0 is
+      both the safe direction and the one that keeps the two paths agreeing.
+
+    Args:
+        total_score: Sum of per-field score times weight.
+        total_weight: Sum of the weights actually folded in.
+        compared_fields: How many fields were folded in at all.
+
+    Returns:
+        The weighted mean, or 1.0 for nothing-compared, or 0.0 for
+        compared-at-zero-weight.
+    """
+    if total_weight > 0:
+        return total_score / total_weight
+    return 0.0 if compared_fields else 1.0
+
+
 class ComparisonHelper:
     """Helper class for StructuredModel field comparison operations."""
 

--- a/src/stickler/structured_object_evaluator/models/structured_model.py
+++ b/src/stickler/structured_object_evaluator/models/structured_model.py
@@ -25,12 +25,15 @@ from stickler.comparators.base import BaseComparator
 from stickler.utils.deprecation import warn_once
 
 from .comparable_field import ComparableField, _named_comparator_threshold
-from .comparison_helper import ComparisonHelper, _maybe_absent
+from .comparison_helper import (
+    ComparisonHelper,
+    absent_on_both,
+    weighted_mean_or_default,
+)
 from .configuration_helper import ConfigurationHelper
 from .evaluator_format_helper import EvaluatorFormatHelper
 from .hungarian_helper import HungarianHelper
 from .metrics_helper import MetricsHelper
-from .null_helper import NullHelper
 from .optional_annotation import union_args, unwrap_annotated, unwrap_optional
 from .rich_value_helper import RichValueHelper
 from .threshold_helper import THRESHOLD_DOCS_URL
@@ -1618,6 +1621,7 @@ class StructuredModel(BaseModel):
 
         total_score = 0.0
         total_weight = 0.0
+        compared_fields = 0
 
         for field_name in self.__class__.model_fields:
             # Skip the extra_fields attribute in comparison
@@ -1628,17 +1632,10 @@ class StructuredModel(BaseModel):
                 other_value = getattr(other, field_name)
 
                 # A true negative is absence of evidence, not evidence that two
-                # objects match. Omit absent-on-both fields from the weighted
-                # average that Hungarian matching uses. The cheap guard preserves
-                # the populated-value fast path in pairwise cost matrices.
-                if _maybe_absent(self_value) and _maybe_absent(other_value):
-                    is_absent = (
-                        NullHelper.is_effectively_null_for_lists
-                        if self._is_list_field(field_name)
-                        else NullHelper.is_effectively_null_for_primitives
-                    )
-                    if is_absent(self_value) and is_absent(other_value):
-                        continue
+                # objects match. Shared with `compare_recursive` so the two
+                # aggregation paths cannot drift apart again; see `absent_on_both`.
+                if absent_on_both(self, field_name, self_value, other_value):
+                    continue
 
                 # Get field configuration
                 info = self.__class__._get_comparison_info(field_name)
@@ -1649,16 +1646,15 @@ class StructuredModel(BaseModel):
                 field_score = self.compare_field_raw(field_name, other_value)
 
                 # Update total score
+                compared_fields += 1
                 total_score += field_score * weight
                 total_weight += weight
 
-        # Calculate overall score
-        if total_weight > 0:
-            return total_score / total_weight
-
-        # Every compared field was absent on both sides. Nothing disagreed, so
-        # identical empty objects remain a perfect match (#233).
-        return 1.0
+        # `compared_fields` tells "nothing was compared" (identical empty objects,
+        # a perfect match per #233) apart from "fields were compared at weights
+        # summing to zero", which must not be 1.0: this is the Hungarian cost
+        # function, so a free perfect score makes every pairing free.
+        return weighted_mean_or_default(total_score, total_weight, compared_fields)
 
     def compare_with(
         self,

--- a/tests/structured_object_evaluator/test_absent_on_both_aggregation.py
+++ b/tests/structured_object_evaluator/test_absent_on_both_aggregation.py
@@ -1,0 +1,269 @@
+"""A field absent on both sides is not evidence that two objects match (#345).
+
+`compare()` has skipped absent-on-both fields since #233, with the reasoning
+written down at the call site: a true negative is absence of evidence, not
+evidence of agreement. `compare_recursive()`, which backs `compare_with()` and
+therefore `stickler.evaluate()`, folded them in at a perfect score and full
+weight. Empty fields paid out as matches.
+
+The headline shape, on a five-field model where the ONE populated field disagrees
+completely:
+
+    overall_score  0.8      <- four empty fields carried it
+    matched        True     <- the only extracted value is wrong
+    f1             0.0
+
+The two defects this file pins are one bug seen from two directions:
+
+* the mean is inflated by fields that contributed nothing, and
+* the two aggregation paths therefore disagree about the same pair.
+
+The second is the more dangerous one, because `compare()` is the Hungarian cost
+function. List pairing and per-item tp/fd classification were decided on one
+number while the score reported beside them was a different number.
+
+Why 2739 tests missed it, recorded so the tests below are the right ones: no test
+scored a multi-field model with fields absent on BOTH sides -- fixtures populate
+what they assert on -- and no test asserted the two paths agree. #301 unified the
+*gate* the two paths consult and left the arithmetic alone, so `TestBothPathsAgree`
+is deliberately structural rather than a list of remembered numbers.
+"""
+
+from typing import Optional
+
+import pytest
+from pydantic import BaseModel
+
+import stickler
+from stickler import ComparableField, StructuredModel
+
+
+class FiveOptional(StructuredModel):
+    a: Optional[str] = ComparableField(default=None)
+    b: Optional[str] = ComparableField(default=None)
+    c: Optional[str] = ComparableField(default=None)
+    d: Optional[str] = ComparableField(default=None)
+    e: Optional[str] = ComparableField(default=None)
+
+
+class TwoOptional(StructuredModel):
+    present: Optional[str] = ComparableField(default=None)
+    absent: Optional[str] = ComparableField(default=None)
+
+
+class ZeroWeight(StructuredModel):
+    x: str = ComparableField(weight=0.0)
+
+
+class TestEmptyFieldsDoNotPayOut:
+    """The defect as a user meets it, through the public entry point."""
+
+    def test_one_wrong_value_among_empty_fields_is_not_a_match(self):
+        """The regression in its original form (#345).
+
+        Four fields absent on both sides, one populated field that disagrees
+        completely. Before the fix this reported 0.8 and `matched=True` at an F1
+        of 0.0 -- the pair the library exists to catch, reported as passing.
+        """
+
+        class Invoice(BaseModel):
+            a: Optional[str] = None
+            b: Optional[str] = None
+            c: Optional[str] = None
+            d: Optional[str] = None
+            e: Optional[str] = None
+
+        result = stickler.evaluate(
+            Invoice(a="ACME Corporation"), Invoice(a="totally different value")
+        )
+
+        assert result.matched is False
+        assert result.overall_score < 0.5
+        # The point of the test: `matched` cannot be True while F1 is 0.0. That
+        # combination is what made the old behaviour indefensible rather than
+        # merely generous.
+        assert not (result.matched and result.f1 == 0.0)
+
+    def test_the_score_ignores_how_many_fields_were_empty(self):
+        """Adding empty fields to a schema must not raise its score.
+
+        This is the property that makes the defect scale: the sparser the
+        document, the more the mean was inflated, and sparse documents are the
+        common case in extraction.
+        """
+        one_wrong = FiveOptional(a="hello"), FiveOptional(a="wrong entirely")
+        narrow = TwoOptional(present="hello"), TwoOptional(present="wrong entirely")
+
+        wide_score = one_wrong[0].compare_with(one_wrong[1])["overall_score"]
+        narrow_score = narrow[0].compare_with(narrow[1])["overall_score"]
+
+        assert wide_score == pytest.approx(narrow_score), (
+            "a five-field model with four empty fields scored differently from a "
+            "two-field model with one, on the same populated pair"
+        )
+
+    def test_absent_on_both_is_still_a_true_negative(self):
+        """Kept OUT of the mean, kept IN the matrix.
+
+        The fix must not overreach: an empty-on-both field is a genuine true
+        negative and still belongs in the confusion matrix. Only its contribution
+        to the weighted average is wrong. Asserting this stops a future
+        simplification from dropping the field entirely.
+        """
+        result = FiveOptional(a="hello").compare_with(
+            FiveOptional(a="hello"), include_confusion_matrix=True
+        )
+
+        assert result["confusion_matrix"]["overall"]["tn"] == 4
+        assert set(result["field_scores"]) == set(FiveOptional.model_fields) - {
+            "extra_fields"
+        }
+
+    def test_identical_empty_objects_are_still_a_perfect_match(self):
+        """#233, which the fix must not regress.
+
+        Nothing disagreed, so there is nothing to report as wrong. This is the
+        case that makes `total_weight == 0` mean two different things, and it is
+        why the guard needs a compared-field count rather than a weight test.
+        """
+        empty = FiveOptional()
+
+        assert empty.compare(FiveOptional()) == pytest.approx(1.0)
+        assert empty.compare_with(FiveOptional())["overall_score"] == pytest.approx(1.0)
+
+
+class TestZeroWeightIsNotAPerfectMatch:
+    def test_weights_summing_to_zero_do_not_score_one(self):
+        """`total_weight == 0` had one answer for two different causes.
+
+        `return 1.0` is right for "nothing was compared" and catastrophic for
+        "fields were compared at zero weight": two completely different objects
+        scored a perfect match. Because this is the Hungarian cost function, it
+        also made every pairing in a list of such models free.
+        """
+        assert ZeroWeight(x="aaa").compare(ZeroWeight(x="zzz")) == pytest.approx(0.0)
+
+    def test_zero_weight_agrees_across_both_paths(self):
+        different = ZeroWeight(x="aaa"), ZeroWeight(x="zzz")
+
+        assert different[0].compare(different[1]) == pytest.approx(
+            different[0].compare_with(different[1])["overall_score"]
+        )
+
+    def test_zero_weight_is_not_rescued_by_being_identical(self):
+        """Deliberately pinned: identical values at zero weight score 0.0 too.
+
+        Not obviously the only defensible answer -- an argument exists for 1.0 --
+        but it is what `compare_with()` returned before this change, so the two
+        paths agree and the behaviour is recorded rather than accidental. Revisit
+        with a decision, not with a patch.
+        """
+        same = ZeroWeight(x="aaa"), ZeroWeight(x="aaa")
+
+        assert same[0].compare(same[1]) == pytest.approx(0.0)
+        assert same[0].compare_with(same[1])["overall_score"] == pytest.approx(0.0)
+
+
+class TestBothPathsAgree:
+    """The test that would have caught this, and the one #301 stopped short of.
+
+    #301 unified the GATE the two paths consult. It never asserted they produce
+    the same number, so `compare()` carried the #233 skip and
+    `compare_recursive()` did not, and the same pair scored 0.174 and 0.8.
+
+    Parametrized over shapes rather than asserting remembered constants: the claim
+    is that the two agree, whatever the right value turns out to be.
+    """
+
+    @pytest.mark.parametrize(
+        "gt_kwargs,pred_kwargs,label",
+        [
+            ({}, {}, "all fields empty on both sides"),
+            ({"a": "v"}, {"a": "v"}, "one identical, four empty"),
+            ({"a": "hello"}, {"a": "hellp"}, "one near match, four empty"),
+            ({"a": "hello", "b": "world"}, {"a": "hellp", "b": "world"}, "two present"),
+            (
+                {k: "hello" for k in "abcde"},
+                {k: "hellp" for k in "abcde"},
+                "all five present and near",
+            ),
+            ({"a": "only gt"}, {}, "present on gt, absent on prediction"),
+            ({}, {"a": "only pred"}, "absent on gt, present on prediction"),
+        ],
+    )
+    def test_compare_matches_compare_with(self, gt_kwargs, pred_kwargs, label):
+        gt, pred = FiveOptional(**gt_kwargs), FiveOptional(**pred_kwargs)
+
+        direct = gt.compare(pred)
+        aggregated = gt.compare_with(pred)["overall_score"]
+
+        assert direct == pytest.approx(aggregated), (
+            f"{label}: compare() gave {direct:.4f} and compare_with() gave "
+            f"{aggregated:.4f}. These feed Hungarian pairing and the reported "
+            f"score respectively, so a gap means items are paired on one number "
+            f"and reported on another."
+        )
+
+    def test_the_two_paths_share_one_absence_predicate(self):
+        """Structural, because the numeric tests above cannot prove intent.
+
+        Two copies of the absence rule is what let them drift for two releases.
+        This asserts there is one, so a future edit to either path has to go
+        through the shared helper or fail here.
+        """
+        import inspect
+
+        from stickler.structured_object_evaluator.models import (
+            comparison_engine,
+            structured_model,
+        )
+
+        for module in (comparison_engine, structured_model):
+            source = inspect.getsource(module)
+            assert "absent_on_both(" in source, (
+                f"{module.__name__} no longer routes through the shared "
+                f"absent-on-both predicate"
+            )
+            assert "is_effectively_null_for_lists" not in source, (
+                f"{module.__name__} re-implements the absence rule instead of "
+                f"calling `absent_on_both`, which is how the two paths drifted "
+                f"apart in the first place"
+            )
+
+
+class TestTheRemainingDivergenceIsDeliberate:
+    """`compare()` is raw, `compare_with()` is threshold-applied. That is by design.
+
+    Recorded because the two DO still differ when clipping fires, and a future
+    reader comparing them will find it. `compare()` deliberately skips thresholds:
+    it is a cost function, and clipping every weak pair to 0.0 would make them
+    indistinguishable to the assignment algorithm, which needs graded costs to
+    pick the best pairing rather than an arbitrary one.
+    """
+
+    def test_clipping_is_the_only_remaining_gap(self):
+        gt = FiveOptional(a="ACME Corporation")
+        pred = FiveOptional(a="totally different value")
+
+        # Clipped: below threshold, so the reported score zeroes while the cost
+        # function keeps the graded value.
+        assert gt.compare(pred) > 0.0
+        assert gt.compare_with(pred)["overall_score"] == pytest.approx(0.0)
+
+    def test_with_clipping_disabled_the_two_agree_exactly(self):
+        """Isolates the cause: disable clipping and the gap closes."""
+
+        class NoClip(StructuredModel):
+            a: Optional[str] = ComparableField(
+                default=None, clip_under_threshold=False
+            )
+            b: Optional[str] = ComparableField(
+                default=None, clip_under_threshold=False
+            )
+
+        gt = NoClip(a="ACME Corporation")
+        pred = NoClip(a="totally different value")
+
+        assert gt.compare(pred) == pytest.approx(
+            gt.compare_with(pred)["overall_score"]
+        )


### PR DESCRIPTION
## Description

Fixes the three blockers from @vawsgit's review of the v1.0.0 release PR (#345). All three were reproduced to the digit before being touched, and all three are score-affecting rather than cosmetic.

**These would have shipped in 1.0.** They are the same class of bug the release set out to correct: a reported match the code cannot justify.

### 1. A field absent on BOTH sides counted as a perfect match

`comparison_engine.py` folded every field into the weighted average unconditionally. A field empty on both sides arrives with a perfect per-field score and full weight, so empty fields paid out as matches:

```python
class Invoice(BaseModel):        # five optional fields
    a: Optional[str] = None
    ...
stickler.evaluate(Invoice(a="ACME Corporation"),
                  Invoice(a="totally different value"))
```

| | before | after |
|---|---|---|
| `overall_score` | `0.8000` | `0.0000` |
| `matched` | **`True`** | `False` |
| `f1` | `0.0000` | `0.0000` |
| confusion | `tp=0 fd=1 fp=1 tn=4 fn=0` | unchanged |

`matched=True` at an F1 of zero, on a document whose only extracted value is completely wrong. That is the pair this library exists to catch, reported as passing.

`EvalResult.matched` was **not** the defect. Deriving it from `overall_score` is well argued at `auto/facade.py:70-80` and is unchanged here. The mean feeding it was inflated, and fixing the mean made `matched` correct for free.

The effect scales with how optional a schema is, so sparse documents — the common case in extraction — are where scores drop most, and every corpus-level average was inflated.

### 2. `compare()` and `compare_with()` returned different scores for the same pair

Same root cause. `compare()` has skipped absent-on-both since #233, with the reasoning written at the call site:

> A true negative is absence of evidence, not evidence that two objects match.

That never reached the aggregation path, so the same pair scored **0.174** via `compare()` and **0.8** via `compare_with()`.

This one matters more than the gap suggests, because `compare()` is the Hungarian cost function. List pairing and per-item tp/fd classification were decided on one number while the score reported beside them was a different number. That is precisely the score-versus-classification split #301 closed for the *gate* the two paths consult, left open on the arithmetic.

### 3. `total_weight == 0` returned `1.0` for two different causes

`return 1.0` is right for "nothing was compared" (identical empty objects, #233) and catastrophic for "fields were compared at weights summing to zero":

```python
class ZeroW(StructuredModel):
    x: str = ComparableField(weight=0.0)

ZeroW(x="aaa").compare(ZeroW(x="zzz"))   # was 1.0, now 0.0
```

Two completely different objects scored a perfect match, and being the Hungarian cost, that made every pairing in a list of such models free. Told apart with a compared-field count.

## Approach: extraction, not two patches

The obvious fix is to add the skip to `comparison_engine` and move on. I did not do that, because **two copies of the absence rule is what let these paths drift for two releases**. Finding 2 *is* that drift.

`absent_on_both` and `weighted_mean_or_default` now live in `comparison_helper.py` and are called by both paths. `test_the_two_paths_share_one_absence_predicate` asserts structurally that neither module re-implements the rule, so a future edit has to go through the shared helper or fail loudly.

## What is deliberately unchanged

- **Absent-on-both fields remain true negatives** in the confusion matrix (`tn=4` above) and remain present in `field_scores`. Only their contribution to the mean is gone. Pinned by `test_absent_on_both_is_still_a_true_negative`, so a future simplification cannot drop the field entirely.
- **Two identical empty objects still score `1.0`** (#233). This is why the guard needs a compared-field count rather than a weight test.
- **One divergence between the two paths remains, and is correct.** `compare()` uses raw scores, `compare_with()` threshold-applied ones, so they still differ when clipping fires. `compare()` is a cost function and needs graded costs: clipping every weak pair to `0.0` would make them indistinguishable to the assignment algorithm, which needs to pick the *best* pairing rather than an arbitrary one. Disabling clip closes the gap exactly, which `TestTheRemainingDivergenceIsDeliberate` demonstrates. @vawsgit's five-field example happened to exercise both causes at once, so this is a partial correction to finding 2 rather than a disagreement with it.

## Why 2739 tests missed this

Worth stating plainly, because it is the more useful finding: **this fix changes `overall_score` from 0.8 to 0.0 on a five-field model and broke nothing in the existing suite.**

Two structural gaps, not missing edge cases:

1. **No test scored a multi-field model with fields absent on both sides.** Fixtures populate what they assert on, so the defect was invisible by construction.
2. **No test asserted the two aggregation paths return the same number.** #301 unified the gate and left the arithmetic alone.

`TestBothPathsAgree` is parametrized over seven shapes and asserts the two *agree*, not that they equal remembered constants — so it pins the property rather than today's numbers.

## Type of Change

Breaking bug fix. Every score on a model with unpopulated optional fields changes, downward.

## Testing

- [x] **2756 passed**, 12 skipped, 1 xfailed
- [x] `ruff check src/ tests/` — clean
- [x] 17 new tests in `tests/structured_object_evaluator/test_absent_on_both_aggregation.py`
- [x] **Verified the new tests are real coverage, not tautologies: 12 of 17 fail against the unfixed code.** Checked by restoring the three files from `dev` and re-running.
- [x] All three blockers re-measured after the fix, through the public API

## Related Issues

Blocks #345 (the v1.0.0 release PR). That PR needs re-running against `dev` once this lands.

Not addressed here, and not regressions: the 12 non-blocking findings in the same review. Their recurring theme is the config/schema path diverging from the Python path, which is the same class of defect as this one. Filing as one tracking issue rather than twelve, so the triage decision is deliberate.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
